### PR TITLE
Validate Python version when initializing xbuildenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variable to skip emscripten version check.
   [#53](https://github.com/pyodide/pyodide-build/pull/53)
 
+- The `pyodide build` command will now raise an error if the local Python version has been changed,
+  after the cross-build environment has been set up.
+  [#62](https://github.com/pyodide/pyodide-build/pull/62)
+
 ## [0.29.0] - 2024/09/19
 
 ### Added

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -83,6 +83,8 @@ def _init_xbuild_env(*, quiet: bool = False) -> Path:
         if manager.current_version is None:
             manager.install()
 
+        manager.check_version_marker()
+
         return manager.pyodide_root
 
 

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -117,8 +117,8 @@ def _uninstall(
     """
     check_xbuildenv_root(path)
     manager = CrossBuildEnvManager(path)
-    manager.uninstall_version(version)
-    typer.echo(f"Pyodide cross-build environment {version} uninstalled")
+    v = manager.uninstall_version(version)
+    typer.echo(f"Pyodide cross-build environment {v} uninstalled")
 
 
 @app.command("use")

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -423,7 +423,8 @@ class CrossBuildEnvManager:
             raise ValueError(
                 f"local Python version ({version_local}) does not match the Python version ({version_on_install}) "
                 "used to create the Pyodide cross-build environment. "
-                "Please reinstall the xbuildenv, by running `pyodide xbuildenv uninstall` and then `pyodide xbuildenv install`"
+                "Please switch back to the original Python version, "
+                "or reinstall the xbuildenv, by running `pyodide xbuildenv uninstall` and then `pyodide xbuildenv install`"
             )
 
 


### PR DESCRIPTION
This adds a check when initializing xbuildenv (== `init_environment`) to make sure the local Python version used to install the xbuildenv was not changed.

This prevents the following scenario:

1. One has a local Python version (3.11.3) and installs Pyodide xbuildenv (0.25.1).
2. Then, one changes the local Python version to (3.12.1) using pyenv.
3. Pyodide xbuildenv 0.25.1 is no longer compatible to the local Python version, so it should fail.

Related issue: https://github.com/pyodide/pyodide-build/issues/44

