### PR TITLE
Remove `shared_library` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.28.0] - 2024/08/14
+
 - `pyodide xbuildenv` subcommand is now publicly available.
   [#15](https://github.com/pyodide/pyodide-build/pull/15)
 

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -731,11 +731,7 @@ def generate_packagedata(
 
         pkg_type = pkg.package_type
         if pkg_type == "shared_library":
-            # We handle cpython modules as shared libraries
-            pkg_entry.shared_library = True
-            pkg_entry.install_dir = (
-                "stdlib" if pkg_type == "cpython_module" else "dynlib"
-            )
+            pkg_entry.install_dir = "dynlib"
 
         pkg_entry.depends = [x.lower() for x in pkg.run_dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.12"
 dependencies = [
     "build~=1.2.0",
     "pyodide-cli~=0.2.1",
-    "pyodide-lock==0.1.0a6",
+    "pyodide-lock==0.1.0a7",
     "auditwheel-emscripten~=0.0.9",
     "pydantic>=2,<3",
     "cmake>=3.24",


### PR DESCRIPTION
This key is removed in

- pyodide: https://github.com/pyodide/pyodide/pull/4996
- pyodide-lock: https://github.com/pyodide/pyodide-lock/pull/31

and this is the last PR to remove it in pyodide-build as well.
