### PR TITLE
Respect `SOURCE_DATE_EPOCH` for better reproducibility of builds

### DIFF
--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -547,7 +547,7 @@ class RecipeBuilderPackage(RecipeBuilder):
     ) -> None:
         """Package a wheel
 
-        This unpacks the wheel, unvendors tests if necessary, runs and "build.post"
+        This unpacks the wheel, unvendors tests if necessary, and runs the "build.post"
         script, and then repacks the wheel.
 
         Parameters

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -627,7 +627,24 @@ class RecipeBuilderPackage(RecipeBuilder):
                     )
                     if nmoved:
                         with chdir(self.src_dist_dir):
-                            shutil.make_archive(f"{self.name}-tests", "tar", test_dir)
+                            filetime = _get_source_epoch()
+                            make_archive_kwargs = {
+                                "root_dir": "tests",
+                                "owner": "root",
+                                "group": "root",
+                            }
+
+                            if "SOURCE_DATE_EPOCH" in os.environ:
+
+                                def _set_time(tarinfo):
+                                    tarinfo.mtime = filetime
+                                    return tarinfo
+
+                                make_archive_kwargs["filter"] = _set_time
+
+                            shutil.make_archive(
+                                f"{self.name}-tests", "tar", **make_archive_kwargs
+                            )
             finally:
                 shutil.rmtree(test_dir, ignore_errors=True)
 

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Iterator
 from datetime import datetime
 from email.message import Message
@@ -44,6 +45,18 @@ from pyodide_build.recipe.bash_runner import (
     get_bash_runner,
 )
 from pyodide_build.recipe.spec import MetaConfig, _SourceSpec
+
+
+def _get_source_epoch() -> int:
+    """Get SOURCE_DATE_EPOCH from environment or fallback to current time.
+    Uses 315532800, i.e., 1980-01-01 00:00:00 UTC as minimum timestamp (as
+    this is the zipfile limit).
+    """
+    try:
+        source_epoch = int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+        return max(315532800, source_epoch)
+    except ValueError:
+        return int(time.time())
 
 
 def _make_whlfile(

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import time
 from collections.abc import Iterator
 from datetime import datetime
@@ -352,7 +353,7 @@ class RecipeBuilder:
                 _get_source_epoch() if "SOURCE_DATE_EPOCH" in os.environ else None
             )
 
-            def reproducible_filter(tarinfo):
+            def reproducible_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
                 """Filter that preserves permissions but normalizes ownership and optionally
                 timestamps. This is similar to the "data" filter but injects SOURCE_DATE_EPOCH."""
 

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -62,6 +62,9 @@ def _get_source_epoch() -> int:
 def _make_whlfile(
     *args: Any, owner: int | None = None, group: int | None = None, **kwargs: Any
 ) -> str:
+    filetime = _get_source_epoch()
+    # gtime() ensures UTC
+    kwargs["date_time"] = time.gmtime(filetime)[:6]
     return shutil._make_zipfile(*args, **kwargs)  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
## Description

This PR add supports for the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) environment variable when creating wheels from recipes to enable reproducible builds. The implementation follows the Python example from the https://reproducible-builds.org specification.

I can't say that this change makes builds completely reproducible, as we are responsible only for these utility functions and our usage of `pypa/build` as a build frontend – which doesn't guarantee reproducibility at all (see https://github.com/pypa/build/issues/385); that responsibility relies on the build backend, which we are agnostic to. It's a start towards more reproducibility, however.

I've modifies the `_make_whlfile` function to set the timestamps based on `SOURCE_DATE_EPOCH`. When `SOURCE_DATE_EPOCH` is provided, all files inside the wheel will have their timestamps set to the provided date. "January 1st 1980 00:00:00 UTC" (Unix timestamp `315532800`) is used as it is the minimum for ZIP file compatibility. A `reproducible_filter` has been added for tarfile creation that acts similarly to the "data" filter but with added `SOURCE_DATE_EPOCH` consideration.
