### PR TITLE
Use Emscripten's  `llvm-readobj` by default

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -344,10 +344,10 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
     emcc = Path(which_emcc)
     readobj = (emcc / "../../bin/llvm-readobj").resolve()
     if readobj.exists():
-        readobj_path=str(readobj)
+        readobj_path = str(readobj)
     else:
         readobj_path = shutil.which("llvm-readobj")
-    assert(readobj_path)
+    assert readobj_path
 
     args = [
         readobj_path,

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -351,8 +351,8 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
     else:
         readobj_path = shutil.which("llvm-readobj")
     if not readobj_path:
-       print("Failed to find llvm-readobj, quitting", file=sys.stdout)
-       sys.exit(1)
+        print("Failed to find llvm-readobj, quitting", file=sys.stdout)
+        sys.exit(1)
 
     args = [
         readobj_path,

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -348,11 +348,6 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
     else:
         readobj_path = shutil.which("llvm-readobj")
     assert(readobj_path)
-    args = [
-        readobj_path,
-        "--section-details",
-        "-st",
-    ] + objects
 
     args = [
         readobj_path,

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -350,7 +350,9 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
         readobj_path = str(readobj)
     else:
         readobj_path = shutil.which("llvm-readobj")
-    assert readobj_path
+    if not readobj_path:
+       print("Failed to find llvm-readobj, quitting", file=sys.stdout)
+       sys.exit(1)
 
     args = [
         readobj_path,

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -339,12 +339,21 @@ def _calculate_object_exports_readobj_parse(output: str) -> list[str]:
 def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
     import shutil
 
-    readobj_path = shutil.which("llvm-readobj")
-    if not readobj_path:
-        which_emcc = shutil.which("emcc")
-        assert which_emcc
-        emcc = Path(which_emcc)
-        readobj_path = str((emcc / "../../bin/llvm-readobj").resolve())
+    which_emcc = shutil.which("emcc")
+    assert which_emcc
+    emcc = Path(which_emcc)
+    readobj = (emcc / "../../bin/llvm-readobj").resolve()
+    if readobj.exists():
+        readobj_path=str(readobj)
+    else:
+        readobj_path = shutil.which("llvm-readobj")
+    assert(readobj_path)
+    args = [
+        readobj_path,
+        "--section-details",
+        "-st",
+    ] + objects
+
     args = [
         readobj_path,
         "--section-details",

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -339,6 +339,9 @@ def _calculate_object_exports_readobj_parse(output: str) -> list[str]:
 def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
     import shutil
 
+    # This works for bootstrapped Emscripten via GitHub sources.
+    # llvm-readobj might not be available this way with Homebrew
+    # or conda-forge distributions of Emscripten.
     which_emcc = shutil.which("emcc")
     assert which_emcc
     emcc = Path(which_emcc)


### PR DESCRIPTION
## Description

This PR is a rework of pyodide/pyodide#4186. I think the premise of the original PR—which I agree with—was that it is better for us to rely on `llvm-readobj` from the Emscripten toolchain first, before seeking the one on `PATH`.

## Additional info

`llvm-readobj` is not available with Homebrew's Emscripten recipe, but with LLVM (of course):

```bash
$(brew --prefix llvm)/bin/llvm-readobj --version
```

```
Homebrew LLVM version 19.1.6
  Optimized build.
```

v.s. Emscripten 3.1.58 (note the slightly older LLVM, but tip-of-tree at that time for Emscripten 3.1.58 which we use at the time of writing):

```bash
Users/agriyakhetarpal/emsdk/upstream/bin/llvm-readobj --version
```

```
LLVM (http://llvm.org/):
  LLVM version 19.0.0git
  Optimized build.
```

Unfortunately, I can't test what the conda-forge feedstock for Emscripten does as of now, because I can't install it on my M-series machine. I've opened an issue about it here: https://github.com/conda-forge/emscripten-feedstock/issues/35