### PR TITLE
Add config variable for setting index url for build requirements

### DIFF
--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -175,6 +175,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "path": "PATH",
     "zip_compression_level": "PYODIDE_ZIP_COMPRESSION_LEVEL",
     "skip_emscripten_version_check": "SKIP_EMSCRIPTEN_VERSION_CHECK",
+    "build_dependency_index_url": "BUILD_DEPENDENCY_INDEX_URL",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -190,6 +191,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "rust_toolchain",
     "meson_cross_file",
     "skip_emscripten_version_check",
+    "build_dependency_index_url",
     # maintainer only
     "_f2c_fixes_wrapper",
 }
@@ -208,6 +210,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     # Other configuration
     "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",
+    "build_dependency_index_url": "https://pypi.anaconda.org/pyodide/simple",
     # maintainer only
     "_f2c_fixes_wrapper": "",
 }

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -89,6 +89,7 @@ class TestConfigManager_OutOfTree:
                                   ldflags = "-L/path/to/lib"
                                   rust_toolchain = "nightly"
                                   meson_cross_file = "$(MESON_CROSS_FILE)"
+                                  build_dependency_index_url = "https://example.com/simple"
                                   """)
 
         xbuildenv_manager = CrossBuildEnvManager(
@@ -103,6 +104,7 @@ class TestConfigManager_OutOfTree:
         assert config["ldflags"] == "-L/path/to/lib"
         assert config["rust_toolchain"] == "nightly"
         assert config["meson_cross_file"] == "/path/to/crossfile"
+        assert config["build_dependency_index_url"] == "https://example.com/simple"
 
     def test_config_all(self, dummy_xbuildenv, reset_env_vars, reset_cache):
         xbuildenv_manager = CrossBuildEnvManager(


### PR DESCRIPTION
This adds a new configuration variable, `build_dependency_index_url,` which will be used (TODO) to install build requirements when building packages. I'm splitting PRs to make the changes smaller.

related: #43 