### PR TITLE
Don't restore sys.platform in venv.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Pyodide venv `sys_platform` marker evaluation with pip >= 25.
+  [#108](https://github.com/pyodide/pyodide-build/pull/108)
+
 ## [0.29.3] - 2025/02/04
 
 ### Added

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -141,7 +141,6 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         f"""
         os_name, sys_platform, platform_system, multiarch, host_platform = {platform_data}
         os.name = os_name
-        orig_platform = sys.platform
         sys.platform = sys_platform
         sys.platlibdir = "lib"
         sys.implementation._multiarch = multiarch
@@ -153,7 +152,6 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         import sysconfig
         sysconfig._init_config_vars()
         del os.environ["_PYTHON_SYSCONFIGDATA_NAME"]
-        sys.platform = orig_platform
         """
     )
 


### PR DESCRIPTION
This is buggy when combined with pip 25. The commit when it was added mentions it was needed for `test_oot_build` to pass, but it seems to pass now.

Tested downstream:
https://github.com/pyodide/pyodide/pull/5455

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry