### PR TITLE
Add a new configuration variable for setting default xbuildenv url

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -15,7 +15,7 @@ from packaging.tags import Tag, compatible_tags, cpython_tags
 
 from pyodide_build import __version__
 from pyodide_build.common import search_pyproject_toml, to_bool, xbuildenv_dirname
-from pyodide_build.config import ConfigManager
+from pyodide_build.config import ConfigManager, CrossBuildEnvConfigManager
 from pyodide_build.recipe import load_all_recipes
 
 RUST_BUILD_PRELUDE = """
@@ -120,7 +120,7 @@ def get_build_environment_vars(pyodide_root: Path) -> dict[str, str]:
     """
     Get common environment variables for the in-tree and out-of-tree build.
     """
-    config_manager = ConfigManager(pyodide_root)
+    config_manager = CrossBuildEnvConfigManager(pyodide_root)
     env = config_manager.to_env()
 
     env.update(
@@ -137,12 +137,29 @@ def get_build_environment_vars(pyodide_root: Path) -> dict[str, str]:
     return env
 
 
+@functools.cache
+def get_host_build_environment_vars() -> dict[str, str]:
+    manager = ConfigManager()
+    return manager.to_env()
+
+
 def get_build_flag(name: str) -> str:
     """
     Get a value of a build flag.
     """
     pyodide_root = get_pyodide_root()
     build_vars = get_build_environment_vars(pyodide_root)
+    if name not in build_vars:
+        raise ValueError(f"Unknown build flag: {name}")
+
+    return build_vars[name]
+
+
+def get_host_build_flag(name: str) -> str:
+    """
+    Get a value of a build flag without accessing the cross-build environment.
+    """
+    build_vars = get_host_build_environment_vars()
     if name not in build_vars:
         raise ValueError(f"Unknown build flag: {name}")
 

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -34,7 +34,7 @@ class ConfigManager:
     def _load_default_config(self) -> Mapping[str, str]:
         return deepcopy(DEFAULT_CONFIG)
 
-    def _load_cross_build_envs() -> Mapping[str, str]:
+    def _load_cross_build_envs(self) -> Mapping[str, str]:
         """
         Load environment variables from the cross build environment.
         """

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -177,6 +177,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "zip_compression_level": "PYODIDE_ZIP_COMPRESSION_LEVEL",
     "skip_emscripten_version_check": "SKIP_EMSCRIPTEN_VERSION_CHECK",
     "build_dependency_index_url": "BUILD_DEPENDENCY_INDEX_URL",
+    "default_cross_build_env_url": "DEFAULT_CROSS_BUILD_ENV_URL",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -193,6 +194,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "meson_cross_file",
     "skip_emscripten_version_check",
     "build_dependency_index_url",
+    "default_cross_build_env_url"
     # maintainer only
     "_f2c_fixes_wrapper",
 }
@@ -212,6 +214,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",
     "build_dependency_index_url": "https://pypi.anaconda.org/pyodide/simple",
+    "default_cross_build_env_url": "",
     # maintainer only
     "_f2c_fixes_wrapper": "",
 }

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 from types import MappingProxyType
 
@@ -14,7 +15,80 @@ from pyodide_build.logger import logger
 
 class ConfigManager:
     """
