### PR TITLE
Properly parse the content disposition filename

### DIFF
--- a/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide_build/tests/test_buildpkg.py
@@ -260,3 +260,24 @@ def test_copy_sharedlib(tmp_path):
     deps = ("sharedlib-test.so", "sharedlib-test-dep.so", "sharedlib-test-dep2.so")
     for dep in deps:
         assert dep in dep_map
+
+
+def test_extract_tarballname():
+    url = "https://www.test.com/ball.tar.gz"
+    headers = [
+        {},
+        {"Content-Disposition": "inline"},
+        {"Content-Disposition": "attachment"},
+        {"Content-Disposition": 'attachment; filename="ball 2.tar.gz"'},
+        {"Content-Disposition": "attachment; filename*=UTF-8''ball%203.tar.gz"},
+    ]
+    tarballnames = [
+        "ball.tar.gz",
+        "ball.tar.gz",
+        "ball.tar.gz",
+        "ball 2.tar.gz",
+        "ball 3.tar.gz",
+    ]
+
+    for header, tarballname in zip(headers, tarballnames, strict=True):
+        assert buildpkg._extract_tarballname(url, header) == tarballname


### PR DESCRIPTION
If the content disposition header filename uses quotes, `pyodide-build` includes the quotes in the literal filename, which e.g. confuses `shutil.unpack_archive` in determining the file type.

This PR ~~includes a simple fix to check and strip the quotes~~ uses the `email.message.Message` parser to properly extract the filename (see https://stackoverflow.com/a/78073510).

~~The PR should be squashed (the first commit is overriden by the second one).~~