### PR TITLE
`skeleton`: Handle universal wheel case when generating predictable URLs for distributions

### DIFF
--- a/pyodide_build/recipe/skeleton.py
+++ b/pyodide_build/recipe/skeleton.py
@@ -124,6 +124,13 @@ def _make_predictable_url(
 
     elif source_type == "wheel":
         try:
+            # Special case for universal wheels (py2.py3)
+            # we return early as packaging doesn't handle
+            # this case properly.
+            if "-py2.py3-none-any.whl" in filename:
+                python_tag = "py2.py3"
+                return f"{host}/packages/{python_tag}/{package_url_name[0]}/{package_url_name}/{filename}"
+
             _, _, _, tags = parse_wheel_filename(filename)
             python_tag = None
             for tag in tags:

--- a/pyodide_build/tests/recipe/test_skeleton.py
+++ b/pyodide_build/tests/recipe/test_skeleton.py
@@ -182,8 +182,22 @@ def test_mkpkg_update_pinned(tmpdir):
             "scikit-learn-1.6.1.tar.gz",
             "https://files.pythonhosted.org/packages/source/s/scikit_learn/scikit_learn-1.6.1.tar.gz",
         ),
+        # test universal wheel with py2.py3 tags
+        (
+            "distlib",
+            "0.3.9",
+            "wheel",
+            "distlib-0.3.9-py2.py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/py2.py3/d/distlib/distlib-0.3.9-py2.py3-none-any.whl",
+        ),
     ],
-    ids=["numpy-sdist", "sympy-wheel", "example-wheel-build", "scikit-learn-sdist"],
+    ids=[
+        "numpy-sdist",
+        "sympy-wheel",
+        "example-wheel-build",
+        "scikit-learn-sdist",
+        "distlib-universal-wheel",
+    ],
 )
 def test_make_predictable_url(package, version, source_type, filename, expected_url):
     """Test that predictable URLs are generated correctly for various package formats."""


### PR DESCRIPTION
## Description

This was a case I missed with #101 that @hoodmane raised in #124 where the predictable URLs were incorrectly generated for universal wheels (which have `py2.py3` in the tag name).

## Additional context

As to why I missed this, see this snippet below:

```python
from packaging.utils import parse_wheel_filename
_, _, _, foo_tags = parse_wheel_filename("foo-1.0-py2.py3-none-any.whl")
```

and `foo_tags` returns `frozenset({<py2-none-any @ 4398716288>, <py3-none-any @ 4424434368>})`

but

```python
from packaging.tags import Tag
foo_tags == {Tag("py2.py3", "none", "any")}   # False
foo_tags == {Tag("py2-py3", "none", "any")}  # False
foo_tags == {Tag("py3", "none", "any")}  # False
foo_tags == {Tag("py3", "none", "any")  # False
foo_tags == {Tag("py3", "none", "any"), Tag("py2", "none", "any")}  # True
```

So `packaging.tags.Tag` can't handle this in the context of PyPI constructing predictable URLs (as it wasn't designed to), and we need to jump in manually and handle this on our own – there is a mismatch in how `packaging` generates a frozenset with multiple `Tag` objects, while PyPI has them combined.
