### PR TITLE
Make needs_rebuild aware of wheel tags

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -6,7 +6,7 @@ import os
 import re
 import subprocess
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import nullcontext, redirect_stdout
 from io import StringIO
 from pathlib import Path
@@ -219,7 +219,7 @@ def wheel_platform() -> str:
     return f"pyodide_{abi_version}_wasm32"
 
 
-def pyodide_tags() -> Iterator[Tag]:
+def pyodide_tags_() -> Iterator[Tag]:
     """
     Returns the sequence of tag triples for the Pyodide interpreter.
 
@@ -233,6 +233,11 @@ def pyodide_tags() -> Iterator[Tag]:
     yield from compatible_tags(platforms=PLATFORMS, python_version=python_version)
     # Following line can be removed once packaging 22.0 is released and we update to it.
     yield Tag(interpreter=f"cp{PYMAJOR}{PYMINOR}", abi="none", platform="any")
+
+
+@functools.cache
+def pyodide_tags() -> Sequence[Tag]:
+    return list(pyodide_tags_())
 
 
 def replace_so_abi_tags(wheel_dir: Path) -> None:

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -14,7 +14,7 @@ import tomllib
 import warnings
 import zipfile
 from collections import deque
-from collections.abc import Generator, Iterable, Iterator, Mapping
+from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -35,11 +35,13 @@ def xbuildenv_dirname() -> str:
     return f".pyodide-xbuildenv-{__version__}"
 
 
-def find_matching_wheels(
-    wheel_paths: Iterable[Path], supported_tags: Iterator[Tag]
+def _find_matching_wheels(
+    wheel_paths: Iterable[Path], supported_tags: Sequence[Tag], version: str = None
 ) -> Iterator[Path]:
     """
     Returns the sequence wheels whose tags match the Pyodide interpreter.
+
+    We don't bother ordering them carefully because we are only hoping to find one.
 
     Parameters
     ----------
