### PR TITLE
Split config manager into `ConfigManager` and `CrossBuildEnvConfigManager`

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -15,7 +15,7 @@ from packaging.tags import Tag, compatible_tags, cpython_tags
 
 from pyodide_build import __version__
 from pyodide_build.common import search_pyproject_toml, to_bool, xbuildenv_dirname
-from pyodide_build.config import ConfigManager
+from pyodide_build.config import ConfigManager, CrossBuildEnvConfigManager
 from pyodide_build.recipe import load_all_recipes
 
 RUST_BUILD_PRELUDE = """
@@ -120,7 +120,7 @@ def get_build_environment_vars(pyodide_root: Path) -> dict[str, str]:
     """
     Get common environment variables for the in-tree and out-of-tree build.
     """
-    config_manager = ConfigManager(pyodide_root)
+    config_manager = CrossBuildEnvConfigManager(pyodide_root)
     env = config_manager.to_env()
 
     env.update(
@@ -137,12 +137,29 @@ def get_build_environment_vars(pyodide_root: Path) -> dict[str, str]:
     return env
 
 
+@functools.cache
+def get_host_build_environment_vars() -> dict[str, str]:
+    manager = ConfigManager()
+    return manager.to_env()
+
+
 def get_build_flag(name: str) -> str:
     """
     Get a value of a build flag.
     """
     pyodide_root = get_pyodide_root()
     build_vars = get_build_environment_vars(pyodide_root)
+    if name not in build_vars:
+        raise ValueError(f"Unknown build flag: {name}")
+
+    return build_vars[name]
+
+
+def get_host_build_flag(name: str) -> str:
+    """
+    Get a value of a build flag without accessing the cross-build environment.
+    """
+    build_vars = get_host_build_environment_vars()
     if name not in build_vars:
         raise ValueError(f"Unknown build flag: {name}")
 

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 from types import MappingProxyType
 
@@ -14,7 +15,80 @@ from pyodide_build.logger import logger
 
 class ConfigManager:
     """
+    Configuration manager for pyodide-build.
+    This class works "before" installing the cross build environment.
+    So it does not have access to the variables that are retrieved from the cross build environment.
+
+    Most of the times, use CrossBuildEnvConfigManager instead of this class.
+    But if you need to access the configuration without installing the cross build environment, use this class.
+    """
+
+    def __init__(self):
+        self._config = {
+            **self._load_default_config(),
+            **self._load_cross_build_envs(),
+            **self._load_config_file(Path.cwd(), os.environ),
+            **self._load_config_from_env(os.environ),
+        }
+
+    def _load_default_config(self) -> Mapping[str, str]:
+        return deepcopy(DEFAULT_CONFIG)
+
+    def _load_cross_build_envs(self) -> Mapping[str, str]:
+        """
+        Load environment variables from the cross build environment.
+        """
+
+        # This method should be implemented in the subclass.
+        return {}
+
+    def _load_config_from_env(self, env: Mapping[str, str]) -> Mapping[str, str]:
+        return {
+            BUILD_VAR_TO_KEY[key]: env[key] for key in env if key in BUILD_VAR_TO_KEY
+        }
+
+    def _load_config_file(
+        self, curdir: Path, env: Mapping[str, str]
+    ) -> Mapping[str, str]:
+        pyproject_path, configs = search_pyproject_toml(curdir)
+
+        if pyproject_path is None or configs is None:
+            return {}
+
+        if (
+            "tool" in configs
+            and "pyodide" in configs["tool"]
+            and "build" in configs["tool"]["pyodide"]
+        ):
+            build_config = {}
+            for key, v in configs["tool"]["pyodide"]["build"].items():
+                if key not in OVERRIDABLE_BUILD_KEYS:
+                    logger.warning(
+                        "WARNING: The provided build key %s is either invalid or not overridable, hence ignored.",
+                        key,
+                    )
+                    continue
+                build_config[key] = _environment_substitute_str(v, env)
+
+            return build_config
+        else:
+            return {}
+
+    @property
+    def config(self) -> Mapping[str, str]:
+        return MappingProxyType(self._config)
+
+    def to_env(self) -> dict[str, str]:
+        """
+        Export the configuration to environment variables.
+        """
+        return {BUILD_KEY_TO_VAR[k]: v for k, v in self.config.items()}
+
+
+class CrossBuildEnvConfigManager(ConfigManager):
+    """
     Configuration manager for Package build process.
