### PR TITLE
Bump default Rust toolchain to `nightly-2025-02-01`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The Rust toolchain version has been updated to `nightly-2025-01-18`.
+  [#103](https://github.com/pyodide/pyodide-build/pull/103)
+
 ## [0.29.3] - 2025/02/04
 
 ### Added

--- a/integration_tests/recipes/orjson/meta.yaml
+++ b/integration_tests/recipes/orjson/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: orjson
-  version: 3.10.13
+  version: 3.10.15
   top-level:
     - orjson
 source:
-  url: https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.13.tar.gz
-  sha256: eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec
+  url: https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.15.tar.gz
+  sha256: 05ca7fe452a2e9d8d9d706a2984c95b9c2ebc5db417ce0b7a49b91d50642a23e
 requirements:
   executable:
     - rustup

--- a/integration_tests/recipes/orjson/meta.yaml
+++ b/integration_tests/recipes/orjson/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: orjson
-  version: 3.10.15
+  version: 3.10.13
   top-level:
     - orjson
 source:
-  url: https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.15.tar.gz
-  sha256: 05ca7fe452a2e9d8d9d706a2984c95b9c2ebc5db417ce0b7a49b91d50642a23e
+  url: https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.13.tar.gz
+  sha256: eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec
 requirements:
   executable:
     - rustup

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -228,7 +228,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     "rustflags": "-C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT -Z link-native-libraries=no",
     "cargo_build_target": "wasm32-unknown-emscripten",
     "cargo_target_wasm32_unknown_emscripten_linker": "emcc",
-    "rust_toolchain": "nightly-2025-02-18",
+    "rust_toolchain": "nightly-2025-02-01",
     # Other configuration
     "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -228,7 +228,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     "rustflags": "-C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT -Z link-native-libraries=no",
     "cargo_build_target": "wasm32-unknown-emscripten",
     "cargo_target_wasm32_unknown_emscripten_linker": "emcc",
-    "rust_toolchain": "nightly-2024-01-29",
+    "rust_toolchain": "nightly-2025-02-18",
     # Other configuration
     "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",


### PR DESCRIPTION
## Description

`orjson` version 3.10.13 in #101 requires `rustc` 1.82 or newer, but we currently use 1.77-nightly ([see logs](https://github.com/pyodide/pyodide-build/actions/runs/13406461423/job/37447193337?pr=101)).

I have also performed the same update in https://github.com/pyodide/pyodide/pull/5249/ in parallel, so if that passes, we should be safe to merge this. I can also open a new PR with the submodule updated to check if that PR doesn't pass.

**Update, 23/02/2025:** all builds passed in pyodide/pyodide#5439.