### PR TITLE
Try again if rmtree raises `OsError: Directory not empty`

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -504,15 +504,11 @@ def retrying_rmtree(d):
     """
     for _ in range(3):
         try:
-            shutil.rmtree(d)
+            return shutil.rmtree(d)
         except OSError as e:
             if e.strerror == "Directory not empty":
                 # wait a bit and try again up to 3 tries
                 time.sleep(0.01)
-                continue
             else:
                 raise
-        return
-    raise RuntimeError(
-        f"shutil.rmtree('{d}') failed with ENOTEMPTY three times"
-    )
+    raise RuntimeError(f"shutil.rmtree('{d}') failed with ENOTEMPTY three times")

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -37,6 +37,7 @@ from pyodide_build.common import (
     make_zip_archive,
     modify_wheel,
     retag_wheel,
+    retrying_rmtree,
 )
 from pyodide_build.logger import logger
 from pyodide_build.recipe.bash_runner import (
@@ -243,14 +244,7 @@ class RecipeBuilder:
 
         # clear the build directory
         if self.build_dir.resolve().is_dir():
-            try:
-                shutil.rmtree(self.build_dir)
-            except OSError as e:
-                if e.strerror == "Directory not empty":
-                    # Not sure why this happens, but trying again seems to fix it usually?
-                    shutil.rmtree(self.build_dir)
-                else:
-                    raise
+            retrying_rmtree(self.build_dir)
 
         self.build_dir.mkdir(parents=True, exist_ok=True)
 

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -249,6 +249,8 @@ class RecipeBuilder:
                 if e.strerror == "Directory not empty":
                     # Not sure why this happens, but trying again seems to fix it usually?
                     shutil.rmtree(self.build_dir)
+                else:
+                    raise
 
         self.build_dir.mkdir(parents=True, exist_ok=True)
 

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -243,7 +243,12 @@ class RecipeBuilder:
 
         # clear the build directory
         if self.build_dir.resolve().is_dir():
-            shutil.rmtree(self.build_dir)
+            try:
+                shutil.rmtree(self.build_dir)
+            except OSError as e:
+                if e.strerror == "Directory not empty":
+                    # Not sure why this happens, but trying again seems to fix it usually?
+                    shutil.rmtree(self.build_dir)
 
         self.build_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
I get this error a lot when rmtree tries to remove the directory. I am not sure why it happens, but let's just try again in this case.