### PR TITLE
Make pyodide venv work from a uv-managed python virtual environment

### DIFF
--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -234,9 +234,19 @@ def create_pip_script(venv_bin):
         pip.unlink(missing_ok=True)
         pip.symlink_to(pip_path)
 
-    host_python_path.symlink_to(sys.executable)
+    # We used to use a symlink here, but getpath.py failed when used with uv
+    # python. So now we do this instead.
+    host_python_path.write_text(
+        dedent(
+            f"""\
+            #!/bin/sh
+            exec {sys.executable} $@
+            """
+        )
+    )
+    host_python_path.chmod(0o777)
     # in case someone needs a Python-version-agnostic way to refer to python-host
-    (venv_bin / "python-host").symlink_to(sys.executable)
+    (venv_bin / "python-host").symlink_to(host_python_path)
 
     pip_path.write_text(
         # Other than the shebang and the monkey patch, this is exactly what


### PR DESCRIPTION
Symlinking python-host to the uv python causes trouble, so instead we use exec.

Now the following works:
```sh
uv python install 3.12
uv venv -p 3.12 .venv
source .venv/bin/activate
uv pip install pip pyodide-build
pyodide venv .venv_pyodide
.venv_pyodide/bin/pip --help
```

Resolves #143. 

It is still necessary to do `uv pip install pip` first, that is a different bug.

- [ ] Add a test
