### PR TITLE
Infer python version from Makefile.envs in PyO3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `pyo3_config_file` is no longer available in `pyodide config` command.
+  Pyodide now sets `PYO3_CROSS_PYTHON_VERSION`, `PYO3_CROSS_LIB_DIR` to specify the cross compilation environment
+  for PyO3.
+  [#19](https://github.com/pyodide/pyodide-build/pull/19)
+
 ## [0.28.0] - 2024/08/14
 
 - `pyodide xbuildenv` subcommand is now publicly available.

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -11,7 +11,6 @@ PYODIDE_CONFIGS = {
     "python_version": "PYVERSION",
     "rustflags": "RUSTFLAGS",
     "cmake_toolchain_file": "CMAKE_TOOLCHAIN_FILE",
-    "pyo3_config_file": "PYO3_CONFIG_FILE",
     "rust_toolchain": "RUST_TOOLCHAIN",
     "cflags": "SIDE_MODULE_CFLAGS",
     "cxxflags": "SIDE_MODULE_CXXFLAGS",

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -162,7 +162,6 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "sysconfig_name": "SYSCONFIG_NAME",
     "targetinstalldir": "TARGETINSTALLDIR",
     "cmake_toolchain_file": "CMAKE_TOOLCHAIN_FILE",
-    "pyo3_config_file": "PYO3_CONFIG_FILE",
     "meson_cross_file": "MESON_CROSS_FILE",
     "cflags_base": "CFLAGS_BASE",
     "cxxflags_base": "CXXFLAGS_BASE",
@@ -193,7 +192,6 @@ TOOLS_DIR = Path(__file__).parent / "tools"
 DEFAULT_CONFIG: dict[str, str] = {
     # Paths to toolchain configuration files
     "cmake_toolchain_file": str(TOOLS_DIR / "cmake/Modules/Platform/Emscripten.cmake"),
-    "pyo3_config_file": str(TOOLS_DIR / "pyo3_config.ini"),
     "meson_cross_file": str(TOOLS_DIR / "emscripten.meson.cross"),
     # Rust-specific configuration
     "rustflags": "-C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT -Z link-native-libraries=no",

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -212,7 +212,7 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "cxxflags": "$(CXXFLAGS_BASE)",
     "ldflags": "$(LDFLAGS_BASE) -s SIDE_MODULE=1",
     # Rust-specific configuration
-    "pyo3_cross_lib_dir": "$(CPYTHONINSTALL)/lib",
+    "pyo3_cross_lib_dir": "$(CPYTHONINSTALL)/sysconfigdata", # FIXME: pyodide xbuildenv stores sysconfigdata here
     "pyo3_cross_include_dir": "$(PYTHONINCLUDE)",
     "pyo3_cross_python_version": "$(PYMAJOR).$(PYMINOR)",
     # Misc

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -143,6 +143,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "pyminor": "PYMINOR",
     "pyo3_cross_include_dir": "PYO3_CROSS_INCLUDE_DIR",
     "pyo3_cross_lib_dir": "PYO3_CROSS_LIB_DIR",
+    "pyo3_cross_python_version": "PYO3_CROSS_PYTHON_VERSION",
     "pyodide_emscripten_version": "PYODIDE_EMSCRIPTEN_VERSION",
     "pyodide_jobs": "PYODIDE_JOBS",
     "pyodide_root": "PYODIDE_ROOT",
@@ -215,6 +216,7 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     # Rust-specific configuration
     "pyo3_cross_lib_dir": "$(CPYTHONINSTALL)/lib",
     "pyo3_cross_include_dir": "$(PYTHONINCLUDE)",
+    "pyo3_cross_python_version": "$(PYMAJOR).$(PYMINOR)",
     # Misc
     "stdlib_module_cflags": "$(CFLAGS_BASE) -I$(PYTHONINCLUDE) -I Include/ -I. -IInclude/internal/",  # TODO: remove this
     # Paths to build dependencies

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -212,7 +212,7 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "cxxflags": "$(CXXFLAGS_BASE)",
     "ldflags": "$(LDFLAGS_BASE) -s SIDE_MODULE=1",
     # Rust-specific configuration
-    "pyo3_cross_lib_dir": "$(CPYTHONINSTALL)/sysconfigdata", # FIXME: pyodide xbuildenv stores sysconfigdata here
+    "pyo3_cross_lib_dir": "$(CPYTHONINSTALL)/sysconfigdata",  # FIXME: pyodide xbuildenv stores sysconfigdata here
     "pyo3_cross_include_dir": "$(PYTHONINCLUDE)",
     "pyo3_cross_python_version": "$(PYMAJOR).$(PYMINOR)",
     # Misc

--- a/pyodide_build/tools/pyo3_config.ini
+++ b/pyodide_build/tools/pyo3_config.ini
@@ -1,6 +1,0 @@
-implementation=CPython
-version=3.10
-shared=true
-abi3=false
-pointer_width=32
-suppress_build_script_link_lines=false

--- a/pyodide_build/tools/pyo3_config.ini
+++ b/pyodide_build/tools/pyo3_config.ini
@@ -1,5 +1,4 @@
 implementation=CPython
-; this value will be overridden by PYO3_CROSS_PYTHON_VERSION
 version=3.10
 shared=true
 abi3=false

--- a/pyodide_build/tools/pyo3_config.ini
+++ b/pyodide_build/tools/pyo3_config.ini
@@ -1,7 +1,5 @@
 implementation=CPython
-version=3.12
 shared=true
 abi3=false
-lib_name=python3.12
 pointer_width=32
 suppress_build_script_link_lines=false

--- a/pyodide_build/tools/pyo3_config.ini
+++ b/pyodide_build/tools/pyo3_config.ini
@@ -1,5 +1,6 @@
 implementation=CPython
-version=3.10  # this value will be overridden by PYO3_CROSS_PYTHON_VERSION
+# this value will be overridden by PYO3_CROSS_PYTHON_VERSION
+version=3.10
 shared=true
 abi3=false
 pointer_width=32

--- a/pyodide_build/tools/pyo3_config.ini
+++ b/pyodide_build/tools/pyo3_config.ini
@@ -1,5 +1,5 @@
 implementation=CPython
-# this value will be overridden by PYO3_CROSS_PYTHON_VERSION
+; this value will be overridden by PYO3_CROSS_PYTHON_VERSION
 version=3.10
 shared=true
 abi3=false

--- a/pyodide_build/tools/pyo3_config.ini
+++ b/pyodide_build/tools/pyo3_config.ini
@@ -1,4 +1,5 @@
 implementation=CPython
+version=3.10  # this value will be overridden by PYO3_CROSS_PYTHON_VERSION
 shared=true
 abi3=false
 pointer_width=32


### PR DESCRIPTION
Instead of hardcoding the Python version, use `PYO3_CROSS_PYTHON_VERSION` env variable, which [PyO3 uses to find the correct Python include/lib paths](https://pyo3.rs/main/building-and-distribution#cross-compiling).

Also removed pyo3_config.ini file. Otherwise, the config file always take precedence.