### PR TITLE
Make xbuildenv subcommand public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `pyodide xbuildenv` subcommand is not publically available.
+- `pyodide xbuildenv` subcommand is not publicly available.
   [#15](https://github.com/pyodide/pyodide-build/pull/15)
 
 ## [0.27.3] - 2024/07/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `pyodide xbuildenv` subcommand is not publically available.
+  [#15](https://github.com/pyodide/pyodide-build/pull/15)
+
 ## [0.27.3] - 2024/07/17
 
 - It is now possible to override `_f2c_fixes.py` file, with `_f2c_fixes_wrapper` variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `pyodide xbuildenv` subcommand is not publicly available.
+- `pyodide xbuildenv` subcommand is now publicly available.
   [#15](https://github.com/pyodide/pyodide-build/pull/15)
 
 ## [0.27.3] - 2024/07/17

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -12,7 +12,7 @@ from ..xbuildenv_releases import (
 
 DIRNAME = xbuildenv_dirname()
 
-app = typer.Typer(hidden=True, no_args_is_help=True)
+app = typer.Typer(no_args_is_help=True)
 
 
 @app.callback()


### PR DESCRIPTION
This makes `pyodide xbuildenv` subcommand public so users can search and install different versions of Pyodide build env.

- [x] changelog