### PR TITLE
Add `FORCE_COLOR: 3` to GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 3
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 3 * * 1"
 
+env:
+  FORCE_COLOR: 3
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This gets us better output for GitHub Actions activities; see https://force-color.org/. I feel all CI providers should enable this everywhere, but that's more of a radical opinion, perhaps 😄