### PR TITLE
Make `pyodide venv` more compatible with standard `virtualenv` args + add tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           name: coverage-no-integration
           path: .coverage
+          if-no-files-found: error
 
   check-integration-test-trigger:
     name: test-integration-test-trigger
@@ -134,6 +135,7 @@ jobs:
         with:
           name: coverage-integration
           path: .coverage
+          if-no-files-found: error
 
   coverage:
     name: Collect and upload coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
           name: coverage-no-integration
           path: .coverage
           if-no-files-found: error
+          include-hidden-files: true
 
   check-integration-test-trigger:
     name: test-integration-test-trigger
@@ -136,6 +137,7 @@ jobs:
           name: coverage-integration
           path: .coverage
           if-no-files-found: error
+          include-hidden-files: true
 
   coverage:
     name: Collect and upload coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install the package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
+          python -m pip install -e .
 
       - name: Install xbuildenv
         run: |
@@ -120,20 +120,14 @@ jobs:
         id: get-cores
         run: echo "CORES=$(nproc)" >> $GITHUB_OUTPUT
 
+      - name: Run tests marked with integration
+        run: pytest --junitxml=test-results/junit.xml --cov=pyodide-build pyodide_build -m "integration"
+
       - name: Run the recipe integration tests (${{ matrix.task }})
         env:
           PYODIDE_JOBS: ${{ steps.get-cores.outputs.CORES }}
-        run: |
-          cd integration_tests
-          make ${{ matrix.task }}
-
-      - name: Run tests marked with integration
-        run: |
-          pytest \
-            --junitxml=test-results/junit.xml \
-            --cov=pyodide-build \
-            pyodide_build \
-            -m "integration"
+        working-directory: integration_tests
+        run: make ${{ matrix.task }}
 
       - name: Upload coverage
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test]"
 
-          pytest -svra \
+          pytest -v \
             --junitxml=test-results/junit.xml \
             --cov=pyodide-build \
             pyodide_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,12 +127,13 @@ jobs:
         run: pytest --junitxml=test-results/junit.xml --cov=pyodide-build pyodide_build -m "integration"
 
       - name: Run the recipe integration tests (${{ matrix.task }})
+        if: matrix.task != 'test-integration-marker'
         env:
           PYODIDE_JOBS: ${{ steps.get-cores.outputs.CORES }}
         working-directory: integration_tests
         run: make ${{ matrix.task }}
 
-      - name: Upload coverage
+      - name: Upload coverage for tests marked with integration
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: matrix.task == 'test-integration-marker'
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [test-recipe, test-src]
+        task: [test-recipe, test-src, test-integration-marker]
     if: needs.check-integration-test-trigger.outputs.run-integration-test
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -123,6 +123,7 @@ jobs:
         run: echo "CORES=$(nproc)" >> $GITHUB_OUTPUT
 
       - name: Run tests marked with integration
+        if: matrix.task == 'test-integration-marker'
         run: pytest --junitxml=test-results/junit.xml --cov=pyodide-build pyodide_build -m "integration"
 
       - name: Run the recipe integration tests (${{ matrix.task }})
@@ -133,8 +134,9 @@ jobs:
 
       - name: Upload coverage
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        if: matrix.task == 'test-integration-marker'
         with:
-          name: coverage-integration
+          name: coverage-from-integration
           path: .coverage
           if-no-files-found: error
           include-hidden-files: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,7 @@ env:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # include tags so that hatch-vcs can infer the version
+          fetch-depth: 0
+          # switch to fetch-tags: true when the following is fixed
+          # see https://github.com/actions/checkout/issues/2041
+          # fetch-tags: true
 
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test
         run: |
           python -m pip install --upgrade pip
-          pip install ".[test]"
+          pip install -e ".[test]"
 
           pytest -v \
             --junitxml=test-results/junit.xml \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test]"
 
-          pytest -v \
+          pytest -svra \
             --junitxml=test-results/junit.xml \
             --cov=pyodide-build \
             pyodide_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,11 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install the package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
+          python -m pip install -e ."[test]"
 
       - name: Install xbuildenv
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,19 +33,23 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Test
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[test]"
 
-          pytest -v \
+      - name: Run tests
+        run: |
+          pytest \
             --junitxml=test-results/junit.xml \
             --cov=pyodide-build \
             pyodide_build
 
-      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+      - name: Upload coverage
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          fail_ci_if_error: false
+          name: coverage-no-integration
+          path: .coverage
 
   check-integration-test-trigger:
     name: test-integration-test-trigger
@@ -116,9 +120,37 @@ jobs:
         id: get-cores
         run: echo "CORES=$(nproc)" >> $GITHUB_OUTPUT
 
-      - name: Run the integration tests (${{ matrix.task }})
+      - name: Run the recipe integration tests (${{ matrix.task }})
         env:
           PYODIDE_JOBS: ${{ steps.get-cores.outputs.CORES }}
         run: |
           cd integration_tests
           make ${{ matrix.task }}
+
+      - name: Run tests marked with integration
+        run: |
+          pytest \
+            --junitxml=test-results/junit.xml \
+            --cov=pyodide-build \
+            pyodide_build \
+            -m "integration"
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: coverage-integration
+          path: .coverage
+
+  coverage:
+    name: Collect and upload coverage
+    runs-on: ubuntu-latest
+    needs: [test, integration-test]
+    steps:
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          merge-multiple: false
+
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        with:
+          fail_ci_if_error: false
+          files: coverage-no-integration/.coverage,coverage-integration/.coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # include tags so that hatch-vcs can infer the version
+          fetch-depth: 0
+          # switch to fetch-tags: true when the following is fixed
+          # see https://github.com/actions/checkout/issues/2041
+          # fetch-tags: true
 
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ venv/
 # integration tests
 integration_tests/**/build.log
 integration_tests/**/.libs
