### PR TITLE
TST Reset cache after test

### DIFF
--- a/pyodide_build/tests/conftest.py
+++ b/pyodide_build/tests/conftest.py
@@ -57,7 +57,7 @@ def reset_env_vars():
 
 @pytest.fixture(scope="function")
 def reset_cache():
-    # Will remove all caches before each test.
+    # Will remove all caches before and after each test.
 
     def _reset():
         build_env.get_pyodide_root.cache_clear()
@@ -68,6 +68,8 @@ def reset_cache():
     _reset()
 
     yield _reset
+
+    _reset()
 
 
 @pytest.fixture(scope="function")

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -18,7 +18,7 @@ def test_remove_avoided_requirements():
     ) == {"baz"}
 
 
-def test_install_reqs(tmp_path):
+def test_install_reqs(tmp_path, dummy_xbuildenv):
     env = MockIsolatedEnv(tmp_path)
 
     reqs = {"foo", "bar", "baz"}
@@ -32,7 +32,7 @@ def test_install_reqs(tmp_path):
         assert req not in env.installed
 
 
-def test_make_command_wrapper_symlinks(tmp_path):
+def test_make_command_wrapper_symlinks(tmp_path, dummy_xbuildenv):
     symlink_dir = tmp_path
     env = pypabuild.make_command_wrapper_symlinks(symlink_dir)
 


### PR DESCRIPTION
Tests that create xbuildenv didn't reset the cached functions, including the one that finds pyodide_root. It made the tests fail in https://github.com/pyodide/pyodide-build/pull/117#issuecomment-2708618265

cc: @agriyakhetarpal 