### PR TITLE
Skip integration tests for the regular tests job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,8 @@ jobs:
           pytest \
             --junitxml=test-results/junit.xml \
             --cov=pyodide-build \
-            pyodide_build
+            pyodide_build \
+            -m "not integration"
 
       - name: Upload coverage
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1


### PR DESCRIPTION
## Description

The `test:` job did not skip the integration tests, which are supposed to run in the integration tests job. This was noted by @ryanking13 in https://github.com/pyodide/pyodide-build/pull/117#issuecomment-2720340639.