+    This class works "after" installing the cross build environment.
 
     The configuration manager is responsible for loading configuration from various sources.
     The configuration can be loaded from the following sources (in order of precedence):
@@ -28,22 +102,9 @@ class ConfigManager:
 
     def __init__(self, pyodide_root: Path):
         self.pyodide_root = pyodide_root
-        self._config = {
-            **self._load_default_config(),
-            **self._load_makefile_envs(),
-            **self._load_config_file(Path.cwd(), os.environ),
-            **self._load_config_from_env(os.environ),
-        }
+        super().__init__()
 
-    def _load_default_config(self) -> Mapping[str, str]:
-        return {
-            k: _environment_substitute_str(
-                v, env={"PYODIDE_ROOT": str(self.pyodide_root)}
-            )
-            for k, v in DEFAULT_CONFIG.items()
-        }
-
-    def _load_makefile_envs(self) -> Mapping[str, str]:
+    def _load_cross_build_envs(self) -> Mapping[str, str]:
         makefile_vars = self._get_make_environment_vars()
         computed_vars = {
             k: _environment_substitute_str(v, env=makefile_vars)
@@ -88,48 +149,6 @@ class ConfigManager:
                 environment[varname] = value
 
         return environment
-
-    def _load_config_from_env(self, env: Mapping[str, str]) -> Mapping[str, str]:
-        return {
-            BUILD_VAR_TO_KEY[key]: env[key] for key in env if key in BUILD_VAR_TO_KEY
-        }
-
-    def _load_config_file(
-        self, curdir: Path, env: Mapping[str, str]
-    ) -> Mapping[str, str]:
-        pyproject_path, configs = search_pyproject_toml(curdir)
-
-        if pyproject_path is None or configs is None:
-            return {}
-
-        if (
-            "tool" in configs
-            and "pyodide" in configs["tool"]
-            and "build" in configs["tool"]["pyodide"]
-        ):
-            build_config = {}
-            for key, v in configs["tool"]["pyodide"]["build"].items():
-                if key not in OVERRIDABLE_BUILD_KEYS:
-                    logger.warning(
-                        "WARNING: The provided build key %s is either invalid or not overridable, hence ignored.",
-                        key,
-                    )
-                    continue
-                build_config[key] = _environment_substitute_str(v, env)
-
-            return build_config
-        else:
-            return {}
-
-    @property
-    def config(self) -> Mapping[str, str]:
-        return MappingProxyType(self._config)
-
-    def to_env(self) -> dict[str, str]:
-        """
-        Export the configuration to environment variables.
-        """
-        return {BUILD_KEY_TO_VAR[k]: v for k, v in self.config.items()}
 
 
 # Configuration variables and corresponding environment variables.

--- a/pyodide_build/tests/conftest.py
+++ b/pyodide_build/tests/conftest.py
@@ -61,6 +61,7 @@ def reset_cache():
 
     def _reset():
         build_env.get_pyodide_root.cache_clear()
+        build_env.get_host_build_environment_vars.cache_clear()
         build_env.get_build_environment_vars.cache_clear()
         build_env.get_unisolated_packages.cache_clear()
 

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -42,10 +42,7 @@ class TestConfigManager:
         config = config_manager._load_config_file(pyproject_file, env)
 
         assert "invalid_flags" not in config
-        assert (
-            config["skip_emscripten_version_check"]
-            == "1"
-        )
+        assert config["skip_emscripten_version_check"] == "1"
 
 
 class TestCrossBuildEnvConfigManager_OutOfTree:


### PR DESCRIPTION
Splitted out from #85 to reduce diff.