### PR TITLE
Add some short installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,43 @@ Tools for building Pyodide.
 See [http://github.com/pyodide/pyodide](http://github.com/pyodide/pyodide) for
 more information.
 
+## Quickstart
+
+### Usage
+
+#### Install it
+
+```bash
+pip install pyodide-build
+pyodide --help
+pyodide build --help
+```
+
+#### Install it globally
+
+```bash
+pipx install --include-deps pyodide-build
+pyodide --help
+pyodide build --help
+```
+
+or, alternatively
+
+```bash
+pipx install pyodide-cli
+pipx inject pyodide-cli pyodide-build
+pyodide --help
+pyodide build --help
+```
+
+### or run it
+
+- with `uv`/`uvx`
+
+```bash
+uvx --from pyodide-cli --with pyodide-build pyodide --help
+```
+
 ## License
 
 Pyodide uses the [Mozilla Public License Version

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ more information.
 
 ### Usage
 
+> [!TIP]
+> Currently, installing `pyodide-build` is preferred to running it.
+
 #### Install it
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ pyodide --help
 pyodide build --help
 ```
 
+> [!NOTE]
+> If installing `pyodide-build` and its dependencies in virtual environments, we recommend
+using ones that are managed by `venv` or `virtualenv` at the moment; see #58.
+
 ### or run it
 
 - with `uv`/`uvx`


### PR DESCRIPTION
## Description

This PR adds usage and installation instructions with `pip`, global installation and usage instructions with `pipx` and `uvx`, and some general recommendations.

This is mainly because I have these saved in my notes, which I have trouble finding at times – and the README could serve as a more permanent place for them until we have the documentation up and hosted.

Related to #54 and #58