### PR TITLE
chore: convert all relative imports to absolute imports

### DIFF
--- a/pyodide_build/_py_compile.py
+++ b/pyodide_build/_py_compile.py
@@ -11,8 +11,8 @@ from typing import Any
 from packaging.tags import Tag
 from packaging.utils import parse_wheel_filename
 
-from .common import _get_sha256_checksum
-from .logger import logger, set_log_level
+from pyodide_build.common import _get_sha256_checksum
+from pyodide_build.logger import logger, set_log_level
 
 
 def _specialize_convert_tags(tags: set[Tag] | frozenset[Tag], wheel_name: str) -> Tag:

--- a/pyodide_build/bash_runner.py
+++ b/pyodide_build/bash_runner.py
@@ -9,12 +9,12 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, TextIO
 
-from .build_env import (
+from pyodide_build.build_env import (
     get_build_environment_vars,
     get_pyodide_root,
 )
-from .common import exit_with_stdio
-from .logger import logger
+from pyodide_build.common import exit_with_stdio
+from pyodide_build.logger import logger
 
 
 class BashRunnerWithSharedEnvironment:

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -13,10 +13,10 @@ from pathlib import Path
 
 from packaging.tags import Tag, compatible_tags, cpython_tags
 
-from . import __version__
-from .common import search_pyproject_toml, xbuildenv_dirname
-from .config import ConfigManager
-from .recipe import load_all_recipes
+from pyodide_build import __version__
+from pyodide_build.common import search_pyproject_toml, xbuildenv_dirname
+from pyodide_build.config import ConfigManager
+from pyodide_build.recipe import load_all_recipes
 
 RUST_BUILD_PRELUDE = """
 rustup toolchain install ${RUST_TOOLCHAIN} && rustup default ${RUST_TOOLCHAIN}
@@ -74,7 +74,7 @@ def _init_xbuild_env(*, quiet: bool = False) -> Path:
     -------
         The path to the Pyodide root directory inside the xbuild environment
     """
-    from .xbuildenv import CrossBuildEnvManager  # avoid circular import
+    from pyodide_build.xbuildenv import CrossBuildEnvManager  # avoid circular import
 
     xbuildenv_path = Path(xbuildenv_dirname()).resolve()
     context = redirect_stdout(StringIO()) if quiet else nullcontext()

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -29,17 +29,17 @@ from rich.progress import BarColumn, Progress, TimeElapsedColumn
 from rich.spinner import Spinner
 from rich.table import Table
 
-from . import build_env, recipe
-from .build_env import BuildArgs
-from .buildpkg import needs_rebuild
-from .common import (
+from pyodide_build import build_env, recipe
+from pyodide_build.build_env import BuildArgs
+from pyodide_build.buildpkg import needs_rebuild
+from pyodide_build.common import (
     extract_wheel_metadata_file,
     find_matching_wheels,
     find_missing_executables,
     repack_zip_archive,
 )
-from .io import MetaConfig, _BuildSpecTypes
-from .logger import console_stdout, logger
+from pyodide_build.io import MetaConfig, _BuildSpecTypes
+from pyodide_build.logger import console_stdout, logger
 
 
 class BuildError(Exception):

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -19,9 +19,9 @@ from typing import Any, cast
 
 import requests
 
-from . import common, pypabuild
-from .bash_runner import BashRunnerWithSharedEnvironment, get_bash_runner
-from .build_env import (
+from pyodide_build import common, pypabuild
+from pyodide_build.bash_runner import BashRunnerWithSharedEnvironment, get_bash_runner
+from pyodide_build.build_env import (
     RUST_BUILD_PRELUDE,
     BuildArgs,
     get_build_environment_vars,
@@ -30,7 +30,7 @@ from .build_env import (
     replace_so_abi_tags,
     wheel_platform,
 )
-from .common import (
+from pyodide_build.common import (
     _environment_substitute_str,
     _get_sha256_checksum,
     chdir,
@@ -40,8 +40,8 @@ from .common import (
     modify_wheel,
     retag_wheel,
 )
-from .io import MetaConfig, _SourceSpec
-from .logger import logger
+from pyodide_build.io import MetaConfig, _SourceSpec
+from pyodide_build.logger import logger
 
 
 def _make_whlfile(

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -10,16 +10,20 @@ import requests
 import typer
 from build import ConfigSettingsType
 
-from ..build_env import check_emscripten_version, get_pyodide_root, init_environment
-from ..io import _BuildSpecExports, _ExportTypes
-from ..logger import logger
-from ..out_of_tree import build
-from ..out_of_tree.pypi import (
+from pyodide_build.build_env import (
+    check_emscripten_version,
+    get_pyodide_root,
+    init_environment,
+)
+from pyodide_build.io import _BuildSpecExports, _ExportTypes
+from pyodide_build.logger import logger
+from pyodide_build.out_of_tree import build
+from pyodide_build.out_of_tree.pypi import (
     build_dependencies_for_wheel,
     build_wheels_from_pypi_requirements,
     fetch_pypi_package,
 )
-from ..pypabuild import parse_backend_flags
+from pyodide_build.pypabuild import parse_backend_flags
 
 
 def convert_exports(exports: str) -> _BuildSpecExports:

--- a/pyodide_build/cli/build_recipes.py
+++ b/pyodide_build/cli/build_recipes.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import typer
 
-from .. import build_env, buildall, buildpkg
-from ..build_env import BuildArgs, init_environment
-from ..common import get_num_cores
-from ..logger import logger
+from pyodide_build import build_env, buildall, buildpkg
+from pyodide_build.build_env import BuildArgs, init_environment
+from pyodide_build.common import get_num_cores
+from pyodide_build.logger import logger
 
 
 @dataclasses.dataclass(eq=False, order=False, kw_only=True)

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -1,6 +1,10 @@
 import typer
 
-from ..build_env import get_build_environment_vars, get_pyodide_root, init_environment
+from pyodide_build.build_env import (
+    get_build_environment_vars,
+    get_pyodide_root,
+    init_environment,
+)
 
 app = typer.Typer(help="Manage config variables used in pyodide")
 

--- a/pyodide_build/cli/create_zipfile.py
+++ b/pyodide_build/cli/create_zipfile.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import typer
 
-from ..pyzip import create_zipfile
+from pyodide_build.pyzip import create_zipfile
 
 
 def main(

--- a/pyodide_build/cli/py_compile.py
+++ b/pyodide_build/cli/py_compile.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import typer
 
-from .._py_compile import _py_compile_archive, _py_compile_archive_dir
+from pyodide_build._py_compile import _py_compile_archive, _py_compile_archive_dir
 
 
 def main(

--- a/pyodide_build/cli/skeleton.py
+++ b/pyodide_build/cli/skeleton.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import typer
 
-from .. import build_env, mkpkg
-from ..logger import logger
+from pyodide_build import build_env, mkpkg
+from pyodide_build.logger import logger
 
 app = typer.Typer()
 

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import typer
 
-from ..build_env import init_environment
-from ..out_of_tree import venv
+from pyodide_build.build_env import init_environment
+from pyodide_build.out_of_tree import venv
 
 
 def main(

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -2,10 +2,10 @@ from pathlib import Path
 
 import typer
 
-from ..build_env import local_versions
-from ..common import xbuildenv_dirname
-from ..xbuildenv import CrossBuildEnvManager
-from ..xbuildenv_releases import (
+from pyodide_build.build_env import local_versions
+from pyodide_build.common import xbuildenv_dirname
+from pyodide_build.xbuildenv import CrossBuildEnvManager
+from pyodide_build.xbuildenv_releases import (
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,
 )

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -23,11 +23,11 @@ from packaging.tags import Tag
 from packaging.utils import canonicalize_name as canonicalize_package_name
 from packaging.utils import parse_wheel_filename
 
-from .logger import logger
+from pyodide_build.logger import logger
 
 
 def xbuildenv_dirname() -> str:
-    from . import __version__
+    from pyodide_build import __version__
 
     return f".pyodide-xbuildenv-{__version__}"
 
@@ -204,7 +204,7 @@ def get_num_cores() -> int:
     Return the number of CPUs the current process can use.
     If the number of CPUs cannot be determined, return 1.
     """
-    from .vendor.loky import cpu_count
+    from pyodide_build.vendor.loky import cpu_count
 
     return cpu_count()
 

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -4,8 +4,12 @@ from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 
-from .common import _environment_substitute_str, exit_with_stdio, search_pyproject_toml
-from .logger import logger
+from pyodide_build.common import (
+    _environment_substitute_str,
+    exit_with_stdio,
+    search_pyproject_toml,
+)
+from pyodide_build.logger import logger
 
 
 class ConfigManager:

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -16,8 +16,8 @@ from urllib import request
 from packaging.version import Version
 from ruamel.yaml import YAML
 
-from .common import parse_top_level_import_name
-from .logger import logger
+from pyodide_build.common import parse_top_level_import_name
+from pyodide_build.logger import logger
 
 
 class URLDict(TypedDict):

--- a/pyodide_build/out_of_tree/build.py
+++ b/pyodide_build/out_of_tree/build.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 from build import ConfigSettingsType
 
-from .. import build_env, common, pypabuild
-from ..build_env import get_pyodide_root, wheel_platform
-from ..io import _BuildSpecExports
+from pyodide_build import build_env, common, pypabuild
+from pyodide_build.build_env import get_pyodide_root, wheel_platform
+from pyodide_build.io import _BuildSpecExports
 
 
 def run(

--- a/pyodide_build/out_of_tree/pypi.py
+++ b/pyodide_build/out_of_tree/pypi.py
@@ -27,11 +27,11 @@ from resolvelib.providers import AbstractProvider
 from unearth.evaluator import TargetPython
 from unearth.finder import PackageFinder
 
-from .. import build_env
-from ..common import repack_zip_archive
-from ..io import _BuildSpecExports
-from ..logger import logger
-from . import build
+from pyodide_build import build_env
+from pyodide_build.common import repack_zip_archive
+from pyodide_build.io import _BuildSpecExports
+from pyodide_build.logger import logger
+from pyodide_build.out_of_tree import build
 
 _PYPI_INDEX = ["https://pypi.org/simple/"]
 _PYPI_TRUSTED_HOSTS = ["pypi.org"]

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -5,9 +5,9 @@ import textwrap
 from pathlib import Path
 from typing import Any
 
-from ..build_env import get_build_flag, get_pyodide_root, in_xbuildenv
-from ..common import exit_with_stdio
-from ..logger import logger
+from pyodide_build.build_env import get_build_flag, get_pyodide_root, in_xbuildenv
+from pyodide_build.common import exit_with_stdio
+from pyodide_build.logger import logger
 
 
 def check_result(result: subprocess.CompletedProcess[str], msg: str) -> None:

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -15,16 +15,16 @@ from build import BuildBackendException, ConfigSettingsType
 from build.env import DefaultIsolatedEnv
 from packaging.requirements import Requirement
 
-from . import _f2c_fixes, common, pywasmcross
-from .build_env import (
+from pyodide_build import _f2c_fixes, common, pywasmcross
+from pyodide_build.build_env import (
     get_build_flag,
     get_hostsitepackages,
     get_pyversion,
     get_unisolated_packages,
     platform,
 )
-from .io import _BuildSpecExports
-from .vendor._pypabuild import (
+from pyodide_build.io import _BuildSpecExports
+from pyodide_build.vendor._pypabuild import (
     _STYLES,
     _DefaultIsolatedEnv,
     _error,

--- a/pyodide_build/pyzip.py
+++ b/pyodide_build/pyzip.py
@@ -3,8 +3,8 @@ from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from ._py_compile import _compile
-from .common import make_zip_archive
+from pyodide_build._py_compile import _compile
+from pyodide_build.common import make_zip_archive
 
 
 def default_filterfunc(

--- a/pyodide_build/recipe.py
+++ b/pyodide_build/recipe.py
@@ -2,8 +2,8 @@ import functools
 from collections.abc import Iterable
 from pathlib import Path
 
-from .io import MetaConfig
-from .logger import logger
+from pyodide_build.io import MetaConfig
+from pyodide_build.logger import logger
 
 
 @functools.lru_cache(maxsize=1)

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -8,10 +8,10 @@ from urllib.request import urlopen
 
 from pyodide_lock import PyodideLockSpec
 
-from . import build_env
-from .create_package_index import create_package_index
-from .logger import logger
-from .xbuildenv_releases import (
+from pyodide_build import build_env
+from pyodide_build.create_package_index import create_package_index
+from pyodide_build.logger import logger
+from pyodide_build.xbuildenv_releases import (
     CrossBuildEnvReleaseSpec,
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,3 +158,6 @@ known-third-party = [
 
 [tool.ruff.lint.mccabe]
 max-complexity = 31  # C901: Recommended goal is 10
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"


### PR DESCRIPTION
## Description

This is a small PR that does some cleanup I wanted to do for a while:

- Converted all relative imports to absolute imports
- Added a rule against this: https://docs.astral.sh/ruff/rules/relative-imports/

Relative imports are not bad, it's just that absolute imports are nicer, at least to me :)