### PR TITLE
Do not require downloading xbuildenv when updating package recipes

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -96,7 +96,7 @@ def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path | No
     """
     Recursively search for the root of the Pyodide repository,
     by looking for the pyproject.toml file in the parent directories
-    which contains [tool.pyodide] section.
+    which contains the [tool._pyodide] section.
     """
     pyproject_path, pyproject_file = search_pyproject_toml(curdir, max_depth)
 

--- a/pyodide_build/cli/skeleton.py
+++ b/pyodide_build/cli/skeleton.py
@@ -76,7 +76,7 @@ def new_recipe_pypi(
             logger.error(f"{name} update failed: {e}")
             sys.exit(1)
         except mkpkg.MkpkgSkipped as e:
-            logger.warn(f"{name} update skipped: {e}")
+            logger.warning(f"{name} update skipped: {e}")
         except Exception:
             print(name)
             raise

--- a/pyodide_build/cli/skeleton.py
+++ b/pyodide_build/cli/skeleton.py
@@ -51,16 +51,23 @@ def new_recipe_pypi(
     Create a new package recipe from PyPI or update an existing recipe.
     """
 
+    # Determine the recipe directory. If it is specified by the user, we use that;
+    # otherwise, we assume that the recipe directory is the ``packages`` directory
+    # in the root of the Pyodide tree, without the need to initialize the
+    # cross-build environment.
+    #
+    # It is unlikely that a user will run this command outside of the Pyodide
+    # tree, so we do not need to initialize the environment at this stage.
+
+    cwd = Path.cwd()
+    root = build_env.search_pyodide_root(curdir=cwd)
+
+    if not root:
+        root = cwd
+
     if recipe_dir:
         recipe_dir_ = Path(recipe_dir)
     else:
-        cwd = Path.cwd()
-
-        if build_env.in_xbuildenv():
-            root = cwd
-        else:
-            root = build_env.search_pyodide_root(cwd) or cwd
-
         recipe_dir_ = root / "packages"
 
     if update or update_patched:

--- a/pyodide_build/cli/skeleton.py
+++ b/pyodide_build/cli/skeleton.py
@@ -48,7 +48,7 @@ def new_recipe_pypi(
     ),
 ) -> None:
     """
-    Create a new package from PyPI.
+    Create a new package recipe from PyPI or update an existing recipe.
     """
 
     if recipe_dir:

--- a/pyodide_build/cli/skeleton.py
+++ b/pyodide_build/cli/skeleton.py
@@ -59,15 +59,15 @@ def new_recipe_pypi(
     # It is unlikely that a user will run this command outside of the Pyodide
     # tree, so we do not need to initialize the environment at this stage.
 
-    cwd = Path.cwd()
-    root = build_env.search_pyodide_root(curdir=cwd)
-
-    if not root:
-        root = cwd
-
     if recipe_dir:
         recipe_dir_ = Path(recipe_dir)
     else:
+        cwd = Path.cwd()
+        root = build_env.search_pyodide_root(curdir=cwd)
+
+        if not root:
+            root = cwd
+
         recipe_dir_ = root / "packages"
 
     if update or update_patched:

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -227,7 +227,7 @@ def update_package(
     meta_path = root / package / "meta.yaml"
     if not meta_path.exists():
         logger.error(f"{meta_path} does not exist")
-        exit(1)
+        raise MkpkgFailedException(f"{package} recipe not found at {meta_path}")
 
     yaml_content = yaml.load(meta_path.read_bytes())
 

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -250,7 +250,7 @@ class CrossBuildEnvManager:
             Path to extract the cross-build environment to.
             If the path already exists, raise an error.
         """
-        logger.info(f"Downloading Pyodide cross-build environment from {url}")
+        logger.info("Downloading Pyodide cross-build environment from %s", url)
 
         if path.exists():
             raise FileExistsError(f"Path {path} already exists")

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -250,7 +250,7 @@ class CrossBuildEnvManager:
             Path to extract the cross-build environment to.
             If the path already exists, raise an error.
         """
-        logger.info("Downloading Pyodide cross-build environment from %s", url)
+        logger.info(f"Downloading Pyodide cross-build environment from {url}")
 
         if path.exists():
             raise FileExistsError(f"Path {path} already exists")


### PR DESCRIPTION
## Description

Closes #25. This PR improves the xbuildenv search logic to not require downloads of the xbuildenv if a package update fails (for any reason). This means that the Pyodide root is searched in the current directory, and if it doesn't exist, we simply assume that the current working directory is the Pyodide root (and the `packages/` directory one level down hosts the recipes).

I confirmed that this does not currently cause issues with the existing setup in the Pyodide repository.