### PR TITLE
Fix typo in shared library builder

### DIFF
--- a/pyodide_build/recipe/graph_builder.py
+++ b/pyodide_build/recipe/graph_builder.py
@@ -199,7 +199,7 @@ class PythonPackage(BasePackage):
 
 @dataclasses.dataclass
 class SharedLibrary(BasePackage):
-    install_dir: str = "dylib"
+    install_dir: str = "dynlib"
 
     def __init__(self, pkgdir: Path, config: MetaConfig) -> None:
         super().__init__(pkgdir, config)


### PR DESCRIPTION
There was a typo that made the shared library installed in an unexpected directory. I guess we should validate this in pyodide-lock.