+    Configuration manager for pyodide-build.
+    This class works "before" installing the cross build environment.
+    So it does not have access to the variables that are retrieved from the cross build environment.
+
+    Most of the times, use CrossBuildEnvConfigManager instead of this class.
+    But if you need to access the configuration without installing the cross build environment, use this class.
+    """
+
+    def __init__(self):
+        self._config = {
+            **self._load_default_config(),
+            **self._load_cross_build_envs(),
+            **self._load_config_file(Path.cwd(), os.environ),
+            **self._load_config_from_env(os.environ),
+        }
+
+    def _load_default_config(self) -> Mapping[str, str]:
+        return deepcopy(DEFAULT_CONFIG)
+
+    def _load_cross_build_envs() -> Mapping[str, str]:
+        """
+        Load environment variables from the cross build environment.
+        """
+
+        # This method should be implemented in the subclass.
+        return {}
+
+    def _load_config_from_env(self, env: Mapping[str, str]) -> Mapping[str, str]:
+        return {
+            BUILD_VAR_TO_KEY[key]: env[key] for key in env if key in BUILD_VAR_TO_KEY
+        }
+
+    def _load_config_file(
+        self, curdir: Path, env: Mapping[str, str]
+    ) -> Mapping[str, str]:
+        pyproject_path, configs = search_pyproject_toml(curdir)
+
+        if pyproject_path is None or configs is None:
+            return {}
+
+        if (
+            "tool" in configs
+            and "pyodide" in configs["tool"]
+            and "build" in configs["tool"]["pyodide"]
+        ):
+            build_config = {}
+            for key, v in configs["tool"]["pyodide"]["build"].items():
+                if key not in OVERRIDABLE_BUILD_KEYS:
+                    logger.warning(
+                        "WARNING: The provided build key %s is either invalid or not overridable, hence ignored.",
+                        key,
+                    )
+                    continue
+                build_config[key] = _environment_substitute_str(v, env)
+
+            return build_config
+        else:
+            return {}
+
+    @property
+    def config(self) -> Mapping[str, str]:
+        return MappingProxyType(self._config)
+
+    def to_env(self) -> dict[str, str]:
+        """
+        Export the configuration to environment variables.
+        """
+        return {BUILD_KEY_TO_VAR[k]: v for k, v in self.config.items()}
+
+
+class CrossBuildEnvConfigManager(ConfigManager):
+    """
     Configuration manager for Package build process.
+    This class works "after" installing the cross build environment.
 
     The configuration manager is responsible for loading configuration from various sources.
     The configuration can be loaded from the following sources (in order of precedence):
@@ -28,22 +102,9 @@ class ConfigManager:
 
     def __init__(self, pyodide_root: Path):
         self.pyodide_root = pyodide_root
-        self._config = {
-            **self._load_default_config(),
-            **self._load_makefile_envs(),
-            **self._load_config_file(Path.cwd(), os.environ),
-            **self._load_config_from_env(os.environ),
-        }
+        super().__init__()
 
-    def _load_default_config(self) -> Mapping[str, str]:
-        return {
-            k: _environment_substitute_str(
-                v, env={"PYODIDE_ROOT": str(self.pyodide_root)}
-            )
-            for k, v in DEFAULT_CONFIG.items()
-        }
-
-    def _load_makefile_envs(self) -> Mapping[str, str]:
+    def _load_cross_build_envs(self) -> Mapping[str, str]:
         makefile_vars = self._get_make_environment_vars()
         computed_vars = {
             k: _environment_substitute_str(v, env=makefile_vars)
@@ -88,48 +149,6 @@ class ConfigManager:
                 environment[varname] = value
 
         return environment
-
-    def _load_config_from_env(self, env: Mapping[str, str]) -> Mapping[str, str]:
-        return {
-            BUILD_VAR_TO_KEY[key]: env[key] for key in env if key in BUILD_VAR_TO_KEY
-        }
-
-    def _load_config_file(
-        self, curdir: Path, env: Mapping[str, str]
-    ) -> Mapping[str, str]:
-        pyproject_path, configs = search_pyproject_toml(curdir)
-
-        if pyproject_path is None or configs is None:
-            return {}
-
-        if (
-            "tool" in configs
-            and "pyodide" in configs["tool"]
-            and "build" in configs["tool"]["pyodide"]
-        ):
-            build_config = {}
-            for key, v in configs["tool"]["pyodide"]["build"].items():
-                if key not in OVERRIDABLE_BUILD_KEYS:
-                    logger.warning(
-                        "WARNING: The provided build key %s is either invalid or not overridable, hence ignored.",
-                        key,
-                    )
-                    continue
-                build_config[key] = _environment_substitute_str(v, env)
-
-            return build_config
-        else:
-            return {}
-
-    @property
-    def config(self) -> Mapping[str, str]:
-        return MappingProxyType(self._config)
-
-    def to_env(self) -> dict[str, str]:
-        """
-        Export the configuration to environment variables.
-        """
-        return {BUILD_KEY_TO_VAR[k]: v for k, v in self.config.items()}
 
 
 # Configuration variables and corresponding environment variables.
@@ -194,7 +213,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "meson_cross_file",
     "skip_emscripten_version_check",
     "build_dependency_index_url",
-    "default_cross_build_env_url"
+    "default_cross_build_env_url",
     # maintainer only
     "_f2c_fixes_wrapper",
 }

