### PR TITLE
Include version and checksum validation when updating packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `pyodide skeleton pypi --update` command and the `--update-patched` variant now
+  validate the version and the source checksum when updating a package's recipe.
+  [#27](https://github.com/pyodide/pyodide-build/pull/27)
+
 - `pyo3_config_file` is no longer available in `pyodide config` command.
   Pyodide now sets `PYO3_CROSS_PYTHON_VERSION`, `PYO3_CROSS_LIB_DIR` to specify the cross compilation environment
   for PyO3.

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -256,6 +256,15 @@ def update_package(
     sha256 = dist_metadata["digests"]["sha256"]
     sha256_local = yaml_content["source"].get("sha256")
 
+    # fail if local version is newer than PyPI version
+    # since updating isn't possible in that case
+    if pypi_ver <= local_ver:
+        raise MkpkgFailedException(
+            f"Local version {local_ver} is newer than PyPI version {pypi_ver}, "
+            f"cannot update {package}. Please verify in case the version was "
+            "updated manually and is correct."
+        )
+
     # conditions to check if the package is up to date
     is_sha256_up_to_date = sha256 == sha256_local
     is_version_up_to_date = pypi_ver <= local_ver
@@ -266,7 +275,7 @@ def update_package(
     if already_up_to_date:
         logger.success(
             f"{package} already up to date."
-            f" Local: {local_ver} PyPI: {pypi_ver}"
+            f" Local: {local_ver} and PyPI: {pypi_ver}"
             f" and checksum received: {sha256} matches local: {sha256_local} ✅"
         )
         return

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -258,7 +258,7 @@ def update_package(
 
     # fail if local version is newer than PyPI version
     # since updating isn't possible in that case
-    if pypi_ver <= local_ver:
+    if pypi_ver < local_ver:
         raise MkpkgFailedException(
             f"Local version {local_ver} is newer than PyPI version {pypi_ver}, "
             f"cannot update {package}. Please verify in case the version was "
@@ -267,7 +267,7 @@ def update_package(
 
     # conditions to check if the package is up to date
     is_sha256_up_to_date = sha256 == sha256_local
-    is_version_up_to_date = pypi_ver <= local_ver
+    is_version_up_to_date = pypi_ver == local_ver
 
     already_up_to_date = (is_sha256_up_to_date and is_version_up_to_date) and (
         source_fmt is None or source_fmt == old_fmt

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -286,6 +286,7 @@ def update_package(
         else:
             raise MkpkgFailedException(
                 f"Pyodide applies patches to {package}. Skipping update."
+                f" Use --update-patched to force updating {package}."
             )
 
     if source_fmt:


### PR DESCRIPTION
This PR closes #24. Here, we now check against two conditions when updating the package
- whether the version is up to date plus valid, and
- whether the SHA-256 checksum matches the one present in the recipe file.

Therefore, updating the package has three scenarios, and here is a summary of what happens:
- local version updated manually to the newest available PyPI version ➡️ checksums will be updated, too
- both version and checksum are out of date ➡️ both of them will be updated (as it was before these changes)
- the checksum is correct and the version is out of date ➡️ this is enough information for us to proceed with updating the version

Additionally, there's now a case where one manually updates the version (in error, for example), to a version that is not released or available on PyPI (yet), which means that the metadata for the version won't exist either. We raise an exception early here, asking the user so that they can check the version while updating. This is a rare situation, so it's more about raising a helpful error that aids the user in debugging the problem. I have skipped adding a test for such a case, but I can add one if needed. Please let me know your thoughts!