@@ -52,17 +54,41 @@ def find_matching_wheels(
     -------
     The subset of wheel_paths that have tags that match the Pyodide interpreter.
     """
-    wheel_paths = list(wheel_paths)
-    wheel_tags_list: list[frozenset[Tag]] = []
-
-    for wheel in wheel_paths:
-        _, _, _, tags = parse_wheel_filename(wheel.name)
-        wheel_tags_list.append(tags)
-
-    for supported_tag in supported_tags:
-        for wheel_path, wheel_tags in zip(wheel_paths, wheel_tags_list, strict=True):
+    for wheel_path in wheel_paths:
+        _, wheel_version, _, wheel_tags = parse_wheel_filename(wheel_path.name)
+        if version and version != str(wheel_version):
+            continue
+        for supported_tag in supported_tags:
             if supported_tag in wheel_tags:
                 yield wheel_path
+                continue
+
+
+def find_matching_wheel(
+    wheel_paths: Iterable[Path], supported_tags: Sequence[Tag], version: str = None
+) -> Path | None:
+    """
+    Find a matching wheel or raise an error if none is present.
+
+    Parameters
+    ----------
+    wheel_paths
+        A list of paths to wheels
+    supported_tags
+        A list of tags that the environment supports
+
+    Returns
+    -------
+    The subset of wheel_paths that have tags that match the Pyodide interpreter.
+    """
+    result = list(_find_matching_wheels(wheel_paths, supported_tags, version))
+    if not result:
+        return None
+    if len(result) > 1:
+        raise RuntimeError(
+            "Found multiple matching wheels:\n" + "\n".join(w.name for w in result)
+        )
+    return result[0]
 
 
 def parse_top_level_import_name(whlfile: Path) -> list[str] | None:

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -36,7 +36,9 @@ def xbuildenv_dirname() -> str:
 
 
 def _find_matching_wheels(
-    wheel_paths: Iterable[Path], supported_tags: Sequence[Tag], version: str | None = None
+    wheel_paths: Iterable[Path],
+    supported_tags: Sequence[Tag],
+    version: str | None = None,
 ) -> Iterator[Path]:
     """
     Returns the sequence wheels whose tags match the Pyodide interpreter.

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -36,7 +36,7 @@ def xbuildenv_dirname() -> str:
 
 
 def _find_matching_wheels(
-    wheel_paths: Iterable[Path], supported_tags: Sequence[Tag], version: str = None
+    wheel_paths: Iterable[Path], supported_tags: Sequence[Tag], version: str | None = None
 ) -> Iterator[Path]:
     """
     Returns the sequence wheels whose tags match the Pyodide interpreter.

--- a/pyodide_build/recipe/graph_builder.py
+++ b/pyodide_build/recipe/graph_builder.py
@@ -33,7 +33,7 @@ from pyodide_build.common import (
     download_and_unpack_archive,
     exit_with_stdio,
     extract_wheel_metadata_file,
-    find_matching_wheels,
+    find_matching_wheel,
     find_missing_executables,
     repack_zip_archive,
 )
@@ -78,6 +78,7 @@ class BasePackage:
         self.version = self.meta.package.version
         self.disabled = self.meta.package.disabled
         self.package_type = self.meta.build.package_type
+        self.is_wheel = self.package_type in ["package", "cpython_module"]
 
         assert self.name == pkgdir.name, f"{self.name} != {pkgdir.name}"
 
@@ -119,7 +120,14 @@ class BasePackage:
         return build_dir / self.name / "build"
 
     def needs_rebuild(self, build_dir: Path) -> bool:
-        return needs_rebuild(self.pkgdir, self.build_path(build_dir), self.meta.source)
+        res = needs_rebuild(
+            self.pkgdir,
+            self.build_path(build_dir),
+            self.meta.source,
+            self.is_wheel,
+            self.version,
+        )
+        return res
 
     def build(self, build_args: BuildArgs, build_dir: Path) -> None:
         p = subprocess.run(
@@ -179,16 +187,12 @@ class PythonPackage(BasePackage):
 
     def dist_artifact_path(self) -> Path | None:
         dist_dir = self.pkgdir / "dist"
-        candidates = list(
-            find_matching_wheels(dist_dir.glob("*.whl"), build_env.pyodide_tags())
+        wheel = find_matching_wheel(
+            dist_dir.glob("*.whl"), build_env.pyodide_tags(), version=self.version
         )
-
-        if len(candidates) != 1:
-            raise RuntimeError(
-                f"Unexpected number of wheels/archives {len(candidates)} when building {self.name}"
-            )
-
-        return candidates[0]
+        if not wheel:
+            raise RuntimeError(f"Found no wheel while building {self.name}")
+        return wheel
 
     def tests_path(self) -> Path | None:
         tests = list((self.pkgdir / "dist").glob("*-tests.tar"))

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -248,11 +248,23 @@ class MockSourceSpec(_SourceSpec):
         return self
 
 
-def test_needs_rebuild(tmpdir):
+@pytest.mark.parametrize("is_wheel", [False, True])
+def test_needs_rebuild(tmpdir, is_wheel):
     pkg_root = Path(tmpdir)
     buildpath = pkg_root / "build"
     meta_yaml = pkg_root / "meta.yaml"
-    packaged = buildpath / ".packaged"
+    version = "12"
+    if is_wheel:
+        dist_dir = pkg_root / "dist"
+        dist_dir.mkdir()
+        # Build of current version with wrong abi
+        (dist_dir / "regex-12-cp311-cp311-pyodide_2024_0_wasm32.whl").touch()
+        # Build of old version with current abi
+        (dist_dir / "regex-11-cp312-cp312-pyodide_2024_0_wasm32.whl").touch()
+        # the version we're trying to build
+        packaged = dist_dir / "regex-12-cp312-cp312-pyodide_2024_0_wasm32.whl"
+    else:
+        packaged = buildpath / ".packaged"
 
     patch_file = pkg_root / "patch"
     extra_file = pkg_root / "extra"
@@ -277,39 +289,53 @@ def test_needs_rebuild(tmpdir):
     src_path_file.touch()
 
     # No .packaged file, rebuild
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is True
+    assert _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
     # .packaged file exists, no rebuild
     packaged.touch()
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is False
+    assert not _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
     # newer meta.yaml file, rebuild
     packaged.touch()
     time.sleep(0.01)
     meta_yaml.touch()
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is True
+    assert _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
     # newer patch file, rebuild
     packaged.touch()
     time.sleep(0.01)
     patch_file.touch()
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is True
+    assert _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
     # newer extra file, rebuild
     packaged.touch()
     time.sleep(0.01)
     extra_file.touch()
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is True
+    assert _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
     # newer source path, rebuild
     packaged.touch()
     time.sleep(0.01)
     src_path_file.touch()
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is True
+    assert _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
     # newer .packaged file, no rebuild
     packaged.touch()
-    assert _builder.needs_rebuild(pkg_root, buildpath, source_metadata) is False
+    assert not _builder.needs_rebuild(
+        pkg_root, buildpath, source_metadata, is_wheel, version
+    )
 
 
 def test_copy_sharedlib(tmp_path):

--- a/pyodide_build/tests/test_build_env.py
+++ b/pyodide_build/tests/test_build_env.py
@@ -219,17 +219,21 @@ def test_wheel_paths(dummy_xbuildenv):
                 strings.append(f"wrapt-1.13.3-{interp}-{abi}-{arch}.whl")
 
     paths = [Path(x) for x in strings]
-    assert [
-        x.stem.split("-", 2)[-1]
-        for x in common.find_matching_wheels(paths, build_env.pyodide_tags())
-    ] == [
-        f"{current_version}-{current_version}-{PLATFORM}",
-        f"{current_version}-abi3-{PLATFORM}",
-        f"{current_version}-none-{PLATFORM}",
-        f"{old_version}-abi3-{PLATFORM}",
-        f"py3-none-{PLATFORM}",
-        f"py2.py3-none-{PLATFORM}",
-        "py3-none-any",
-        "py2.py3-none-any",
-        f"{current_version}-none-any",
-    ]
+    assert sorted(
+        [
+            x.stem.split("-", 2)[-1]
+            for x in common._find_matching_wheels(paths, build_env.pyodide_tags())
+        ]
+    ) == sorted(
+        [
+            f"{current_version}-{current_version}-{PLATFORM}",
+            f"{current_version}-abi3-{PLATFORM}",
+            f"{current_version}-none-{PLATFORM}",
+            f"{old_version}-abi3-{PLATFORM}",
+            f"py3-none-{PLATFORM}",
+            f"py2.py3-none-{PLATFORM}",
+            "py3-none-any",
+            "py2.py3-none-any",
+            f"{current_version}-none-any",
+        ]
+    )

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -23,6 +23,16 @@ runner = CliRunner()
 RECIPE_DIR = Path(__file__).parent / "recipe" / "_test_recipes"
 
 
+def assert_runner_succeeded(result):
+    __tracebackhide__ = True
+    print(result.stdout)
+    if result.exception:
+        import traceback
+
+        traceback.print_exception(result.exception)
+    assert result.exit_code == 0
+
+
 def test_skeleton_pypi(tmp_path):
     test_pkg = "pytest-pyodide"
     old_version = "0.21.0"
@@ -39,7 +49,7 @@ def test_skeleton_pypi(tmp_path):
             old_version,
         ],
     )
-    assert result.exit_code == 0
+    assert_runner_succeeded(result)
     assert "pytest-pyodide/meta.yaml" in result.stdout
 
     result = runner.invoke(
@@ -54,7 +64,7 @@ def test_skeleton_pypi(tmp_path):
             "--update",
         ],
     )
-    assert result.exit_code == 0
+    assert_runner_succeeded(result)
     assert f"Updated {test_pkg} from {old_version} to {new_version}" in result.stdout
 
     result = runner.invoke(
@@ -64,7 +74,7 @@ def test_skeleton_pypi(tmp_path):
     assert "already exists" in str(result.exception)
 
 
-def test_build_recipe(tmp_path, dummy_xbuildenv, mock_emscripten):
+def test_build_recipe_plain(tmp_path, dummy_xbuildenv, mock_emscripten):
     output_dir = tmp_path / "dist"
 
     pkgs = {
@@ -80,6 +90,8 @@ def test_build_recipe(tmp_path, dummy_xbuildenv, mock_emscripten):
 
     app = typer.Typer()
     app.command()(build_recipes.build_recipes)
+    for recipe in RECIPE_DIR.glob("**/meta.yaml"):
+        recipe.touch()
 
     result = runner.invoke(
         app,
@@ -92,8 +104,7 @@ def test_build_recipe(tmp_path, dummy_xbuildenv, mock_emscripten):
             str(output_dir),
         ],
     )
-
-    assert result.exit_code == 0, result.stdout
+    assert_runner_succeeded(result)
 
     for pkg in pkgs_to_build:
         assert f"built {pkg} in" in result.stdout
@@ -102,7 +113,7 @@ def test_build_recipe(tmp_path, dummy_xbuildenv, mock_emscripten):
     assert len(built_wheels) == len(pkgs_to_build)
 
 
-def test_build_recipe_no_deps(tmp_path, dummy_xbuildenv, mock_emscripten):
+def test_build_recipe_no_deps_plain(tmp_path, dummy_xbuildenv, mock_emscripten):
     for build_dir in RECIPE_DIR.rglob("build"):
         shutil.rmtree(build_dir)
 
@@ -110,6 +121,8 @@ def test_build_recipe_no_deps(tmp_path, dummy_xbuildenv, mock_emscripten):
     app.command()(build_recipes.build_recipes_no_deps)
 
     pkgs_to_build = ["pkg_test_graph1", "pkg_test_graph3"]
+    for recipe in RECIPE_DIR.glob("**/meta.yaml"):
+        recipe.touch()
     result = runner.invoke(
         app,
         [
@@ -118,8 +131,7 @@ def test_build_recipe_no_deps(tmp_path, dummy_xbuildenv, mock_emscripten):
             str(RECIPE_DIR),
         ],
     )
-
-    assert result.exit_code == 0, result.stdout
+    assert_runner_succeeded(result)
 
     for pkg in pkgs_to_build:
         assert f"Succeeded building package {pkg}" in result.stdout
@@ -145,8 +157,7 @@ def test_build_recipe_no_deps_force_rebuild(tmp_path, dummy_xbuildenv, mock_emsc
             str(RECIPE_DIR),
         ],
     )
-
-    assert result.exit_code == 0, result.stdout
+    assert_runner_succeeded(result)
 
     result = runner.invoke(
         app,
@@ -157,8 +168,7 @@ def test_build_recipe_no_deps_force_rebuild(tmp_path, dummy_xbuildenv, mock_emsc
         ],
     )
 
-    assert result.exit_code == 0
-    # assert "Creating virtualenv isolated environment" not in result.stdout
+    assert_runner_succeeded(result)
     assert f"Succeeded building package {pkg}" in result.stdout
 
     result = runner.invoke(
@@ -179,6 +189,8 @@ def test_build_recipe_no_deps_force_rebuild(tmp_path, dummy_xbuildenv, mock_emsc
 def test_build_recipe_no_deps_continue(tmp_path, dummy_xbuildenv, mock_emscripten):
     for build_dir in RECIPE_DIR.rglob("build"):
         shutil.rmtree(build_dir)
+    for recipe in RECIPE_DIR.glob("**/meta.yaml"):
+        recipe.touch()
 
     app = typer.Typer()
     app.command()(build_recipes.build_recipes_no_deps)
@@ -193,25 +205,19 @@ def test_build_recipe_no_deps_continue(tmp_path, dummy_xbuildenv, mock_emscripte
         ],
     )
 
-    assert result.exit_code == 0, result.stdout
+    assert_runner_succeeded(result)
     assert f"Succeeded building package {pkg}" in result.stdout
-
-    for wheels in (RECIPE_DIR / pkg / "build").rglob("*.whl"):
-        wheels.unlink()
 
     pyproject_toml = next((RECIPE_DIR / pkg / "build").rglob("pyproject.toml"))
 
     # Modify some metadata and check it is applied when rebuilt with --continue flag
-    version = "99.99.99"
     with open(pyproject_toml, encoding="utf-8") as f:
         pyproject_data = f.read()
 
     pyproject_data = pyproject_data.replace(
-        'version = "1.0.0"', f'version = "{version}"'
+        "authors = []", 'authors = [{"name" = "Samuel Jackson"}]'
     )
-
-    with open(pyproject_toml, "w", encoding="utf-8") as f:
-        f.write(pyproject_data)
+    pyproject_toml.write_text(pyproject_data)
 
     result = runner.invoke(
         app,
@@ -223,9 +229,13 @@ def test_build_recipe_no_deps_continue(tmp_path, dummy_xbuildenv, mock_emscripte
         ],
     )
 
-    assert result.exit_code == 0
+    assert_runner_succeeded(result)
     assert f"Succeeded building package {pkg}" in result.stdout
-    assert f"{pkg}-{version}-py3-none-any.whl" in result.stdout
+    wheel = next((RECIPE_DIR / pkg / "dist").rglob("*.whl"))
+
+    metadata = tmp_path / "METADATA"
+    common.extract_wheel_metadata_file(wheel, metadata)
+    assert metadata.read_text().endswith("Samuel Jackson\n")
 
 
 def test_config_list(dummy_xbuildenv):


### PR DESCRIPTION
This switches to using the wheel itself instead of the ".packaged" marker to decide if a wheel needs to be rebuilt. Static and dynamic libraries still use the ".packaged" marker.

This solves the problem that whenever I switch branches between a Python update branch and any other branch, absolutely everything has to be rebuilt. Instead, this saves the wheels from each branch next to each other.

This should also resolve the annoying `Found multiple matching wheels` errors when switching abis or Python versions.