+.coverage
+/test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new recipe key `requirement.constraint` to set the package-level constraints.
   [#97](https://github.com/pyodide/pyodide-build/pull/97)
 
+- The `pyodide venv` command now supports more `virtualenv` command-line flags
+  to customise the virtual environment creation behaviour.
+  [#117](https://github.com/pyodide/pyodide-build/pull/117)
+
 ## [0.29.2] - 2024/11/29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#97](https://github.com/pyodide/pyodide-build/pull/97)
 
 - The `pyodide venv` command now supports more `virtualenv` command-line flags
-  to customise the virtual environment creation behaviour.
+  to customise the virtual environment creation behaviour (experimental)
   [#117](https://github.com/pyodide/pyodide-build/pull/117)
 
 ## [0.29.2] - 2024/11/29

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -2,10 +2,22 @@ This directory contains assets to run integration tests for pyodide-build.
 
 Tests in this directory are not run by default in CI. To run these tests, add `[integration]` in the commit message.
 
-## Running integration tests locally
+## Running the integration tests locally
 
-To run the integration tests locally, use `make` command in this directory.
+There are two types of integration tests:
+
+- Recipe tests (in this directory)
+- Tests marked with integration marker in the root directory
+
+To run the recipe integration tests locally, use the `make` command in this directory.
 
 ```bash
 make test-recipe
+```
+
+This runs a subset of the tests. The other tests are run from the root directory
+via the following command:
+
+```bash
+pytest -m integration
 ```

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -70,7 +70,7 @@ def main(
     #     False, "--symlink-app-data/--no-symlink-app-data", help="Symlink the python packages from the app-data folder"
     # ),
 ) -> None:
-    """Create a Pyodide virtual environment"""
+    """Create a Pyodide virtual environment. Supports a subset of the arguments that `virtualenv` supports."""
     init_environment()
 
     venv_args = []

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -47,10 +47,10 @@ def main(
         "--extra-search-dir",
         help="A path containing wheels to extend the internal wheel list",
     ),
-    pip: str | None = typer.Option(
-        None,
+    pip: str = typer.Option(
+        "bundle",
         "--pip",
-        help="Version of pip to install as seed: embed, bundle, none or exact version",
+        help="Version of pip to install as seed: embed, bundle, or exact version.",
     ),
     setuptools: str | None = typer.Option(
         None,
@@ -75,7 +75,7 @@ def main(
     #     False, "--symlink-app-data/--no-symlink-app-data", help="Symlink the python packages from the app-data folder"
     # ),
 ) -> None:
-    """Create a Pyodide virtual environment. Supports a subset of the arguments that `virtualenv` supports."""
+    """Create a Pyodide virtual environment. Supports a subset of the arguments that `virtualenv` supports, with some minor differences for Pyodide compatibility."""
     init_environment()
 
     venv_args = []
@@ -96,7 +96,7 @@ def main(
     if extra_search_dir:
         for _ in extra_search_dir:
             venv_args.extend(["--extra-search-dir", _])
-    if pip is not None:
+    if pip:
         venv_args.extend(["--pip", pip])
     if symlinks:
         venv_args.append("--symlinks")

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -23,6 +23,11 @@ def main(
         "--no-vcs-ignore",
         help="Don't create VCS ignore directive in the destination directory",
     ),
+    symlinks: bool = typer.Option(
+        True,
+        "--symlinks",
+        help="Try to use symlinks rather than copies, when symlinks are not the default for the platform",
+    ),
     # copies: bool = typer.Option(
     #     False, "--copies", "--always-copy", help="Use copies rather than symlinks, even when symlinks are the default"
     # ),
@@ -93,6 +98,8 @@ def main(
             venv_args.extend(["--extra-search-dir", _])
     if pip is not None:
         venv_args.extend(["--pip", pip])
+    if symlinks:
+        venv_args.append("--symlinks")
     if setuptools is not None:
         venv_args.extend(["--setuptools", setuptools])
     if wheel is not None:

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -75,7 +75,11 @@ def main(
     #     False, "--symlink-app-data/--no-symlink-app-data", help="Symlink the python packages from the app-data folder"
     # ),
 ) -> None:
-    """Create a Pyodide virtual environment. Supports a subset of the arguments that `virtualenv` supports, with some minor differences for Pyodide compatibility."""
+    """
+    Create a Pyodide virtual environment.
+    Additionally, this interface supports a subset of the arguments that `virtualenv` supports, with some minor differences for Pyodide compatibility.
+    Please note that passing extra options is experimental and may be subject to change.
+    """
     init_environment()
 
     venv_args = []

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -57,15 +57,10 @@ def main(
         "--setuptools",
         help="Version of setuptools to install as seed: embed, bundle, none or exact version",
     ),
-    wheel: str | None = typer.Option(
-        None,
-        "--wheel",
-        help="Version of wheel to install as seed: embed, bundle, none or exact version",
-    ),
     no_setuptools: bool = typer.Option(
         False, "--no-setuptools", help="Do not install setuptools"
     ),
-    no_wheel: bool = typer.Option(False, "--no-wheel", help="Do not install wheel"),
+    no_wheel: bool = typer.Option(True, "--no-wheel", help="Do not install wheel"),
     no_periodic_update: bool = typer.Option(
         False,
         "--no-periodic-update",
@@ -106,8 +101,6 @@ def main(
         venv_args.append("--symlinks")
     if setuptools is not None:
         venv_args.extend(["--setuptools", setuptools])
-    if wheel is not None:
-        venv_args.extend(["--wheel", wheel])
     if no_wheel:
         venv_args.append("--no-wheel")
     if no_setuptools:

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -6,12 +6,103 @@ from pyodide_build.build_env import init_environment
 from pyodide_build.out_of_tree import venv
 
 
+# TODO: disabled options that can be later supported have been commented out, fix them
+# --copies/--always-copy and symlink_app_data
 def main(
     dest: Path = typer.Argument(
         ...,
         help="directory to create virtualenv at",
     ),
+    clear: bool = typer.Option(
+        False,
+        "--clear/--no-clear",
+        help="Remove the destination directory if it exists",
+    ),
+    no_vcs_ignore: bool = typer.Option(
+        False,
+        "--no-vcs-ignore",
+        help="Don't create VCS ignore directive in the destination directory",
+    ),
+    # copies: bool = typer.Option(
+    #     False, "--copies", "--always-copy", help="Use copies rather than symlinks, even when symlinks are the default"
+    # ),
+    no_download: bool = typer.Option(
+        False,
+        "--no-download",
+        "--never-download",
+        help="Disable download of the latest pip/setuptools/wheel from PyPI",
+    ),
+    download: bool = typer.Option(
+        False,
+        "--download/--no-download",
+        help="Enable download of the latest pip/setuptools/wheel from PyPI",
+    ),
+    extra_search_dir: list[str] = typer.Option(
+        None,
+        "--extra-search-dir",
+        help="A path containing wheels to extend the internal wheel list",
+    ),
+    pip: str | None = typer.Option(
+        None,
+        "--pip",
+        help="Version of pip to install as seed: embed, bundle, none or exact version",
+    ),
+    setuptools: str | None = typer.Option(
+        None,
+        "--setuptools",
+        help="Version of setuptools to install as seed: embed, bundle, none or exact version",
+    ),
+    wheel: str | None = typer.Option(
+        None,
+        "--wheel",
+        help="Version of wheel to install as seed: embed, bundle, none or exact version",
+    ),
+    no_setuptools: bool = typer.Option(
+        False, "--no-setuptools", help="Do not install setuptools"
+    ),
+    no_wheel: bool = typer.Option(False, "--no-wheel", help="Do not install wheel"),
+    no_periodic_update: bool = typer.Option(
+        False,
+        "--no-periodic-update",
+        help="Disable the periodic update of the embedded wheels",
+    ),
+    # symlink_app_data: bool = typer.Option(
+    #     False, "--symlink-app-data/--no-symlink-app-data", help="Symlink the python packages from the app-data folder"
+    # ),
 ) -> None:
     """Create a Pyodide virtual environment"""
     init_environment()
-    venv.create_pyodide_venv(dest)
+
+    venv_args = []
+
+    # if copies:
+    #     venv_args.append("--copies")
+    # if symlink_app_data:
+    #     venv_args.append("--symlink-app-data")
+
+    if clear:
+        venv_args.append("--clear")
+    if no_vcs_ignore:
+        venv_args.append("--no-vcs-ignore")
+    if no_download:
+        venv_args.append("--no-download")
+    if download:
+        venv_args.append("--download")
+    if extra_search_dir:
+        for _ in extra_search_dir:
+            venv_args.extend(["--extra-search-dir", _])
+    if pip is not None:
+        venv_args.extend(["--pip", pip])
+    if setuptools is not None:
+        venv_args.extend(["--setuptools", setuptools])
+    if wheel is not None:
+        venv_args.extend(["--wheel", wheel])
+    if no_wheel:
+        venv_args.append("--no-wheel")
+    if no_setuptools:
+        venv_args.append("--no-setuptools")
+
+    if no_periodic_update:
+        venv_args.append("--no-periodic-update")
+
+    venv.create_pyodide_venv(dest, venv_args)

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -23,11 +23,6 @@ def main(
         "--no-vcs-ignore",
         help="Don't create VCS ignore directive in the destination directory",
     ),
-    symlinks: bool = typer.Option(
-        True,
-        "--symlinks",
-        help="Try to use symlinks rather than copies, when symlinks are not the default for the platform",
-    ),
     # copies: bool = typer.Option(
     #     False, "--copies", "--always-copy", help="Use copies rather than symlinks, even when symlinks are the default"
     # ),
@@ -97,8 +92,6 @@ def main(
             venv_args.extend(["--extra-search-dir", search_dir])
     if pip:
         venv_args.extend(["--pip", pip])
-    if symlinks:
-        venv_args.append("--symlinks")
     if setuptools is not None:
         venv_args.extend(["--setuptools", setuptools])
     if no_wheel:

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -98,8 +98,8 @@ def main(
     if download:
         venv_args.append("--download")
     if extra_search_dir:
-        for _ in extra_search_dir:
-            venv_args.extend(["--extra-search-dir", _])
+        for search_dir in extra_search_dir:
+            venv_args.extend(["--extra-search-dir", search_dir])
     if pip:
         venv_args.extend(["--pip", pip])
     if symlinks:

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -185,6 +185,13 @@ def create_pip_script(venv_bin):
     # Python in the shebang. Use whichever Python was used to invoke
     # pyodide venv.
     host_python_path = venv_bin / f"python{get_pyversion()}-host"
+    pip_path = venv_bin / "pip"
+    pyversion = get_pyversion()
+    other_pips = [
+        venv_bin / "pip3",
+        venv_bin / f"pip{pyversion}",
+        venv_bin / f"pip-{pyversion}",
+    ]
 
     # To support the "--clear" and "--no-clear" args, we need to remove
     # the existing symlinks before creating new ones.
@@ -192,15 +199,16 @@ def create_pip_script(venv_bin):
         host_python_path.unlink()
     if (venv_bin / "python-host").exists():
         (venv_bin / "python-host").unlink()
+    if pip_path.exists():
+        pip_path.unlink()
+    for pip in other_pips:
+        if pip.exists():
+            pip.unlink()
+            pip.symlink_to(pip_path)
 
     host_python_path.symlink_to(sys.executable)
     # in case someone needs a Python-version-agnostic way to refer to python-host
     (venv_bin / "python-host").symlink_to(sys.executable)
-
-    pip_path = venv_bin / "pip"
-
-    if pip_path.exists():
-        pip_path.unlink()
 
     pip_path.write_text(
         # Other than the shebang and the monkey patch, this is exactly what
@@ -219,18 +227,6 @@ def create_pip_script(venv_bin):
         )
     )
     pip_path.chmod(0o777)
-
-    pyversion = get_pyversion()
-    other_pips = [
-        venv_bin / "pip3",
-        venv_bin / f"pip{pyversion}",
-        venv_bin / f"pip-{pyversion}",
-    ]
-
-    for pip in other_pips:
-        if pip.exists():
-            pip.unlink()
-        pip.symlink_to(pip_path)
 
 
 def create_pyodide_script(venv_bin: Path) -> None:

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -17,7 +17,6 @@ SUPPORTED_VIRTUALENV_OPTIONS = [
     "--clear",
     "--no-clear",
     "--no-vcs-ignore",
-    "--symlinks",
     # "--copies", "--always-copy", FIXME: node fails to invoke Pyodide
     # "--symlink-app-data", FIXME: node fails to invoke Pyodide
     "--no-download",

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -27,7 +27,6 @@ SUPPORTED_VIRTUALENV_OPTIONS = [
     "--pip",
     "--setuptools",
     "--no-setuptools",
-    "--wheel",
     "--no-wheel",
     "--no-periodic-update",
 ]

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -9,6 +9,29 @@ from pyodide_build.build_env import get_build_flag, get_pyodide_root, in_xbuilde
 from pyodide_build.common import exit_with_stdio
 from pyodide_build.logger import logger
 
+# A subset of supported virtualenv options that make sense in Pyodide's context.
+# Our aim will not be to support all of them, and some of them will never be in
+# the list, for example, --no-pip and so on. We provide these on a best-effort
+# basis as they should work and are easy to test.
+SUPPORTED_VIRTUALENV_OPTIONS = [
+    "--clear",
+    "--no-clear",
+    "--no-vcs-ignore",
+    "--symlinks",
+    # "--copies", "--always-copy", FIXME: node fails to invoke Pyodide
+    # "--symlink-app-data", FIXME: node fails to invoke Pyodide
+    "--no-download",
+    "--never-download",
+    "--download",
+    "--extra-search-dir",
+    "--pip",
+    "--setuptools",
+    "--no-setuptools",
+    "--wheel",
+    "--no-wheel",
+    "--no-periodic-update",
+]
+
 
 def check_result(result: subprocess.CompletedProcess[str], msg: str) -> None:
     """Abort if the process returns a nonzero error code"""

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -225,6 +225,8 @@ def test_pip_install(base_test_dir, packages):
                 text=True,
                 check=False,
             )
+            print("AGRIYA DEBUG POINT 0")
+            print(result.stdout)
             assert (
                 result.returncode == 0
             ), f"Failed to install {package}: {result.stderr}"
@@ -243,6 +245,14 @@ def test_pip_install(base_test_dir, packages):
         import_name = package.replace("-", "_")
 
         with virtual_environment_activator(venv_path):
+            result1 = subprocess.run(
+                [str(python_path), "-c", "import sys; print(sys.platform)"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            print("AGRIYA DEBUG POINT 1")
+            print(result1.stdout)
             result = subprocess.run(
                 [
                     str(python_path),
@@ -253,6 +263,9 @@ def test_pip_install(base_test_dir, packages):
                 text=True,
                 check=False,
             )
+            print("AGRIYA DEBUG POINT 2")
+            print(result.stdout)
+            print(result.stderr)
             assert (
                 result.returncode == 0
             ), f"Failed to import {package}: {result.stderr}"

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -23,7 +23,9 @@ def base_test_dir(tmp_path_factory):
     xbuildenv_test_name = ".pyodide-xbuildenv-for-testing"
 
     manager = CrossBuildEnvManager(xbuildenv_test_name)
-    manager.install()
+    manager.install(
+        url="https://github.com/pyodide/pyodide/releases/download/0.27.3/xbuildenv-0.27.3.tar.bz2"
+    )
 
     os.chdir(cwd)
 

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -52,16 +52,9 @@ def virtual_environment_activator(venv_path):
     activate_venv_script = venv_path / "bin" / "activate_this.py"
     runpy.run_path(str(activate_venv_script))
 
-    print("AGRIYA DEBUG POINT 3")
-    print(f"Activated virtual environment at {venv_path}")
-    print(f"PATH: {os.environ['PATH']}")
-
     yield
 
-    print("AGRIYA DEBUG POINT 4")
     os.environ["PATH"] = original_path
-    print(f"Deactivated virtual environment at {venv_path}")
-    print(f"PATH: {os.environ['PATH']}")
 
 
 @pytest.mark.parametrize(

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -198,9 +198,11 @@ def test_pip_install(base_test_dir, packages):
     pip_path = venv_path / "bin" / "pip"
     assert pip_path.exists(), "pip wasn't found in the virtual environment"
 
+    python_path = venv_path / "bin" / "python"
+
     for package in packages:
         result = subprocess.run(
-            [str(pip_path), "install", package],
+            [str(python_path), "-m", "pip", "install", package, "-v"],
             capture_output=True,
             text=True,
             check=False,

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -139,6 +139,7 @@ def test_supported_virtualenv_options():
     assert set(supported_options) == set(expected_options)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "options,check_function",
     [
@@ -167,6 +168,7 @@ def test_venv_creation(base_test_dir, options, check_function):
     assert check_function(venv_path)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "package,version",
     [
@@ -183,6 +185,7 @@ def test_installation_of_seed_package_versions(base_test_dir, package, version):
     assert len(dist_info_dirs) > 0, f"{package} {version} not found in the venv"
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "packages",
     [

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -198,11 +198,6 @@ def test_pip_install(base_test_dir, packages):
     venv_pip_path = venv_path / "bin" / "pip"
     assert venv_pip_path.exists(), "pip wasn't found in the virtual environment"
 
-    # Find the site-packages directory for setting PYTHONPATH later
-    site_packages_paths = list(venv_path.glob("lib/python*/site-packages"))
-    assert len(site_packages_paths) > 0, "site-packages directory not found"
-    site_packages_path = site_packages_paths[0]
-
     for package in packages:
         result = subprocess.run(
             [
@@ -228,10 +223,6 @@ def test_pip_install(base_test_dir, packages):
     # but it's a good sanity check as this is an integration test, and
     # the import isn't the slow part here.
     python_path = venv_path / "bin" / "python"
-
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(site_packages_path)
-
     for package in packages:
         import_name = package.replace("-", "_")
         result = subprocess.run(
@@ -243,7 +234,6 @@ def test_pip_install(base_test_dir, packages):
             capture_output=True,
             text=True,
             check=False,
-            env=env,
         )
         assert result.returncode == 0, f"Failed to import {package}: {result.stderr}"
         assert result.stdout.strip(), f"No version found for {package}"

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -1,0 +1,225 @@
+import shutil
+import subprocess
+
+import pytest
+
+from pyodide_build.out_of_tree import venv
+
+
+@pytest.fixture
+def temp_venv_path(tmp_path):
+    """Create a temporary directory for the venv and clean up afterward."""
+    venv_path = tmp_path / "test_venv"
+    yield venv_path
+    if venv_path.exists():
+        shutil.rmtree(venv_path)
+
+
+@pytest.mark.parametrize(
+    "options,expected_calls",
+    [
+        ([], []),
+        (["--clear"], ["--clear"]),
+        (["--no-vcs-ignore"], ["--no-vcs-ignore"]),
+        (["--pip", "23.0.1"], ["--pip", "23.0.1"]),
+        (["--no-setuptools"], ["--no-setuptools"]),
+        (["--no-wheel"], ["--no-wheel"]),
+        (["--no-periodic-update"], ["--no-periodic-update"]),
+        # TODO: enable when they are supported
+        # (["--symlink-app-data"], ["--symlink-app-data"]),
+        # (["--copies"], ["--copies"]),
+    ],
+)
+def test_venv_cli_args(monkeypatch, options, expected_calls, temp_venv_path):
+    """Test that CLI options are correctly passed to virtualenv."""
+    captured_args = None
+
+    def mock_session_via_cli(args):
+        nonlocal captured_args
+        captured_args = args
+
+        class MockSession:
+            def __init__(self):
+                self.creator = type("MockCreator", (), {"dest": str(temp_venv_path)})
+
+            def run(self):
+                # create the directory to avoid cleanup issues
+                temp_venv_path.mkdir(exist_ok=True)
+
+        return MockSession()
+
+    temp_venv_path.mkdir(exist_ok=True)
+
+    # Mock most of the functions called by create_pyodide_venv
+    # as we just need to check the arguments passed to it
+    monkeypatch.setattr("virtualenv.session_via_cli", mock_session_via_cli)
+    monkeypatch.setattr(
+        "pyodide_build.out_of_tree.venv.check_host_python_version", lambda session: None
+    )
+    monkeypatch.setattr(
+        "pyodide_build.out_of_tree.venv.create_pip_conf", lambda venv_root: None
+    )
+    monkeypatch.setattr(
+        "pyodide_build.out_of_tree.venv.create_pip_script", lambda venv_bin: None
+    )
+    monkeypatch.setattr(
+        "pyodide_build.out_of_tree.venv.create_pyodide_script", lambda venv_bin: None
+    )
+    monkeypatch.setattr(
+        "pyodide_build.out_of_tree.venv.install_stdlib", lambda venv_bin: None
+    )
+    monkeypatch.setattr(
+        "pyodide_build.out_of_tree.venv.pyodide_dist_dir",
+        lambda: temp_venv_path / "dist",
+    )
+
+    # necessary directories for valid venv
+    (temp_venv_path / "dist").mkdir(exist_ok=True)
+    (temp_venv_path / "bin").mkdir(exist_ok=True)
+
+    venv.create_pyodide_venv(temp_venv_path, options)
+
+    for expected_arg in expected_calls:
+        assert (
+            expected_arg in captured_args
+        ), f"Expected {expected_arg} in call args: {captured_args}"
+
+
+def test_supported_virtualenv_options():
+    """Test that all (currently) supported options are in SUPPORTED_VIRTUALENV_OPTIONS"""
+    supported_options = venv.SUPPORTED_VIRTUALENV_OPTIONS
+    expected_options = [
+        "--clear",
+        "--no-clear",
+        "--no-vcs-ignore",
+        "--symlinks",
+        # "--copies",
+        # "--always-copy",
+        # "--symlink-app-data",
+        "--no-download",
+        "--never-download",
+        "--download",
+        "--extra-search-dir",
+        "--pip",
+        "--setuptools",
+        "--wheel",
+        "--no-setuptools",
+        "--no-wheel",
+        "--no-periodic-update",
+    ]
+
+    assert set(supported_options) == set(expected_options)
+
+
+@pytest.mark.skipif(True, reason="Requiring full Pyodide environment")
+@pytest.mark.parametrize(
+    "options,check_function",
+    [
+        (
+            [],
+            lambda path: (path / "bin" / "python").exists()
+            and (path / "bin" / "pip").exists(),
+        ),
+        (["--clear"], lambda path: (path / "bin" / "python").exists()),
+        (["--no-vcs-ignore"], lambda path: (path / "bin" / "python").exists()),
+        (
+            ["--no-setuptools"],
+            lambda path: not list(path.glob("**/setuptools-*.dist-info")),
+        ),
+        (["--no-wheel"], lambda path: not list(path.glob("**/wheel-*.dist-info"))),
+    ],
+    ids=["default", "clear", "no-vcs-ignore", "no-setuptools", "no-wheel"],
+)
+def test_integration_venv_creation(temp_venv_path, options, check_function):
+    try:
+        venv.create_pyodide_venv(temp_venv_path, options)
+        assert temp_venv_path.exists()
+        assert (temp_venv_path / "bin" / "python").exists()
+        assert (temp_venv_path / "bin" / "pyodide").exists()
+        assert (temp_venv_path / "pip.conf").exists()
+        assert check_function(temp_venv_path)
+
+    except Exception as e:
+        pytest.fail(f"Failed to create virtual environment: {e}")
+
+
+@pytest.mark.skipif(True, reason="Integration test requiring full Pyodide environment")
+@pytest.mark.parametrize(
+    "package,version",
+    [
+        ("pip", "23.0.1"),
+        ("setuptools", "67.6.0"),
+        ("wheel", "0.40.0"),
+    ],
+)
+def test_integration_package_versions(temp_venv_path, package, version):
+    """Test installing specific package versions."""
+    try:
+        venv.create_pyodide_venv(temp_venv_path, [f"--{package}", version])
+
+        # Check that the package is installed with the specified version
+        dist_info_dirs = list(temp_venv_path.glob(f"**/{package}-{version}*.dist-info"))
+        assert len(dist_info_dirs) > 0, f"{package} {version} not found in the venv"
+
+    except Exception as e:
+        pytest.fail(
+            f"Failed to create virtual environment with {package}={version}: {e}"
+        )
+
+
+@pytest.mark.skipif(True, reason="Integration test requiring full Pyodide environment")
+@pytest.mark.parametrize(
+    "packages",
+    [
+        ["six"],  # simple
+        ["numpy"],  # compiled
+        ["six", "numpy"],  # mixed
+    ],
+)
+def test_pip_install(temp_venv_path, packages):
+    """Test that our monkeypatched pip can install packages into the venv"""
+    try:
+        venv.create_pyodide_venv(temp_venv_path, [])
+        pip_path = temp_venv_path / "bin" / "pip"
+        assert pip_path.exists(), "pip wasn't found in the virtual environment"
+
+        for package in packages:
+            result = subprocess.run(
+                [str(pip_path), "install", package],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert (
+                result.returncode == 0
+            ), f"Failed to install {package}: {result.stderr}"
+
+            # Verify package is installed by checking dist-info directory
+            dist_info_dirs = list(
+                temp_venv_path.glob(f"**/{package.replace("-", "_")}-*.dist-info")
+            )
+            assert len(dist_info_dirs) > 0, f"{package} not found in the venv"
+
+        # Verify that the installed packages can be imported. It's overkill
+        # but it's a good sanity check as this is an integration test, and
+        # the import isn't the slow part here.
+        python_path = temp_venv_path / "bin" / "python"
+        for package in packages:
+            import_name = package.replace("-", "_")
+            result = subprocess.run(
+                [
+                    str(python_path),
+                    "-c",
+                    f"import {import_name}; print({import_name}.__version__)",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert (
+                result.returncode == 0
+            ), f"Failed to import {package}: {result.stderr}"
+            assert result.stdout.strip(), f"No version found for {package}"
+
+    except Exception as e:
+        pytest.fail(f"Failed to test pip functionality: {e}")

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -130,7 +130,6 @@ def test_supported_virtualenv_options():
         "--extra-search-dir",
         "--pip",
         "--setuptools",
-        "--wheel",
         "--no-setuptools",
         "--no-wheel",
         "--no-periodic-update",

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -237,12 +237,14 @@ def test_pip_install(base_test_dir, packages):
             )
             assert len(dist_info_dirs) > 0, f"{package} wasn't found in the venv"
 
-            # Verify that the installed packages can be imported. It's overkill
-            # but it's a good sanity check as this is an integration test, and
-            # the import isn't the slow part here.
+    # Verify that the installed packages can be imported. It's overkill
+    # but it's a good sanity check as this is an integration test, and
+    # the import isn't the slow part here.
 
-            import_name = package.replace("-", "_")
+    for package in packages:
+        import_name = package.replace("-", "_")
 
+        with virtual_environment_activator(venv_path):
             result1 = subprocess.run(
                 [str(python_path), "-c", "import sys; print(sys.platform)"],
                 capture_output=True,

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -237,14 +237,12 @@ def test_pip_install(base_test_dir, packages):
             )
             assert len(dist_info_dirs) > 0, f"{package} wasn't found in the venv"
 
-    # Verify that the installed packages can be imported. It's overkill
-    # but it's a good sanity check as this is an integration test, and
-    # the import isn't the slow part here.
+            # Verify that the installed packages can be imported. It's overkill
+            # but it's a good sanity check as this is an integration test, and
+            # the import isn't the slow part here.
 
-    for package in packages:
-        import_name = package.replace("-", "_")
+            import_name = package.replace("-", "_")
 
-        with virtual_environment_activator(venv_path):
             result1 = subprocess.run(
                 [str(python_path), "-c", "import sys; print(sys.platform)"],
                 capture_output=True,

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -225,8 +225,6 @@ def test_pip_install(base_test_dir, packages):
                 text=True,
                 check=False,
             )
-            print("AGRIYA DEBUG POINT 0")
-            print(result.stdout)
             assert (
                 result.returncode == 0
             ), f"Failed to install {package}: {result.stderr}"
@@ -245,14 +243,6 @@ def test_pip_install(base_test_dir, packages):
         import_name = package.replace("-", "_")
 
         with virtual_environment_activator(venv_path):
-            result1 = subprocess.run(
-                [str(python_path), "-c", "import sys; print(sys.platform)"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            print("AGRIYA DEBUG POINT 1")
-            print(result1.stdout)
             result = subprocess.run(
                 [
                     str(python_path),
@@ -263,9 +253,6 @@ def test_pip_install(base_test_dir, packages):
                 text=True,
                 check=False,
             )
-            print("AGRIYA DEBUG POINT 2")
-            print(result.stdout)
-            print(result.stderr)
             assert (
                 result.returncode == 0
             ), f"Failed to import {package}: {result.stderr}"

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -120,7 +120,6 @@ def test_supported_virtualenv_options():
         "--clear",
         "--no-clear",
         "--no-vcs-ignore",
-        "--symlinks",
         # "--copies",
         # "--always-copy",
         # "--symlink-app-data",

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -224,6 +224,13 @@ def test_pip_install(base_test_dir, packages):
 
     python_path = venv_path / "bin" / "python"
 
+    # Find the site-packages directory
+    site_packages_paths = list(venv_path.glob("lib/python*/site-packages"))
+    assert len(site_packages_paths) > 0, "site-packages directory not found"
+    site_packages_path = site_packages_paths[0]
+
+    print(f"Site packages path: {site_packages_path}")
+
     with virtual_environment_activator(venv_path):
         for package in packages:
             result = subprocess.run(
@@ -244,20 +251,21 @@ def test_pip_install(base_test_dir, packages):
             )
             assert len(dist_info_dirs) > 0, f"{package} wasn't found in the venv"
 
-            # Verify that the installed packages can be imported. It's overkill
-            # but it's a good sanity check as this is an integration test, and
-            # the import isn't the slow part here.
-
-            import_name = package.replace("-", "_")
+            # Set PYTHONPATH to include site-packages for the subprocess
+            env = os.environ.copy()
+            env["PYTHONPATH"] = str(site_packages_path)
 
             result1 = subprocess.run(
                 [str(python_path), "-c", "import sys; print(sys.platform)"],
                 capture_output=True,
                 text=True,
                 check=False,
+                env=env,  # Add the environment with PYTHONPATH
             )
             print("AGRIYA DEBUG POINT 1")
             print(result1.stdout)
+
+            import_name = package.replace("-", "_")
             result = subprocess.run(
                 [
                     str(python_path),
@@ -267,6 +275,7 @@ def test_pip_install(base_test_dir, packages):
                 capture_output=True,
                 text=True,
                 check=False,
+                env=env,  # Add the environment with PYTHONPATH
             )
             print("AGRIYA DEBUG POINT 2")
             print(result.stdout)

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -218,22 +218,3 @@ def test_pip_install(base_test_dir, packages):
             venv_path.glob(f"**/{package.replace('-', '_')}-*.dist-info")
         )
         assert len(dist_info_dirs) > 0, f"{package} not found in the venv"
-
-    # Verify that the installed packages can be imported. It's overkill
-    # but it's a good sanity check as this is an integration test, and
-    # the import isn't the slow part here.
-    python_path = venv_path / "bin" / "python"
-    for package in packages:
-        import_name = package.replace("-", "_")
-        result = subprocess.run(
-            [
-                str(python_path),
-                "-c",
-                f"import {import_name}; print({import_name}.__version__)",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode == 0, f"Failed to import {package}: {result.stderr}"
-        assert result.stdout.strip(), f"No version found for {package}"

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -195,14 +195,18 @@ def test_pip_install(base_test_dir, packages):
     venv_path = base_test_dir / "test_venv"
 
     venv.create_pyodide_venv(venv_path, [])
-    pip_path = venv_path / "bin" / "pip"
-    assert pip_path.exists(), "pip wasn't found in the virtual environment"
-
-    python_path = venv_path / "bin" / "python"
+    venv_pip_path = venv_path / "bin" / "pip"
+    assert venv_pip_path.exists(), "pip wasn't found in the virtual environment"
 
     for package in packages:
         result = subprocess.run(
-            [str(python_path), "-m", "pip", "install", package, "-v"],
+            [
+                str(venv_pip_path),
+                "install",
+                package,
+                "-v",
+                "--disable-pip-version-check",
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -224,13 +224,6 @@ def test_pip_install(base_test_dir, packages):
 
     python_path = venv_path / "bin" / "python"
 
-    # Find the site-packages directory
-    site_packages_paths = list(venv_path.glob("lib/python*/site-packages"))
-    assert len(site_packages_paths) > 0, "site-packages directory not found"
-    site_packages_path = site_packages_paths[0]
-
-    print(f"Site packages path: {site_packages_path}")
-
     with virtual_environment_activator(venv_path):
         for package in packages:
             result = subprocess.run(
@@ -251,21 +244,20 @@ def test_pip_install(base_test_dir, packages):
             )
             assert len(dist_info_dirs) > 0, f"{package} wasn't found in the venv"
 
-            # Set PYTHONPATH to include site-packages for the subprocess
-            env = os.environ.copy()
-            env["PYTHONPATH"] = str(site_packages_path)
+            # Verify that the installed packages can be imported. It's overkill
+            # but it's a good sanity check as this is an integration test, and
+            # the import isn't the slow part here.
+
+            import_name = package.replace("-", "_")
 
             result1 = subprocess.run(
                 [str(python_path), "-c", "import sys; print(sys.platform)"],
                 capture_output=True,
                 text=True,
                 check=False,
-                env=env,  # Add the environment with PYTHONPATH
             )
             print("AGRIYA DEBUG POINT 1")
             print(result1.stdout)
-
-            import_name = package.replace("-", "_")
             result = subprocess.run(
                 [
                     str(python_path),
@@ -275,7 +267,6 @@ def test_pip_install(base_test_dir, packages):
                 capture_output=True,
                 text=True,
                 check=False,
-                env=env,  # Add the environment with PYTHONPATH
             )
             print("AGRIYA DEBUG POINT 2")
             print(result.stdout)

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -52,9 +52,16 @@ def virtual_environment_activator(venv_path):
     activate_venv_script = venv_path / "bin" / "activate_this.py"
     runpy.run_path(str(activate_venv_script))
 
+    print("AGRIYA DEBUG POINT 3")
+    print(f"Activated virtual environment at {venv_path}")
+    print(f"PATH: {os.environ['PATH']}")
+
     yield
 
+    print("AGRIYA DEBUG POINT 4")
     os.environ["PATH"] = original_path
+    print(f"Deactivated virtual environment at {venv_path}")
+    print(f"PATH: {os.environ['PATH']}")
 
 
 @pytest.mark.parametrize(

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import shutil
 import subprocess
@@ -38,6 +39,22 @@ def base_test_dir(tmp_path_factory):
                     item.unlink()
     yield base_dir
     shutil.rmtree(base_dir)
+
+
+# FIXME: drop after https://github.com/pyodide/pyodide/pull/5448 is
+# released, as it won't be needed anymore
+@contextlib.contextmanager
+def virtual_environment_activator(venv_path):
+    """Context manager to activate a Pyodide virtual environment."""
+    original_path = os.environ["PATH"]
+    import runpy
+
+    activate_venv_script = venv_path / "bin" / "activate_this.py"
+    runpy.run_path(str(activate_venv_script))
+
+    yield
+
+    os.environ["PATH"] = original_path
 
 
 @pytest.mark.parametrize(
@@ -200,36 +217,43 @@ def test_pip_install(base_test_dir, packages):
 
     python_path = venv_path / "bin" / "python"
 
-    for package in packages:
-        result = subprocess.run(
-            [str(python_path), "-m", "pip", "install", package, "-v"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode == 0, f"Failed to install {package}: {result.stderr}"
+    with virtual_environment_activator(venv_path):
+        for package in packages:
+            result = subprocess.run(
+                [str(python_path), "-m", "pip", "install", package, "-v"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert (
+                result.returncode == 0
+            ), f"Failed to install {package}: {result.stderr}"
 
-        # Verify package is installed by checking dist-info directory
-        dist_info_dirs = list(
-            venv_path.glob(f"**/{package.replace('-', '_')}-*.dist-info")
-        )
-        assert len(dist_info_dirs) > 0, f"{package} not found in the venv"
+            # Verify package is installed by checking dist-info directory
+            dist_info_dirs = list(
+                venv_path.glob(f"**/{package.replace('-', '_')}-*.dist-info")
+            )
+            assert len(dist_info_dirs) > 0, f"{package} wasn't found in the venv"
 
     # Verify that the installed packages can be imported. It's overkill
     # but it's a good sanity check as this is an integration test, and
     # the import isn't the slow part here.
-    python_path = venv_path / "bin" / "python"
+
     for package in packages:
         import_name = package.replace("-", "_")
-        result = subprocess.run(
-            [
-                str(python_path),
-                "-c",
-                f"import {import_name}; print({import_name}.__version__)",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode == 0, f"Failed to import {package}: {result.stderr}"
-        assert result.stdout.strip(), f"No version found for {package}"
+
+        with virtual_environment_activator(venv_path):
+            result = subprocess.run(
+                [
+                    str(python_path),
+                    "-c",
+                    f"import {import_name}; print({import_name}.__version__)",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert (
+                result.returncode == 0
+            ), f"Failed to import {package}: {result.stderr}"
+            assert result.stdout.strip(), f"No version found for {package}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ exclude = [
     "/pyodide_build/tests",
 ]
 
+[tool.pytest.ini_options]
+addopts = "-vra --strict-markers"
+markers = [
+  "integration: mark a test as an integration test"
+]
+
 [tool.mypy]
 python_version = "3.12"
 mypy_path = ["pyodide_build"]


### PR DESCRIPTION
## Description

This PR stems from https://github.com/pyodide/pyodide-build/issues/115#issuecomment-2706715796 where I noticed that it is currently not possible to extend `virtualenv` args in order to override the virtual environment creation behaviour.

I've added a subset of the arguments listed at https://virtualenv.pypa.io/en/stable/cli_interface.html. The environment variables are already supported as we don't have much to deal with them, this PR enables passing those arguments. A warning is raised on currently and to-be-always unsupported arguments. For example, `--no-pip` does not make sense as we need `pip` to be able to install packages, and thus we always need a seeded environment.

It _might_ be possible to add support for the `--copies` and `--symlink-app-data` flags as well, but I haven't looked into them as they seem to be a bit more complex than I expected. Also, I'm not sure if anyone will need the extra complexity.

Further steps that can be taken in the medium term are to create a [`virtualenv-pyodide` plugin](https://virtualenv.pypa.io/en/latest/extend.html) and register it with `virtualenv` so that we can remove `venv.py` out of `pyodide-build` altogether and maintain it separately. I would be happy to work on this, but will probably do it in a separate repository and shift it here.

Possible use cases:
- allow installing a custom version of `pip` when creating the virtual environment, before it is patched up
- disable `pip` version checks when creating an environment
- embed extra packages into the environment at creation time if placed in a local directory
- and so on

cc: @hoodmane

TODO:

- [x] Examine which args to add
- [x] Add CLI support
- [x] Documentation (most likely self-documented, so we don't need anything else)
- [x] Add some basic tests
	- [x] Figure out how to run the slow integration tests; maybe disable isolation to let them reuse the download xbuildenv



