### PR TITLE
Silence `python -m wheel {pack, unpack}` at unvendoring stage

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -315,7 +315,9 @@ def _get_sha256_checksum(archive: Path) -> str:
     return h.hexdigest()
 
 
-def unpack_wheel(wheel_path: Path, target_dir: Path | None = None, verbose=True) -> None:
+def unpack_wheel(
+    wheel_path: Path, target_dir: Path | None = None, verbose=True
+) -> None:
     if target_dir is None:
         target_dir = wheel_path.parent
     result = subprocess.run(

--- a/pyodide_build/recipe/unvendor.py
+++ b/pyodide_build/recipe/unvendor.py
@@ -44,7 +44,7 @@ def unvendor_tests_in_wheel(
     with TemporaryDirectory() as _tmpdir:
         tmpdir = Path(_tmpdir)
         test_dir = tmpdir / "tests"
-        with modify_wheel(wheel) as wheel_extract_dir:
+        with modify_wheel(wheel, verbose=False) as wheel_extract_dir:
             nmoved = unvendor_tests(
                 wheel_extract_dir,
                 test_dir,


### PR DESCRIPTION
After #116, I noticed that there are verbose logs printed at the very end step of recipe build:

```
Building packages... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12 100% Time elapsed: 0:05:13
Copying build logs to /src/packages/build-logs                                                                                                                                                                       
Copying built packages to /src/dist                                                                                                                                                                                  
Writing pyodide-lock.json to /src/dist/pyodide-lock.json                                                                                                                                                             
Unpacking to: /tmp/tmpbcmq2jas/lzma-1.0.0...OK
Repacking wheel as /src/dist/lzma-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl...OK
Unpacking to: /tmp/tmp8h460lyt/sqlite3-1.0.0...OK
Repacking wheel as /src/dist/sqlite3-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl...OK
Unpacking to: /tmp/tmpq4g8gu0_/pydoc_data-1.0.0...OK
Repacking wheel as /src/dist/pydoc_data-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl...OK
Unpacking to: /tmp/tmp2w_726d9/hashlib-1.0.0...OK
Repacking wheel as /src/dist/hashlib-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl...OK
Unpacking to: /tmp/tmp0kwjjwcv/micropip-0.9.0...OK
Repacking wheel as /src/dist/micropip-0.9.0-py3-none-any.whl...OK
Unpacking to: /tmp/tmp76vv54io/ssl-1.0.0...OK
Repacking wheel as /src/dist/ssl-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl...OK
Unpacking to: /tmp/tmpw4r6k1d5/pydecimal-1.0.0...OK
Repacking wheel as /src/dist/pydecimal-1.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl...OK
Unpacking to: /tmp/tmp2p_yb3sh/tblib-3.0.0...OK
Repacking wheel as /src/dist/tblib-3.0.0-py3-none-any.whl...OK
Unpacking to: /tmp/tmpwrj6kqd2/packaging-24.2...OK
Repacking wheel as /src/dist/packaging-24.2-py3-none-any.whl...OK
```

It is because `python -m wheel {pack, unpack}` prints these logs to stdout. So, I added a verbose parameter to silence these outputs when we don't want them.
