### PR TITLE
Insert -Zbuild-std when building rust packages

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -21,6 +21,7 @@ from .recipe import load_all_recipes
 RUST_BUILD_PRELUDE = """
 rustup toolchain install ${RUST_TOOLCHAIN} && rustup default ${RUST_TOOLCHAIN}
 rustup target add wasm32-unknown-emscripten --toolchain ${RUST_TOOLCHAIN}
+rustup component add rust-src --toolchain ${RUST_TOOLCHAIN}
 """
 
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -525,6 +525,9 @@ def handle_command_generate_args(  # noqa: C901
     elif cmd == "strip":
         line[0] = "emstrip"
         return line
+    elif cmd == "cargo":
+        line.insert(1, "-Zbuild-std")
+        return line
     else:
         return line
 

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -262,3 +262,11 @@ def test_is_link_cmd():
     assert is_link_cmd(["test.so"])
     assert is_link_cmd(["test.so.1.2.3"])
     assert not is_link_cmd(["test", "test.a", "test.o", "test.c", "test.cpp", "test.h"])
+
+
+def test_handle_command_cargo(build_args):
+    assert handle_command_generate_args(["cargo", "build"], build_args) == [
+        "cargo",
+        "-Zbuild-std",
+        "build",
+    ]


### PR DESCRIPTION
Otherwise we are linking a copy of the standard library built with some particular version of emscripten selected by the rust compiler that does not match the version we are using. This can lead to ABI mismatch.
https://github.com/rust-lang/rust/issues/131467

cc @messense @davidhewitt perhaps it would be good for maturin to also insert this flag when targeting emscripten.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry