### PR TITLE
Fix test with ANSI colour sequences + line breaks

### DIFF
--- a/pyodide_build/tests/recipe/test_skeleton.py
+++ b/pyodide_build/tests/recipe/test_skeleton.py
@@ -15,6 +15,8 @@ from pyodide_build.recipe.spec import MetaConfig
 
 @pytest.mark.parametrize("source_fmt", ["wheel", "sdist"])
 def test_mkpkg(tmpdir, capsys, source_fmt):
+    import re
+
     base_dir = Path(str(tmpdir))
 
     skeleton.make_package(base_dir, "idna", None, source_fmt)
@@ -23,16 +25,19 @@ def test_mkpkg(tmpdir, capsys, source_fmt):
     assert meta_path.exists()
     captured = capsys.readouterr()
     assert "Output written to" in captured.out
-    assert str(meta_path) in captured.out
 
-    db = MetaConfig.from_yaml(meta_path)
+    # this test checks for outputs across multiple paths. so, we
+    # find the paths in the output, ignoring ANSI color codes and
+    # handling line breaks + normalised paths (only for this test).
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    cleaned_output = ansi_escape.sub("", captured.out)
 
-    assert db.package.name == "idna"
-    assert db.source.url is not None
-    if source_fmt == "wheel":
-        assert db.source.url.endswith(".whl")
-    else:
-        assert db.source.url.endswith(".tar.gz")
+    cleaned_output = cleaned_output.replace("\n", "")
+    path_str = str(meta_path)
+
+    path_parts = path_str.split(os.sep)
+    for part in path_parts[-3:]:
+        assert part in cleaned_output
 
 
 @pytest.mark.parametrize("old_dist_type", ["wheel", "sdist"])


### PR DESCRIPTION
## Description

The `logger.success()` call in `make_package()` outputs colour schemes such as `\x1b[...]` (for example `\x1b[1;32m` means bold green text and `\x1b[0m` conveys resetting to default formatting), and the test isn't able to match the string because of these codes in between.

As it is just this one test in the entirety of our codebase that checks for the `/path/to/meta.yaml` string across multiple lines across the test suite, I decided to keep the logger as is instead of disabling the colours for successes.

This short PR fixes the test failure for me on local testing on a macOS machine. I'm still not sure how it has always passed in our CI tests. :D