### PR TITLE
Add option to skip emscripten version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `skip_emscripten_version_check` flag to skip emscripten version check.
+  [#53](https://github.com/pyodide/pyodide-build/pull/53)
+
 ## [0.29.0] - 2024/09/19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `skip_emscripten_version_check` flag and SKIP_EMSCRIPTEN_VERSION_CHECK environment
-variable to skip emscripten version check.
+  variable to skip emscripten version check.
   [#53](https://github.com/pyodide/pyodide-build/pull/53)
 
 ## [0.29.0] - 2024/09/19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `skip_emscripten_version_check` flag to skip emscripten version check.
+- Add `skip_emscripten_version_check` flag and SKIP_EMSCRIPTEN_VERSION_CHECK environment
+variable to skip emscripten version check.
   [#53](https://github.com/pyodide/pyodide-build/pull/53)
 
 ## [0.29.0] - 2024/09/19

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -252,8 +252,10 @@ def check_emscripten_version() -> None:
     installed_version = None
     try:
         for x in reversed(version_info.partition("\n")[0].split(" ")):
-            if re.match(r"[0-9]+\.[0-9]+\.[0-9]+", x):
-                installed_version = x
+            # (X.Y.Z) or (X.Y.Z)-git
+            match = re.match(r"(\d+\.\d+\.\d+)(-\w+)?", x)
+            if match:
+                installed_version = match.group(1)
                 break
     except Exception:
         raise RuntimeError("Failed to determine Emscripten version.") from None

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from packaging.tags import Tag, compatible_tags, cpython_tags
 
 from pyodide_build import __version__
-from pyodide_build.common import search_pyproject_toml, xbuildenv_dirname, to_bool
+from pyodide_build.common import search_pyproject_toml, to_bool, xbuildenv_dirname
 from pyodide_build.config import ConfigManager
 from pyodide_build.recipe import load_all_recipes
 

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from packaging.tags import Tag, compatible_tags, cpython_tags
 
 from pyodide_build import __version__
-from pyodide_build.common import search_pyproject_toml, xbuildenv_dirname
+from pyodide_build.common import search_pyproject_toml, xbuildenv_dirname, to_bool
 from pyodide_build.config import ConfigManager
 from pyodide_build.recipe import load_all_recipes
 
@@ -238,6 +238,10 @@ def get_emscripten_version_info() -> str:
 
 
 def check_emscripten_version() -> None:
+    skip = get_build_flag("SKIP_EMSCRIPTEN_VERSION_CHECK")
+    if to_bool(skip):
+        return
+
     needed_version = emscripten_version()
     try:
         version_info = get_emscripten_version_info()

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -446,4 +446,4 @@ def to_bool(value: str) -> bool:
     """
     Convert a string to a boolean value. Useful for parsing environment variables.
     """
-    return not value.lower() in {"", "0", "false", "no", "off"}
+    return value.lower() not in {"", "0", "false", "no", "off"}

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -440,3 +440,10 @@ def search_pyproject_toml(
             raise ValueError(f"Could not parse {pyproject_file}.") from e
 
     return None, None
+
+
+def to_bool(value: str) -> bool:
+    """
+    Convert a string to a boolean value. Useful for parsing environment variables.
+    """
+    return not value.lower() in {"", "0", "false", "no", "off"}

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -174,6 +174,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "home": "HOME",
     "path": "PATH",
     "zip_compression_level": "PYODIDE_ZIP_COMPRESSION_LEVEL",
+    "skip_emscripten_version_check": "SKIP_EMSCRIPTEN_VERSION_CHECK",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -188,6 +189,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "ldflags",
     "rust_toolchain",
     "meson_cross_file",
+    "skip_emscripten_version_check",
     # maintainer only
     "_f2c_fixes_wrapper",
 }
@@ -205,6 +207,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     "rust_toolchain": "nightly-2024-01-29",
     # Other configuration
     "pyodide_jobs": "1",
+    "skip_emscripten_version_check": "0",
     # maintainer only
     "_f2c_fixes_wrapper": "",
 }

--- a/pyodide_build/tests/test_build_env.py
+++ b/pyodide_build/tests/test_build_env.py
@@ -165,6 +165,12 @@ clang version 15.0.0 (https://github.com/llvm/llvm-project 7effcbda49ba32991b895
 """
     build_env.check_emscripten_version()
 
+    s = f"""\
+emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) {build_env.emscripten_version()}-git
+clang version 15.0.0 (https://github.com/llvm/llvm-project 7effcbda49ba32991b8955821b8fdbd4f8f303e2)
+"""
+    build_env.check_emscripten_version()
+
     def get_emscripten_version_info():  # type: ignore[no-redef]
         raise FileNotFoundError()
 

--- a/pyodide_build/tests/test_build_env.py
+++ b/pyodide_build/tests/test_build_env.py
@@ -179,6 +179,16 @@ clang version 15.0.0 (https://github.com/llvm/llvm-project 7effcbda49ba32991b895
         build_env.check_emscripten_version()
 
 
+def test_check_emscripten_version_skip(dummy_xbuildenv, monkeypatch, reset_cache):
+    with pytest.raises(RuntimeError):
+        monkeypatch.setenv("SKIP_EMSCRIPTEN_VERSION_CHECK", "0")
+        build_env.check_emscripten_version()
+
+    reset_cache()
+    monkeypatch.setenv("SKIP_EMSCRIPTEN_VERSION_CHECK", "1")
+    build_env.check_emscripten_version()
+
+
 def test_wheel_paths(dummy_xbuildenv):
     from pathlib import Path
 


### PR DESCRIPTION
Adds an option to skip emscripten version check. A user can either set `SKIP_EMSCRIPTEN_VERSION_CHECK` env variable, or `skip_emscripten_version_check` in the toml file.

I think it is useful in following scenarios:

- When we update the Emscripten version in Pyodide but it is not released yet, so a user wants to build a package against newer emscripten version.
- When a user needs a newer version of Emscripten to make their package work. But the Emscripten version in Pyodide is not updated yet.

Of course, these scenarios will not work if two versions of Emscripten are incompatible. But I think it is useful to provide this option as not always 