### PR TITLE
Apply PIP_CONSTRAINT while installing dependencies

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -318,7 +318,8 @@ def _create_constraints_file() -> str:
 
     if len(constraints.split(maxsplit=1)) > 1:
         raise ValueError(
-            "PIP_CONSTRAINT contains spaces so pip will misinterpret it. Make sure you clone Pyodide on a path with no spaces."
+            "PIP_CONSTRAINT contains spaces so pip will misinterpret it. Make sure the path to pyodide has no spaces.\n"
+            "See https://github.com/pypa/pip/issues/13283"
         )
 
     constraints_file = Path(constraints)

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -316,6 +316,11 @@ def _create_constraints_file() -> str:
     if not constraints:
         return ""
 
+    if len(constraints.split(maxsplit=1)) > 1:
+        raise ValueError(
+            "PIP_CONSTRAINT contains spaces so pip will misinterpret it. Make sure you clone Pyodide on a path with no spaces."
+        )
+
     constraints_file = Path(constraints)
     if not constraints_file.is_file():
         constraints_file.parent.mkdir(parents=True, exist_ok=True)

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -305,3 +305,19 @@ def local_versions() -> dict[str, str]:
         "pyodide-build": __version__,
         # "emscripten": "TODO"
     }
+
+
+def _create_constraints_file() -> str:
+    try:
+        constraints = get_build_flag("PIP_CONSTRAINT")
+    except ValueError:
+        return ""
+
+    if not constraints:
+        return ""
+
+    constraints_file = Path(constraints)
+    if not constraints_file.is_file():
+        constraints_file.parent.mkdir(parents=True, exist_ok=True)
+        constraints_file.write_text("")
+    return constraints

