### PR TITLE
Virtual environment: handle pip updates

### DIFF
--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -248,10 +248,7 @@ def test_pip_downgrade(base_test_dir):
     assert result.returncode == 0, f"Failed to downgrade pip: {result.stderr}"
 
     result = subprocess.run(
-        [
-            str(venv_pip_path),
-            "--version"
-        ],
+        [str(venv_pip_path), "--version"],
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
Instead of putting our payload into pip and making pip3 and pip3.12 symlinks to pip, put our payload into pip_patched and symlink all pip variants to that. Then we can check for a problematic update by testing whether readlink() of the current executing file still points to pip_patched. If it doesn't, put it back.

Resolves #128