### PR TITLE
Fix pyodide venv after removing shared_library key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.2]
+
+### Fixed
+
+- Fixed `pyodide venv` command not loading the shared libraries correctly, resulting in the package load failure.
+  This bug was introduced in version 0.28.
+  [#67](https://github.com/pyodide/pyodide-build/pull/67)
+
 ## [0.29.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.29.2]
+## [0.29.2] - 2024/11/29
 
 ### Fixed
 
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This bug was introduced in version 0.28.
   [#67](https://github.com/pyodide/pyodide-build/pull/67)
 
-## [0.29.1]
+## [0.29.1] - 2024/11/27
 
 ### Added
 

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -228,7 +228,6 @@ def install_stdlib(venv_bin: Path) -> None:
     # `--extra-index-url` it would install the pypi version which we don't want.
 
     # Other stuff we need to load with loadPackage
-    # TODO: Also load all shared libs.
     to_load = ["micropip"]
     result = subprocess.run(
         [
@@ -239,7 +238,7 @@ def install_stdlib(venv_bin: Path) -> None:
                 from pyodide_js import loadPackage
                 from pyodide_js._api import lockfile_packages
                 from pyodide_js._api import lockfile_unvendored_stdlibs_and_test
-                shared_libs = [pkgname for (pkgname,pkg) in lockfile_packages.object_entries() if getattr(pkg, "shared_library", False)]
+                shared_libs = [pkgname for (pkgname,pkg) in lockfile_packages.object_entries() if getattr(pkg, "package_type") == "shared_library"]
 
                 to_load = [*lockfile_unvendored_stdlibs_and_test, *shared_libs, *{to_load!r}]
                 loadPackage(to_load);


### PR DESCRIPTION
I removed `shared_library` key in the lock file in favor of `package_type` field (#18), but it was not applied in the `pyodide venv` command, resulting in the failure in the cmdline_runner test.