### PR TITLE
Fix is_link_cmd command to support response file

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -83,11 +83,18 @@ def is_link_cmd(line: list[str]) -> bool:
     """
     Check if the command is a linker invocation.
     """
-    import re
-
-    SHAREDLIB_REGEX = re.compile(r"\.so(.\d+)*$")
     for arg in line:
-        if not arg.startswith("-") and SHAREDLIB_REGEX.search(arg):
+        parts = arg.split(".")
+        idx = len(parts) - 1
+
+        # response file
+        if parts[-1] == "rsp":
+            idx -= 1
+
+        while idx > 0 and parts[idx].isdigit():
+            idx -= 1
+
+        if idx > 0 and parts[idx] == "so":
             return True
 
     return False

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -266,4 +266,8 @@ def test_handle_command_cmake(build_args):
 def test_is_link_cmd():
     assert is_link_cmd(["test.so"])
     assert is_link_cmd(["test.so.1.2.3"])
+    assert is_link_cmd(["test.so.rsp"])
+    assert is_link_cmd(["test.1.2.3.so.rsp"])
+    assert not is_link_cmd(["test.1.2.3.rsp"])
+    assert is_link_cmd(["emcc.py", "test.so"])
     assert not is_link_cmd(["test", "test.a", "test.o", "test.c", "test.cpp", "test.h"])


### PR DESCRIPTION
Fix https://github.com/pyodide/pyodide/issues/5131

This fixes the `is_link_cmd` function which is used to detect the linker invocation.

If the command is too long, build systems like Ninja (or CMake, etc) use a response file to store the commands into a file. For instance, the command

```
emcc.py -o output.so input1.o input2.o ... inputN.o
```

becomes

```
emcc.py @output.so.rsp
```

where the file `output.so.rsp` stores all the commandline parameters.

Therefore, this PR fixes the `is_link_cmd` to detect the response file.

Note that I also removed the usage of `re` module, as I found that using string commands are much cheaper than compiling the regex.

- [ ] changelog
