### PR TITLE
Update rust_toolchain, drop link_native_libs=no and bigint flags

### DIFF
--- a/integration_tests/recipes/orjson/meta.yaml
+++ b/integration_tests/recipes/orjson/meta.yaml
@@ -9,8 +9,6 @@ source:
 requirements:
   executable:
     - rustup
-build:
-  script: export RUSTFLAGS="-Z link-native-libraries=yes"
 about:
   home: https://github.com/ijl/orjson
   PyPI: https://pypi.org/project/orjson

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -204,10 +204,10 @@ DEFAULT_CONFIG: dict[str, str] = {
     "cmake_toolchain_file": str(TOOLS_DIR / "cmake/Modules/Platform/Emscripten.cmake"),
     "meson_cross_file": str(TOOLS_DIR / "emscripten.meson.cross"),
     # Rust-specific configuration
-    "rustflags": "-C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT -Z link-native-libraries=no",
+    "rustflags": "-C link-arg=-sSIDE_MODULE=2",
     "cargo_build_target": "wasm32-unknown-emscripten",
     "cargo_target_wasm32_unknown_emscripten_linker": "emcc",
-    "rust_toolchain": "nightly-2024-01-29",
+    "rust_toolchain": "nightly-2025-01-15",
     # Other configuration
     "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",


### PR DESCRIPTION
We don't need these anymore. link_native_libs=no was fixed by:
https://github.com/rust-lang/libc/pull/4002
and wasm_bigint was fixed by:
https://github.com/rust-lang/rust/pull/131736