### PR TITLE
Use hatch-vcs for versioning pyodide-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.27.0] - 2024/06/18
+
 - pyodide-build is now developed under https://github.com/pyodide/pyodide-build.

--- a/pyodide_build/__init__.py
+++ b/pyodide_build/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.27.0.dev0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pyodide-build")
+except PackageNotFoundError:
+    __version__ = "1.0.0.dev0"

--- a/pyodide_build/tests/test_build_env.py
+++ b/pyodide_build/tests/test_build_env.py
@@ -125,7 +125,7 @@ class TestOutOfTree(TestInTree):
         assert "RANDOM_ENV" not in e
 
 
-def test_check_emscripten_version(monkeypatch):
+def test_check_emscripten_version(dummy_xbuildenv, monkeypatch):
     s = None
 
     def get_emscripten_version_info():

--- a/pyodide_build/tests/test_build_env.py
+++ b/pyodide_build/tests/test_build_env.py
@@ -179,7 +179,7 @@ clang version 15.0.0 (https://github.com/llvm/llvm-project 7effcbda49ba32991b895
         build_env.check_emscripten_version()
 
 
-def test_wheel_paths():
+def test_wheel_paths(dummy_xbuildenv):
     from pathlib import Path
 
     old_version = "cp38"

--- a/pyodide_build/tests/test_buildall.py
+++ b/pyodide_build/tests/test_buildall.py
@@ -48,7 +48,7 @@ def test_generate_dependency_graph_disabled():
     assert set(pkg_map.keys()) == set()
 
 
-def test_generate_lockfile(tmp_path):
+def test_generate_lockfile(tmp_path, dummy_xbuildenv):
     pkg_map = buildall.generate_dependency_graph(
         RECIPE_DIR, {"pkg_1", "pkg_2", "libtest", "libtest_shared"}
     )

--- a/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide_build/tests/test_buildpkg.py
@@ -7,8 +7,8 @@ from typing import Self
 import pydantic
 import pytest
 
-from pyodide_build import build_env, buildpkg, common
-from pyodide_build.build_env import BuildArgs, get_pyodide_root
+from pyodide_build import buildpkg, common
+from pyodide_build.build_env import BuildArgs
 from pyodide_build.buildpkg import RecipeBuilder
 from pyodide_build.io import _SourceSpec
 

--- a/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide_build/tests/test_buildpkg.py
@@ -72,7 +72,6 @@ def test_prepare_source(monkeypatch, tmp_path):
         returncode = 0
         stdout = ""
 
-    build_env.get_build_environment_vars(get_pyodide_root())
     monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: subprocess_result)
     monkeypatch.setattr(buildpkg, "check_checksum", lambda *args, **kwargs: True)
     monkeypatch.setattr(shutil, "unpack_archive", lambda *args, **kwargs: True)

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -233,7 +233,7 @@ def test_build_recipe_no_deps_continue(tmp_path, dummy_xbuildenv, mock_emscripte
     assert f"{pkg}-{version}-py3-none-any.whl" in result.stdout
 
 
-def test_config_list():
+def test_config_list(dummy_xbuildenv):
     result = runner.invoke(
         config.app,
         [
@@ -249,7 +249,7 @@ def test_config_list():
 
 
 @pytest.mark.parametrize("cfg_name,env_var", config.PYODIDE_CONFIGS.items())
-def test_config_get(cfg_name, env_var):
+def test_config_get(cfg_name, env_var, dummy_xbuildenv):
     result = runner.invoke(
         config.app,
         [
@@ -411,7 +411,7 @@ def test_build2_replace_so_abi_tags(
     assert so_file.endswith(".cpython-311-wasm32-emscripten.so")
 
 
-def test_build_exports(monkeypatch):
+def test_build_exports(monkeypatch, dummy_xbuildenv):
     def download_url_shim(url, tmppath):
         (tmppath / "build").mkdir()
         return "blah"
@@ -469,7 +469,7 @@ def test_build_exports(monkeypatch):
     )
 
 
-def test_build_config_settings(monkeypatch):
+def test_build_config_settings(monkeypatch, dummy_xbuildenv):
     app = typer.Typer()
 
     app.command(

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import subprocess
+import warnings
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from urllib.request import urlopen
@@ -273,7 +274,12 @@ class CrossBuildEnvManager:
         with NamedTemporaryFile(suffix=".tar") as f:
             f_path = Path(f.name)
             f_path.write_bytes(data)
-            shutil.unpack_archive(str(f_path), path)
+            with warnings.catch_warnings():
+                # Python 3.12-3.13 emits a DeprecationWarning when using shutil.unpack_archive without a filter,
+                # but filter doesn't work well for zip files, so we suppress the warning until we find a better solution.
+                # https://github.com/python/cpython/issues/112760
+                warnings.simplefilter("ignore")
+                shutil.unpack_archive(str(f_path), path)
 
     def _install_cross_build_packages(
         self, xbuildenv_root: Path, xbuildenv_pyodide_root: Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -66,8 +66,8 @@ test = [
     "packaging",
 ]
 
-[tool.hatch]
-version.path = "pyodide_build/__init__.py"
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
Instead of updating the version number manually, this use `hatch-vcs` and use git metadata to handle the version. Just same as micropip and pytest-pyodide.