--- a/pyodide_build/tests/conftest.py
+++ b/pyodide_build/tests/conftest.py
@@ -61,6 +61,7 @@ def reset_cache():
 
     def _reset():
         build_env.get_pyodide_root.cache_clear()
+        build_env.get_host_build_environment_vars.cache_clear()
         build_env.get_build_environment_vars.cache_clear()
         build_env.get_unisolated_packages.cache_clear()
 

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -4,16 +4,58 @@ from pyodide_build.config import (
     DEFAULT_CONFIG,
     DEFAULT_CONFIG_COMPUTED,
     ConfigManager,
+    CrossBuildEnvConfigManager,
 )
 from pyodide_build.xbuildenv import CrossBuildEnvManager
 
 
-class TestConfigManager_OutOfTree:
+class TestConfigManager:
+    def test_default_config(self, reset_env_vars, reset_cache):
+        config_manager = ConfigManager()
+        default_config = config_manager._load_default_config()
+        assert default_config.keys() == DEFAULT_CONFIG.keys()
+
+    def test_load_config_from_env(self, reset_env_vars, reset_cache):
+        config_manager = ConfigManager()
+        env = {
+            "CMAKE_TOOLCHAIN_FILE": "/path/to/toolchain",
+            "MESON_CROSS_FILE": "/path/to/crossfile",
+        }
+
+        config = config_manager._load_config_from_env(env)
+        assert config["cmake_toolchain_file"] == "/path/to/toolchain"
+        assert config["meson_cross_file"] == "/path/to/crossfile"
+
+    def test_load_config_from_file(self, tmp_path, reset_env_vars, reset_cache):
+        pyproject_file = tmp_path / "pyproject.toml"
+
+        env = {
+            "MESON_CROSS_FILE": "/path/to/crossfile",
+        }
+
+        pyproject_file.write_text("""[tool.pyodide.build]
+                                  invalid_flags = "this_should_not_be_parsed"
+                                  default_cross_build_env_url = "https://example.com/cross_build_env.tar.gz"
+                                  """)
+
+        config_manager = ConfigManager()
+        config = config_manager._load_config_file(pyproject_file, env)
+
+        assert "invalid_flags" not in config
+        assert (
+            config["default_cross_build_env_url"]
+            == "https://example.com/cross_build_env.tar.gz"
+        )
+
+
+class TestCrossBuildEnvConfigManager_OutOfTree:
     def test_default_config(self, dummy_xbuildenv, reset_env_vars, reset_cache):
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
 
         default_config = config_manager._load_default_config()
         assert default_config.keys() == DEFAULT_CONFIG.keys()
@@ -22,7 +64,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
 
         makefile_vars = config_manager._load_makefile_envs()
 
@@ -41,7 +85,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
         make_vars = config_manager._get_make_environment_vars()
         assert make_vars["PYODIDE_ROOT"] == str(xbuildenv_manager.pyodide_root)
 
@@ -49,7 +95,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
 
         makefile_vars = config_manager._load_makefile_envs()
 
