### PR TITLE
Add testing for macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,10 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -81,12 +84,13 @@ jobs:
           fi
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: [check-integration-test-trigger]
     strategy:
       fail-fast: false
       matrix:
         task: [test-recipe, test-src, test-integration-marker]
+        os: [ubuntu-latest, macos-latest]
     if: needs.check-integration-test-trigger.outputs.run-integration-test
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Description

This pull request closes #127 by adding macOS as a tested platform., which should help our clients such as `cibuildwheel` and also aid local testing for contributors on macOS devices. We could skip the integration tests for macOS, but I think we would be fine with keeping them as we would still be under the limit for the number of concurrent jobs on a free GHA plan (8).