### PR TITLE
Integration tests: fix `orjson`'s builds with Maturin 1.8, and bump to NumPy v2

### DIFF
--- a/integration_tests/recipes/numpy/meta.yaml
+++ b/integration_tests/recipes/numpy/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: numpy
-  version: 1.26.4
+  version: 2.0.2
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
-  sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
+  url: https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz
+  sha256: 883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78
 
 build:
   # numpy uses vendored meson, so we need to pass the cross file manually
@@ -22,12 +22,12 @@ build:
     -Wno-return-type
   cross-build-env: true
   cross-build-files:
-    - numpy/core/include/numpy/numpyconfig.h
-    - numpy/core/include/numpy/_numpyconfig.h
-    - numpy/core/lib/libnpymath.a
+    - numpy/_core/include/numpy/numpyconfig.h
+    - numpy/_core/include/numpy/_numpyconfig.h
+    - numpy/_core/lib/libnpymath.a
     - numpy/random/lib/libnpyrandom.a
 about:
   home: https://www.numpy.org
   PyPI: https://pypi.org/project/numpy
   summary: NumPy is the fundamental package for array computing with Python.
-  license: BSD
+  license: BSD-3-Clause

--- a/integration_tests/recipes/orjson/meta.yaml
+++ b/integration_tests/recipes/orjson/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: orjson
-  version: 3.10.1
+  version: 3.10.13
   top-level:
     - orjson
 source:
-  url: https://files.pythonhosted.org/packages/f5/af/0daa12a907215a5af6d97db8adf301ef14a1b1c651f7e176ee04e0998433/orjson-3.10.1.tar.gz
-  sha256: a883b28d73370df23ed995c466b4f6c708c1f7a9bdc400fe89165c96c7603204
+  url: https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.13.tar.gz
+  sha256: eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec
 requirements:
   executable:
     - rustup


### PR DESCRIPTION
## Description

Please see https://github.com/pyodide/pyodide/pull/5283 for the context behind this change. This PR updates `orjson` to https://github.com/ijl/orjson/releases/tag/3.10.13 which fixed a missing `version` attribute in the project's declarative metadata, which resulted in a regression with https://github.com/PyO3/maturin/releases/tag/v1.8.0

## Additional context

- List of changes for Maturin 1.8: https://github.com/PyO3/maturin/blob/main/Changelog.md#180