@@ -62,7 +110,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
 
         env = {
             "CMAKE_TOOLCHAIN_FILE": "/path/to/toolchain",
@@ -95,7 +145,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
 
         config = config_manager._load_config_file(pyproject_file, env)
 
@@ -110,7 +162,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
         config = config_manager.config
 
         for key in BUILD_KEY_TO_VAR.keys():
@@ -120,7 +174,9 @@ class TestConfigManager_OutOfTree:
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
-        config_manager = ConfigManager(pyodide_root=xbuildenv_manager.pyodide_root)
+        config_manager = CrossBuildEnvConfigManager(
+            pyodide_root=xbuildenv_manager.pyodide_root
+        )
         env = config_manager.to_env()
         for env_var in BUILD_KEY_TO_VAR.values():
             assert env_var in env

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -60,7 +60,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
         default_config = config_manager._load_default_config()
         assert default_config.keys() == DEFAULT_CONFIG.keys()
 
-    def test_makefile_envs(self, dummy_xbuildenv, reset_env_vars, reset_cache):
+    def test_cross_build_envs(self, dummy_xbuildenv, reset_env_vars, reset_cache):
         xbuildenv_manager = CrossBuildEnvManager(
             dummy_xbuildenv / common.xbuildenv_dirname()
         )
@@ -68,7 +68,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
             pyodide_root=xbuildenv_manager.pyodide_root
         )
 
-        makefile_vars = config_manager._load_makefile_envs()
+        makefile_vars = config_manager._load_cross_build_envs()
 
         # It should contain information about the cpython and emscripten versions
         assert "pyversion" in makefile_vars
@@ -99,7 +99,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
             pyodide_root=xbuildenv_manager.pyodide_root
         )
 
-        makefile_vars = config_manager._load_makefile_envs()
+        makefile_vars = config_manager._load_cross_build_envs()
 
         for k, v in DEFAULT_CONFIG_COMPUTED.items():
             assert k in makefile_vars

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -209,7 +209,13 @@ class TestCrossBuildEnvManager:
         ).read_text() == f"{sys.version_info.major}.{sys.version_info.minor}"
 
     def test_install_url_default(
-        self, tmp_path, dummy_xbuildenv_url, monkeypatch, monkeypatch_subprocess_run_pip, reset_cache, reset_env_vars
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch,
+        monkeypatch_subprocess_run_pip,
+        reset_cache,
+        reset_env_vars,
     ):
         manager = CrossBuildEnvManager(tmp_path)
 

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -225,9 +225,6 @@ class TestCrossBuildEnvManager:
         assert manager.symlink_dir.resolve() == tmp_path / version
         assert (manager.symlink_dir / "xbuildenv").exists()
         assert (manager.symlink_dir / "xbuildenv" / "pyodide-root").exists()
-        assert not (
-            manager.symlink_dir / "xbuildenv" / "pyodide-root" / "package_index"
-        ).exists()
         assert (manager.symlink_dir / "xbuildenv" / "site-packages-extras").exists()
 
         assert (manager.symlink_dir / ".build-python-version").exists()

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import pytest
@@ -127,6 +128,24 @@ class TestCrossBuildEnvManager:
         ):
             manager._find_latest_version()
 
