### PR TITLE
Better check for write access when determining default xbuildenv path

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -83,14 +83,16 @@ def _has_write_access(folder: Path) -> bool:
 
         # 1. check owner by name
         try:
-            return p.owner() == os.getlogin()
+            if p.owner() == os.getlogin():
+                return True
         except Exception:
             pass
 
         # 2. check owner by UID
         if hasattr(os, "geteuid"):
             try:
-                return p.stat().st_uid == os.geteuid()
+                if p.stat().st_uid == os.geteuid():
+                    return True
             except (OSError, NotImplementedError):
                 pass
 


### PR DESCRIPTION
## Description

As a small follow-up to the changes made in #148, this PR adds a better check to evaluate if we have write access to the xbuildenv directory. It also adds the relevant attribution to the code that I had forgotten to attach in the review there.