--- a/pyodide_build/out_of_tree/build.py
+++ b/pyodide_build/out_of_tree/build.py
@@ -24,6 +24,7 @@ def run(
     target_install_dir = os.environ.get(
         "TARGETINSTALLDIR", build_env.get_build_flag("TARGETINSTALLDIR")
     )
+    build_env._create_constraints_file()
     env = os.environ.copy()
     env.update(build_env.get_build_environment_vars(get_pyodide_root()))
 

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -160,7 +160,7 @@ def _build_in_isolated_env(
         # first install the build dependencies
         symlink_unisolated_packages(env)
         install_reqs(build_env, env, builder.build_system_requires)
-        build_reqs = None
+        build_reqs: set[str] | None = None
         try:
             build_reqs = builder.get_requires_for_build(
                 distribution,
@@ -172,7 +172,11 @@ def _build_in_isolated_env(
             # get_requires_for_build in native env failed. Maybe trying to
             # execute get_requires_for_build in the cross build environment will
             # work?
-            # TODO: Is this case ever used? Add test coverage or remove.
+
+            # This case is used in pygame-ce. In native env, the setup.py picks
+            # up native SDL2 config, then fails. In the cross env, it correctly
+            # picks up Emscripten SDL2 config.
+            # TODO: Add test coverage.
             with common.replace_env(build_env):
                 build_reqs = builder.get_requires_for_build(
                     distribution,

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -123,13 +123,19 @@ def remove_avoided_requirements(
     return requires
 
 
-def install_reqs(env: DefaultIsolatedEnv, reqs: set[str]) -> None:
-    env.install(
-        remove_avoided_requirements(
-            reqs,
-            get_unisolated_packages() + AVOIDED_REQUIREMENTS,
+def install_reqs(
+    build_env: Mapping[str, str], env: DefaultIsolatedEnv, reqs: set[str]
+) -> None:
+    # propagate PIP config from build_env to current environment
+    with common.replace_env(
+        os.environ | {k: v for k, v in build_env.items() if k.startswith("PIP")}
+    ):
+        env.install(
+            remove_avoided_requirements(
+                reqs,
+                get_unisolated_packages() + AVOIDED_REQUIREMENTS,
+            )
         )
-    )
 
 
 def _build_in_isolated_env(
@@ -142,7 +148,7 @@ def _build_in_isolated_env(
     # For debugging: The following line disables removal of the isolated venv.
     # It will be left in the /tmp folder and can be inspected or entered as
     # needed.
-    # _DefaultIsolatedEnv.__exit__ = lambda *args: None
+    # _DefaultIsolatedEnv.__exit__ = lambda self, *args: print("Skipping removing isolated env in", self.path)
     with _DefaultIsolatedEnv() as env:
         env = cast(_DefaultIsolatedEnv, env)
         builder = _ProjectBuilder.from_isolated_env(
@@ -153,26 +159,29 @@ def _build_in_isolated_env(
 
         # first install the build dependencies
         symlink_unisolated_packages(env)
-        install_reqs(env, builder.build_system_requires)
-        installed_requires_for_build = False
+        install_reqs(build_env, env, builder.build_system_requires)
+        build_reqs = None
         try:
             build_reqs = builder.get_requires_for_build(
                 distribution,
             )
         except BuildBackendException:
             pass
-        else:
-            install_reqs(env, build_reqs)
-            installed_requires_for_build = True
 
-        with common.replace_env(build_env):
-            if not installed_requires_for_build:
+        if not build_reqs:
+            # get_requires_for_build in native env failed. Maybe trying to
+            # execute get_requires_for_build in the cross build environment will
+            # work?
+            # TODO: Is this case ever used? Add test coverage or remove.
+            with common.replace_env(build_env):
                 build_reqs = builder.get_requires_for_build(
                     distribution,
                     config_settings,
                 )
-                install_reqs(env, build_reqs)
 
+        install_reqs(build_env, env, build_reqs)
+
+        with common.replace_env(build_env):
             return builder.build(
                 distribution,
                 outdir,

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -128,7 +128,8 @@ class RecipeBuilder:
         )
         if len(str(self.build_dir).split(maxsplit=1)) > 1:
             raise ValueError(
-                "PIP_CONSTRAINT contains spaces so pip will misinterpret it. Make sure the path to the package build directory has no spaces."
+                "PIP_CONSTRAINT contains spaces so pip will misinterpret it. Make sure the path to the package build directory has no spaces.\n"
+                "See https://github.com/pypa/pip/issues/13283"
             )
         self.library_install_prefix = self.build_dir.parent.parent / ".libs"
         self.src_extract_dir = (

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -126,6 +126,10 @@ class RecipeBuilder:
         self.build_dir = (
             Path(build_dir).resolve() if build_dir else self.pkg_root / "build"
         )
+        if len(str(self.build_dir).split(maxsplit=1)) > 1:
+            raise ValueError(
+                "PIP_CONSTRAINT contains spaces so pip will misinterpret it. Make sure the path to the package build directory has no spaces."
+            )
         self.library_install_prefix = self.build_dir.parent.parent / ".libs"
         self.src_extract_dir = (
             self.build_dir / self.fullname
@@ -366,14 +370,11 @@ class RecipeBuilder:
             return host_constraints
 
         new_constraints_file = self.build_dir / "constraints.txt"
-        if host_constraints:
-            shutil.copy(host_constraints, new_constraints_file)
-
-        with new_constraints_file.open("a") as f:
+        with new_constraints_file.open("w") as f:
             for constraint in constraints:
                 f.write(constraint + "\n")
 
-        return str(new_constraints_file)
+        return host_constraints + " " + str(new_constraints_file)
 
     def _compile(
         self,

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -21,8 +21,8 @@ from pyodide_build import common, pypabuild
 from pyodide_build.build_env import (
     RUST_BUILD_PRELUDE,
     BuildArgs,
+    _create_constraints_file,
     get_build_environment_vars,
-    get_build_flag,
     get_pyodide_root,
     get_pyversion_major,
     get_pyversion_minor,
@@ -358,20 +358,16 @@ class RecipeBuilder:
 
         returns the path to the new constraints file.
         """
-        try:
-            host_constraints = get_build_flag("PIP_CONSTRAINT")
-        except ValueError:
-            host_constraints = ""
+        host_constraints = _create_constraints_file()
 
         constraints = self.recipe.requirements.constraint
         if not constraints:
             # nothing to override
             return host_constraints
 
-        host_constraints_file = Path(host_constraints)
         new_constraints_file = self.build_dir / "constraints.txt"
-        if host_constraints_file.is_file():
-            shutil.copy(host_constraints_file, new_constraints_file)
+        if host_constraints:
+            shutil.copy(host_constraints, new_constraints_file)
 
         with new_constraints_file.open("a") as f:
             for constraint in constraints:

--- a/pyodide_build/tests/recipe/_test_recipes/pkg_test_constraint/meta.yaml
+++ b/pyodide_build/tests/recipe/_test_recipes/pkg_test_constraint/meta.yaml
@@ -5,5 +5,6 @@ requirements:
   constraint:
     - numpy < 2.0
     - pytest == 7.0
+    - setuptools < 75
 source:
   path: src

--- a/pyodide_build/tests/recipe/_test_recipes/pkg_test_constraint/src/pyproject.toml
+++ b/pyodide_build/tests/recipe/_test_recipes/pkg_test_constraint/src/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "pytest"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyodide_build/tests/recipe/_test_recipes/pkg_test_constraint/src/setup.py
+++ b/pyodide_build/tests/recipe/_test_recipes/pkg_test_constraint/src/setup.py
@@ -1,0 +1,9 @@
+from importlib.metadata import version
+from pathlib import Path
+
+from setuptools import setup
+
+for pkg in ["setuptools", "pytest"]:
+    Path(f"../{pkg}.version").write_text(version(pkg))
+
+setup()

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -239,7 +239,7 @@ def test_create_constraints_file_override(tmp_path, dummy_xbuildenv):
     assert path == str(tmp_path / "constraints.txt")
 
     data = Path(path).read_text().strip().split("\n")
-    assert data[-3:] == ["numpy < 2.0", "pytest == 7.0"], data
+    assert data[-3:] == ["numpy < 2.0", "pytest == 7.0", "setuptools < 75"], data
 
 
 class MockSourceSpec(_SourceSpec):

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -235,10 +235,10 @@ def test_create_constraints_file_override(tmp_path, dummy_xbuildenv):
         build_dir=tmp_path,
     )
 
-    path = builder._create_constraints_file()
-    assert path == str(tmp_path / "constraints.txt")
+    paths = builder._create_constraints_file()
+    assert paths == get_build_flag("PIP_CONSTRAINT") + " " + str(tmp_path / "constraints.txt")
 
-    data = Path(path).read_text().strip().split("\n")
+    data = Path(paths.split()[-1]).read_text().strip().split("\n")
     assert data[-3:] == ["numpy < 2.0", "pytest == 7.0", "setuptools < 75"], data
 
 

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -236,7 +236,9 @@ def test_create_constraints_file_override(tmp_path, dummy_xbuildenv):
     )
 
     paths = builder._create_constraints_file()
-    assert paths == get_build_flag("PIP_CONSTRAINT") + " " + str(tmp_path / "constraints.txt")
+    assert paths == get_build_flag("PIP_CONSTRAINT") + " " + str(
+        tmp_path / "constraints.txt"
+    )
 
     data = Path(paths.split()[-1]).read_text().strip().split("\n")
     assert data[-3:] == ["numpy < 2.0", "pytest == 7.0", "setuptools < 75"], data

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -580,3 +580,29 @@ def test_build_cpython_module(tmp_path, dummy_xbuildenv, mock_emscripten):
     assert len(results) == 1
     result = results[0]
     assert result.name == "pydecimal-1.0.0-cp312-cp312-pyodide_2024_0_wasm32.whl"
+
+
+def test_build_constraint(tmp_path, dummy_xbuildenv, mock_emscripten, capsys):
+    for build_dir in RECIPE_DIR.rglob("build"):
+        shutil.rmtree(build_dir)
+
+    app = typer.Typer()
+    app.command()(build_recipes.build_recipes_no_deps)
+
+    pkg = "pkg_test_constraint"
+    for recipe in RECIPE_DIR.glob("**/meta.yaml"):
+        recipe.touch()
+    result = runner.invoke(
+        app,
+        [
+            pkg,
+            "--recipe-dir",
+            str(RECIPE_DIR),
+        ],
+    )
+    assert_runner_succeeded(result)
+
+    assert f"Succeeded building package {pkg}" in result.stdout
+    build_dir = RECIPE_DIR / pkg / "build"
+    assert (build_dir / "setuptools.version").read_text() == "74.1.3"
+    assert (build_dir / "pytest.version").read_text() == "7.0.0"

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -23,11 +23,11 @@ def test_install_reqs(tmp_path, dummy_xbuildenv):
 
     reqs = {"foo", "bar", "baz"}
 
-    pypabuild.install_reqs(env, reqs)  # type: ignore[arg-type]
+    pypabuild.install_reqs({}, env, reqs)  # type: ignore[arg-type]
     for req in reqs:
         assert req in env.installed
 
-    pypabuild.install_reqs(env, set(pypabuild.AVOIDED_REQUIREMENTS))  # type: ignore[arg-type]
+    pypabuild.install_reqs({}, env, set(pypabuild.AVOIDED_REQUIREMENTS))  # type: ignore[arg-type]
     for req in pypabuild.AVOIDED_REQUIREMENTS:
         assert req not in env.installed
 


### PR DESCRIPTION
We apply the PIP_CONSTRAINT by setting an environment variable. But it isn't around when we actually install dependencies so it is ignored. This fixes it.