+    def test_get_default_xbuildenv_url(
+        self, tmp_path, fake_xbuildenv_releases_compatible, reset_cache, reset_env_vars
+    ):
+        manager = CrossBuildEnvManager(
+            tmp_path, str(fake_xbuildenv_releases_compatible)
+        )
+        url = manager._get_default_xbuildenv_url()
+        assert url == ""
+
+        reset_cache()
+
+        os.environ["DEFAULT_CROSS_BUILD_ENV_URL"] = (
+            "https://example.com/xbuildenv-0.25.0.tar.bz2"
+        )
+
+        url = manager._get_default_xbuildenv_url()
+        assert url == "https://example.com/xbuildenv-0.25.0.tar.bz2"
+
     def test_install_version(
         self,
         tmp_path,
@@ -169,6 +188,33 @@ class TestCrossBuildEnvManager:
         manager = CrossBuildEnvManager(tmp_path)
 
         manager.install(version=None, url=dummy_xbuildenv_url)
+        version = _url_to_version(dummy_xbuildenv_url)
+
+        assert (tmp_path / version).exists()
+        assert (tmp_path / version / ".installed").exists()
+        assert manager.current_version == version
+
+        assert manager.symlink_dir.is_symlink()
+        assert manager.symlink_dir.resolve() == tmp_path / version
+        assert (manager.symlink_dir / "xbuildenv").exists()
+        assert (manager.symlink_dir / "xbuildenv" / "pyodide-root").exists()
+        assert not (
+            manager.symlink_dir / "xbuildenv" / "pyodide-root" / "package_index"
+        ).exists()
+        assert (manager.symlink_dir / "xbuildenv" / "site-packages-extras").exists()
+
+        assert (manager.symlink_dir / ".build-python-version").exists()
+        assert (
+            manager.symlink_dir / ".build-python-version"
+        ).read_text() == f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    def test_install_url_default(
+        self, tmp_path, dummy_xbuildenv_url, monkeypatch, monkeypatch_subprocess_run_pip, reset_cache, reset_env_vars
+    ):
+        manager = CrossBuildEnvManager(tmp_path)
+
+        os.environ["DEFAULT_CROSS_BUILD_ENV_URL"] = dummy_xbuildenv_url
+        manager.install(version=None)
         version = _url_to_version(dummy_xbuildenv_url)
 
         assert (tmp_path / version).exists()

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -170,7 +170,7 @@ class CrossBuildEnvManager:
             version = _url_to_version(url)
             download_url = url
         else:
-            version = version or self._find_latest_version()
+            version = version or self._get_default_version() or self._find_latest_version()
 
             local_versions = build_env.local_versions()
             release = self._find_remote_release(version)

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -169,8 +169,12 @@ class CrossBuildEnvManager:
         if url:
             version = _url_to_version(url)
             download_url = url
+        # if default version is specified in the configuration, use that
+        elif not version and (default_url := self._get_default_xbuildenv_url()):
+            version = _url_to_version(default_url)
+            download_url = default_url
         else:
-            version = version or self._get_default_version() or self._find_latest_version()
+            version = version or self._find_latest_version()
 
             local_versions = build_env.local_versions()
             release = self._find_remote_release(version)
@@ -239,6 +243,12 @@ class CrossBuildEnvManager:
             raise ValueError("No compatible cross-build environment found")
 
         return latest.version
+
+    def _get_default_xbuildenv_url(self) -> str:
+        """
+        Get the default URL for the cross-build environment. If not specified, return empty string (no default).
+        """
+        return build_env.get_host_build_flag("DEFAULT_CROSS_BUILD_ENV_URL")
 
     def _install_cross_build_packages(
         self, xbuildenv_root: Path, xbuildenv_pyodide_root: Path


### PR DESCRIPTION
This PR adds a new config variable: `default_cross_build_env_url.`

This variable is used to set the default xbuildenv URL, which will be downloaded when a user calls `pyodide xbuildenv install` without passing the version, or when a user calls `pyodide build` without explicitly installing the xbuildenv.

__When is this variable useful?__

For now, building packages using the nightly cross-build env, we need to explicitly install it from URL:

```
pyodide xbuildenv install --url http://example.com/xbuildenv/dev/xbuildenv.tar.bz2
```

For instance, in pyodide-recipes repository, this is set in [CI script](https://github.com/pyodide/pyodide-recipes/blob/eb15b15360a8b11bdf510935120fa42e9be2311c/.github/workflows/build.yml#L111).

However, I would like to put this value in the `pyproject.toml`, which, I think is more appropriate place to put build-related variables.