### PR TITLE
Support custom xbuildenv paths, and add xbuildenv path to `ConfigManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added basic support for uv. `uv tool install pyodide-cli --with pyodide-build`, or `uvx --from pyodide-cli --with pyodide-build pyodide --help`, or using `pyodide-build` in `uv`-managed virtual environments will now work.
   [#132](https://github.com/pyodide/pyodide-build/pull/132)
 
+- `pyodide build` now takes an additional `--xbuildenv-path` argument and corresponding
+  equivalent `PYODIDE_XBUILDENV_PATH` environment variable to either use an existing
+  cross-build environment or create one at the specified path. This means that users
+  can use `pyodide xbuildenv install <...> --path` to install a cross-build environment
+  somewhere and reuse this with `pyodide build`.
+  [#158](https://github.com/pyodide/pyodide-build/pull/158)
+
+- Added a new config variable `xbuildenv_path` that can be left in the `[tool.pyodide.build]`
+  section in `pyproject.toml` and retrieved through `pyodide config get xbuildenv_path`.
+  The `pyodide xbuildenv` and `pyodide build` commands will setup/use cross-build environments
+  at this path if one isn't specified as a CLI argument or unless overridden through the
+  `PYODIDE_XBUILDENV_PATH` environment variable.
+  [#158](https://github.com/pyodide/pyodide-build/pull/158)
+
 ### Changed
 
 - The Rust toolchain version has been updated to `nightly-2025-01-18`.

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -37,7 +37,9 @@ class BuildArgs:
     builddir: str = ""  # The path to run pypa/build
 
 
-def init_environment(*, quiet: bool = False) -> None:
+def init_environment(
+    *, quiet: bool = False, xbuildenv_path: Path | None = None
+) -> None:
     """
     Initialize Pyodide build environment.
     This function needs to be called before any other Pyodide build functions.
@@ -46,6 +48,9 @@ def init_environment(*, quiet: bool = False) -> None:
     ----------
     quiet
         If True, do not print any messages
+    xbuildenv_path
+        Path to the cross-build environment directory. If None, the default
+        location will be used.
     """
 
     # Already initialized
@@ -54,12 +59,14 @@ def init_environment(*, quiet: bool = False) -> None:
 
     root = search_pyodide_root(Path.cwd())
     if not root:  # Not in Pyodide tree
-        root = _init_xbuild_env(quiet=quiet)
+        root = _init_xbuild_env(quiet=quiet, xbuildenv_path=xbuildenv_path)
 
     os.environ["PYODIDE_ROOT"] = str(root)
 
 
-def _init_xbuild_env(*, quiet: bool = False) -> Path:
+def _init_xbuild_env(
+    *, quiet: bool = False, xbuildenv_path: Path | None = None
+) -> Path:
     """
     Initialize the build environment for out-of-tree builds.
 
@@ -67,6 +74,8 @@ def _init_xbuild_env(*, quiet: bool = False) -> Path:
     ----------
     quiet
         If True, do not print any messages
+    xbuildenv_path
+        Path to the cross-build environment directory. If None, the default location will be used.
 
     Returns
     -------
@@ -74,7 +83,7 @@ def _init_xbuild_env(*, quiet: bool = False) -> Path:
     """
     from pyodide_build.xbuildenv import CrossBuildEnvManager  # avoid circular import
 
-    xbuildenv_path = default_xbuildenv_path()
+    xbuildenv_path = xbuildenv_path or default_xbuildenv_path()
     context = redirect_stdout(StringIO()) if quiet else nullcontext()
     with context:
         manager = CrossBuildEnvManager(xbuildenv_path)

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -174,10 +174,16 @@ def main(
         ),
         metavar="KEY[=VALUE]",
     ),
+    xbuildenv_path: Optional[Path] = typer.Option(  # noqa: UP007 typer does not accept Path | None yet.
+        None,
+        "--xbuildenv-path",
+        envvar="PYODIDE_XBUILDENV_PATH",
+        help="Path to the cross-build environment directory. If not provided, the default location will be used.",
+    ),
     ctx: typer.Context = typer.Context,  # type: ignore[assignment]
 ) -> None:
     """Use pypa/build to build a Python package from source, pypi or url."""
-    init_environment()
+    init_environment(xbuildenv_path=xbuildenv_path)
     try:
         check_emscripten_version()
     except RuntimeError as e:

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -15,6 +15,7 @@ from pyodide_build.build_env import (
     get_pyodide_root,
     init_environment,
 )
+from pyodide_build.common import default_xbuildenv_path
 from pyodide_build.logger import logger
 from pyodide_build.out_of_tree import build
 from pyodide_build.out_of_tree.pypi import (
@@ -120,6 +121,9 @@ def source(
     return built_wheel
 
 
+DEFAULT_PATH = default_xbuildenv_path()
+
+
 # simple 'pyodide build' command
 def main(
     source_location: Optional[str] = typer.Argument(  # noqa: UP007 typer does not accept list[str] | None yet.
@@ -174,11 +178,11 @@ def main(
         ),
         metavar="KEY[=VALUE]",
     ),
-    xbuildenv_path: Optional[Path] = typer.Option(  # noqa: UP007 typer does not accept Path | None yet.
-        None,
+    xbuildenv_path: Path = typer.Option(
+        DEFAULT_PATH,
         "--xbuildenv-path",
         envvar="PYODIDE_XBUILDENV_PATH",
-        help="Path to the cross-build environment directory. If not provided, the default location will be used.",
+        help="Path to the cross-build environment directory.",
     ),
     ctx: typer.Context = typer.Context,  # type: ignore[assignment]
 ) -> None:

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -34,9 +34,6 @@ def _get_configs() -> dict[str, str]:
 
     configs: dict[str, str] = get_build_environment_vars(get_pyodide_root())
 
-    # Print out empty config variables as well, instead of ignoring them. It
-    # helps with visibility as to what is being used in the builds, and what
-    # isn't being used.
     configs_filtered = {k: configs.get(v, "") for k, v in PYODIDE_CONFIGS.items()}
 
     return configs_filtered

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -20,6 +20,7 @@ PYODIDE_CONFIGS = {
     "cxxflags": "SIDE_MODULE_CXXFLAGS",
     "ldflags": "SIDE_MODULE_LDFLAGS",
     "meson_cross_file": "MESON_CROSS_FILE",
+    "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
 }
 
 
@@ -33,7 +34,11 @@ def _get_configs() -> dict[str, str]:
 
     configs: dict[str, str] = get_build_environment_vars(get_pyodide_root())
 
-    configs_filtered = {k: configs[v] for k, v in PYODIDE_CONFIGS.items()}
+    # Print out empty config variables as well, instead of ignoring them. It
+    # helps with visibility as to what is being used in the builds, and what
+    # isn't being used.
+    configs_filtered = {k: configs.get(v, "") for k, v in PYODIDE_CONFIGS.items()}
+
     return configs_filtered
 
 

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -34,8 +34,7 @@ def _get_configs() -> dict[str, str]:
 
     configs: dict[str, str] = get_build_environment_vars(get_pyodide_root())
 
-    configs_filtered = {k: configs.get(v, "") for k, v in PYODIDE_CONFIGS.items()}
-
+    configs_filtered = {k: configs[v] for k, v in PYODIDE_CONFIGS.items()}
     return configs_filtered
 
 

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -35,7 +35,9 @@ def _install(
         None, help="version of cross-build environment to install"
     ),
     path: Path = typer.Option(
-        DEFAULT_PATH, help="path to cross-build environment directory"
+        DEFAULT_PATH,
+        envvar="PYODIDE_XBUILDENV_PATH",
+        help="path to download cross-build environment directory to.",
     ),
     url: str = typer.Option(None, help="URL to download cross-build environment from"),
     force_install: bool = typer.Option(

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -37,7 +37,7 @@ def _install(
     path: Path = typer.Option(
         DEFAULT_PATH,
         envvar="PYODIDE_XBUILDENV_PATH",
-        help="path to download cross-build environment directory to.",
+        help="destination to download cross-build environment directory to.",
     ),
     url: str = typer.Option(None, help="URL to download cross-build environment from"),
     force_install: bool = typer.Option(

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -64,7 +64,7 @@ def default_xbuildenv_path() -> Path:
         if _has_write_access(path):
             return path
         else:
-            logger.warning(
+            logger.error(
                 "The directory specified in PYODIDE_XBUILDENV_PATH (%s) is not writable. "
                 "Falling back to other locations.",
                 path,
@@ -86,13 +86,13 @@ def default_xbuildenv_path() -> Path:
             if _has_write_access(config_path):
                 return config_path
             else:
-                warning_msg = (
-                    f"The directory specified in pyproject.toml ({config_path}) is not writable. "
-                    "Falling back to default locations."
+                logger.error(
+                    "The directory specified in pyproject.toml (%s) is not writable. "
+                    "Falling back to default locations.",
+                    config_path,
                 )
-                logger.warning(warning_msg)
     except Exception as e:
-        logger.warning("Error reading xbuildenv_path from config system: %s", e)
+        logger.error("Error reading xbuildenv_path from config system: %s", e)
 
     # 3. use default locations from platformdirs and elsewhere
     dirname = xbuildenv_dirname()

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -72,8 +72,7 @@ def default_xbuildenv_path() -> Path:
                 return config_path
             else:
                 logger.error(
-                    "The directory specified in pyproject.toml (%s) is not writable. "
-                    "Falling back to default locations.",
+                    "Error: the directory specified in pyproject.toml or PYODIDE_XBUILDENV_PATH (%s) is not writable. ",
                     config_path,
                 )
 

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -66,10 +66,7 @@ def default_xbuildenv_path() -> Path:
         # we can skip to fallback options if the config path is empty
         # as Path("") returns Path("."), which is not what we want.
         if config_path_str:
-            config_path = Path(config_path_str)
-
-            if not config_path.is_absolute():
-                config_path = Path.cwd() / config_path
+            config_path = Path(config_path_str).resolve()
 
             if _has_write_access(config_path):
                 return config_path

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -103,38 +103,15 @@ def default_xbuildenv_path() -> Path:
     )
 
 
-# Adapted from
-# https://github.com/jupyter/jupyter_core/blob/dc840a3bef34316a511aacb5972b5212c4c0e7af/jupyter_core/paths.py#L83-L108
-# License: BSD-3-Clause
 def _has_write_access(folder: Path) -> bool:
     """
     Checks if the current user has write access to the given folder using pathlib.
     """
     try:
-        # If folder doesn't exist, recursively check parent (unless we're at root)
         if not folder.exists() and folder.parent != folder:
             return _has_write_access(folder.parent)
 
-        p = folder.resolve()
-
-        # 1. check owner by name
-        try:
-            if p.owner() == os.getlogin():
-                return True
-        except Exception:
-            pass
-
-        # 2. check owner by UID
-        if hasattr(os, "geteuid"):
-            try:
-                if p.stat().st_uid == os.geteuid():
-                    return True
-            except (OSError, NotImplementedError):
-                pass
-
-        # 3. fall back to access check if both fail
-        return os.access(str(p), os.W_OK)
-
+        return os.access(str(folder), os.W_OK)
     except OSError:
         return False
 

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -61,20 +61,25 @@ def default_xbuildenv_path() -> Path:
     try:
         from pyodide_build.build_env import get_host_build_flag
 
-        config_path = Path(get_host_build_flag("PYODIDE_XBUILDENV_PATH"))
-        print("CONFIG PATH", config_path)
+        config_path_str = get_host_build_flag("PYODIDE_XBUILDENV_PATH")
 
-        if not config_path.is_absolute():
-            config_path = Path.cwd() / config_path
+        # we can skip to fallback options if the config path is empty
+        # as Path("") returns Path("."), which is not what we want.
+        if config_path_str:
+            config_path = Path(config_path_str)
 
-        if _has_write_access(config_path):
-            return config_path
-        else:
-            logger.error(
-                "The directory specified in pyproject.toml (%s) is not writable. "
-                "Falling back to default locations.",
-                config_path,
-            )
+            if not config_path.is_absolute():
+                config_path = Path.cwd() / config_path
+
+            if _has_write_access(config_path):
+                return config_path
+            else:
+                logger.error(
+                    "The directory specified in pyproject.toml (%s) is not writable. "
+                    "Falling back to default locations.",
+                    config_path,
+                )
+
     except Exception as e:
         logger.error("Error reading xbuildenv_path from config system: %s", e)
 

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -43,17 +43,71 @@ def xbuildenv_dirname() -> str:
 @cache
 def default_xbuildenv_path() -> Path:
     """
-    Return the default path to the cross-build environment directory.
+    Return the default path to the cross-build environment directory. This directory
+    is used when no path is provided to `pyodide xbuildenv`'s subcommands.
 
-    This directory is used when no path is provided to the `pyodide xbuildenv` subcommands.
+    The search order for determining the path is as follows:
+    1. the PYODIDE_XBUILDENV_PATH environment variable if set
+    2. the value provided by "pyodide config xbuildenv_path"
+    3. the default location based on platformdirs
+
+    Returns
+    -------
+    Path
+        The path to the cross-build environment directory
     """
+    # We need some special handling for the config tests as this seems
+    # to conflict with the paths and picks up non-mocked paths otherwise
+    in_pytest = "PYTEST_CURRENT_TEST" in os.environ
+    test_path = os.environ.get("_PYTEST_XBUILDENV_PATH")
+    if in_pytest and test_path:
+        return Path(test_path)
+
+    # 1. check environment variable
+    env_path = os.environ.get("PYODIDE_XBUILDENV_PATH")
+    if env_path:
+        path = Path(env_path)
+        if _has_write_access(path):
+            return path
+        else:
+            logger.warning(
+                "The directory specified in PYODIDE_XBUILDENV_PATH (%s) is not writable. "
+                "Falling back to other locations.",
+                path,
+            )
+
+    # 2. check "pyodide config xbuildenv_path"
+    if not in_pytest:
+        try:
+            from pyodide_build.config import ConfigManager
+
+            config_manager = ConfigManager()
+            if (
+                "xbuildenv_path" in config_manager.config
+                and config_manager.config["xbuildenv_path"]
+            ):
+                config_path = Path(config_manager.config["xbuildenv_path"])
+                if not config_path.is_absolute():
+                    config_path = Path.cwd() / config_path
+
+                if _has_write_access(config_path):
+                    return config_path
+                else:
+                    warning_msg = (
+                        f"The directory specified in pyproject.toml ({config_path}) is not writable. "
+                        "Falling back to default locations."
+                    )
+                    logger.warning(warning_msg)
+        except Exception as e:
+            logger.warning("Error reading xbuildenv_path from config system: %s", e)
+
+    # 3. use default locations from platformdirs and elsewhere
     dirname = xbuildenv_dirname()
     candidates = []
 
-    # 1. default cache directory
+    # 3.1. default cache directory
     candidates.append(Path(platformdirs.user_cache_dir()) / dirname)
-
-    # 2. current working directory
+    # 3.2. current working directory
     candidates.append(Path.cwd() / dirname)
 
     for candidate in candidates:

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -198,6 +198,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "skip_emscripten_version_check": "SKIP_EMSCRIPTEN_VERSION_CHECK",
     "build_dependency_index_url": "BUILD_DEPENDENCY_INDEX_URL",
     "default_cross_build_env_url": "DEFAULT_CROSS_BUILD_ENV_URL",
+    "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -216,6 +217,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "skip_emscripten_version_check",
     "build_dependency_index_url",
     "default_cross_build_env_url",
+    "xbuildenv_path",
     # maintainer only
     "_f2c_fixes_wrapper",
 }
@@ -237,6 +239,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     "skip_emscripten_version_check": "0",
     "build_dependency_index_url": "https://pypi.anaconda.org/pyodide/simple",
     "default_cross_build_env_url": "",
+    "xbuildenv_path": "",
     # maintainer only
     "_f2c_fixes_wrapper": "",
 }

--- a/pyodide_build/tests/conftest.py
+++ b/pyodide_build/tests/conftest.py
@@ -103,10 +103,14 @@ def dummy_xbuildenv(
 
     xbuildenv_dir = tmp_path / xbuildenv_dirname()
 
+    from pyodide_build.build_env import get_host_build_flag
+
+    original_get_host_build_flag = get_host_build_flag
+
     def mock_get_host_build_flag(flag_name):
         if flag_name == "PYODIDE_XBUILDENV_PATH":
             return str(xbuildenv_dir)
-        return ""
+        return original_get_host_build_flag(flag_name)
 
     monkeypatch.setattr(
         "pyodide_build.build_env.get_host_build_flag", mock_get_host_build_flag

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -218,7 +218,7 @@ def test_default_xbuildenv_path_relative_config(reset_cache, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Test only runs on Linux")
-def test_default_xbuildenv_path_xdg_cache_home(tmp_path, monkeypatch):
+def test_default_xbuildenv_path_xdg_cache_home(tmp_path, reset_cache, monkeypatch):
     """Test XDG_CACHE_HOME on Linux."""
 
     os.environ.pop("XDG_CACHE_HOME", None)
@@ -244,7 +244,7 @@ def test_default_xbuildenv_path_xdg_cache_home(tmp_path, monkeypatch):
     assert default_xbuildenv_path() == Path.cwd() / dirname
 
 
-def test_config_with_pyproject_toml(tmp_path, monkeypatch):
+def test_config_with_pyproject_toml(tmp_path, reset_cache, monkeypatch):
     """Test that xbuildenv_path from pyproject.toml is properly used."""
     # Create a temporary pyproject.toml file
     pyproject_dir = tmp_path / "project"
@@ -289,7 +289,6 @@ def test_config_full_precedence(tmp_path, reset_cache, monkeypatch):
 
     # 2. set environment variable and verify it takes precedence
     monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(env_var_path))
-
     reset_cache()
 
     path = default_xbuildenv_path()

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -182,16 +182,6 @@ def test_default_xbuildenv_path_default(monkeypatch):
     assert default_xbuildenv_path() == expected_path
 
 
-def test_default_xbuildenv_path_env_var_takes_precedence(
-    tmp_path, reset_cache, monkeypatch
-):
-    custom_path = tmp_path / "custom" / "path"
-
-    monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(custom_path))
-
-    assert default_xbuildenv_path() == custom_path
-
-
 def test_default_xbuildenv_path_from_config(tmp_path, monkeypatch):
     """Test that the path is correctly read from the ConfigManager."""
 
@@ -273,30 +263,3 @@ xbuildenv_path = "{xbuildenv_path}"
 
     path = default_xbuildenv_path()
     assert path == xbuildenv_path
-
-
-def test_config_full_precedence(tmp_path, reset_cache, monkeypatch):
-    """Test the full precedence order: env var > pyproject.toml > platformdirs."""
-    pyproject_dir = tmp_path / "project"
-    pyproject_dir.mkdir()
-
-    env_var_path = tmp_path / "env-var-path"
-    pyproject_path_value = pyproject_dir / "pyproject-path"
-
-    mock_config_manager = MockConfigManager(
-        {"xbuildenv_path": str(pyproject_path_value)}
-    )
-    monkeypatch.setattr(
-        "pyodide_build.config.ConfigManager", lambda: mock_config_manager
-    )
-
-    # 1. test using pyodide config when no env var is set
-    path = default_xbuildenv_path()
-    assert path == pyproject_path_value
-
-    # 2. set environment variable and verify it takes precedence
-    monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(env_var_path))
-    reset_cache()
-
-    path = default_xbuildenv_path()
-    assert path == env_var_path

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -232,8 +232,13 @@ def test_default_xbuildenv_path_xdg_cache_home(tmp_path, reset_cache, monkeypatc
 
     assert default_xbuildenv_path() == Path(platformdirs.user_cache_dir()) / dirname
 
+    reset_cache()
+
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
     assert default_xbuildenv_path() == tmp_path / dirname
+
+    reset_cache()
 
     not_writeable_path = tmp_path / "not_writeable"
     not_writeable_path.mkdir()
@@ -242,6 +247,8 @@ def test_default_xbuildenv_path_xdg_cache_home(tmp_path, reset_cache, monkeypatc
     monkeypatch.setenv("XDG_CACHE_HOME", str(not_writeable_path))
 
     assert default_xbuildenv_path() == Path.cwd() / dirname
+
+    reset_cache()
 
 
 def test_config_with_pyproject_toml(tmp_path, reset_cache, monkeypatch):

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -20,11 +20,13 @@ class TestConfigManager:
         env = {
             "CMAKE_TOOLCHAIN_FILE": "/path/to/toolchain",
             "MESON_CROSS_FILE": "/path/to/crossfile",
+            "PYODIDE_XBUILDENV_PATH": "/path/to/xbuildenv",
         }
 
         config = config_manager._load_config_from_env(env)
         assert config["cmake_toolchain_file"] == "/path/to/toolchain"
         assert config["meson_cross_file"] == "/path/to/crossfile"
+        assert config["xbuildenv_path"] == "/path/to/xbuildenv"
 
     def test_load_config_from_file(self, tmp_path, reset_env_vars, reset_cache):
         pyproject_file = tmp_path / "pyproject.toml"
@@ -37,6 +39,7 @@ class TestConfigManager:
                                   invalid_flags = "this_should_not_be_parsed"
                                   default_cross_build_env_url = "https://example.com/cross_build_env.tar.gz"
                                   skip_emscripten_version_check = "1"
+                                  xbuildenv_path = "my_custom/xbuildenv_path"
                                   """)
 
         config_manager = ConfigManager()
@@ -48,6 +51,7 @@ class TestConfigManager:
             == "https://example.com/cross_build_env.tar.gz"
         )
         assert config["skip_emscripten_version_check"] == "1"
+        assert config["xbuildenv_path"] == "my_custom/xbuildenv_path"
 
 
 class TestCrossBuildEnvConfigManager_OutOfTree:
@@ -119,11 +123,13 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
         env = {
             "CMAKE_TOOLCHAIN_FILE": "/path/to/toolchain",
             "MESON_CROSS_FILE": "/path/to/crossfile",
+            "PYODIDE_XBUILDENV_PATH": "/path/to/xbuildenv",
         }
 
         config = config_manager._load_config_from_env(env)
         assert config["cmake_toolchain_file"] == "/path/to/toolchain"
         assert config["meson_cross_file"] == "/path/to/crossfile"
+        assert config["xbuildenv_path"] == "/path/to/xbuildenv"
 
     def test_load_config_from_file(
         self, tmp_path, dummy_xbuildenv, reset_env_vars, reset_cache
@@ -142,6 +148,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
                                   rust_toolchain = "nightly"
                                   meson_cross_file = "$(MESON_CROSS_FILE)"
                                   build_dependency_index_url = "https://example.com/simple"
+                                  xbuildenv_path = "../my_custom/xbuildenv_path" # also helps check relative paths
                                   """)
 
         xbuildenv_manager = CrossBuildEnvManager(
@@ -159,6 +166,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
         assert config["rust_toolchain"] == "nightly"
         assert config["meson_cross_file"] == "/path/to/crossfile"
         assert config["build_dependency_index_url"] == "https://example.com/simple"
+        assert config["xbuildenv_path"] == "../my_custom/xbuildenv_path"
 
     def test_config_all(self, dummy_xbuildenv, reset_env_vars, reset_cache):
         xbuildenv_manager = CrossBuildEnvManager(


### PR DESCRIPTION
## Description

This PR closes #114, and is a follow-up to #148 and #154. adds the following:

1. an `--xbuildenv-path` argument to the `pyodide build` CLI that gets passed on to `pyodide xbuildenv install --path`.
2. an `xbuildenv_path` config variable to the `pyodide config` list, so that people can configure a default path under the `[tool.pyodide.build]` table in `pyproject.toml`
3. a `PYODIDE_XBUILDENV_PATH` environment variable that can be used for configuration.

The order of precedence is:
- `PYODIDE_XBUILDENV_PATH`, then
- the value of the `pyodide config get xbuildenv_path` command (supports relative paths as well)
- the default location, i.e., what is defined by `platformdirs` across Linux/macOS devices

Use cases:
- set a persistent xbuildenv path at a fixed location of the user's choice, instead of what is set by `platformdirs`
- use the environment variable to cache the xbuildenv in CI
- and so on

