### PR TITLE
Fix two problems with pyodide venv

### DIFF
--- a/pyodide_build/create_package_index.py
+++ b/pyodide_build/create_package_index.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from textwrap import dedent
+from urllib.parse import urlparse
 
 from pyodide_lock.spec import PackageSpec
 
@@ -84,8 +85,11 @@ def create_package_index(
     for pkgname, pkginfo in packages.items():
         pkgdir = index_dir / pkgname
         filename = pkginfo.file_name
-        shasum = pkginfo.sha256
-        href = f"{dist_url}{filename}#sha256={shasum}"
+        if urlparse(filename).scheme:
+            href = filename
+        else:
+            shasum = pkginfo.sha256
+            href = f"{dist_url}{filename}#sha256={shasum}"
         links_str = f'<a href="{href}">{pkgname}</a>\n'
         files_html = files_template.format(pkgname=pkgname, links=links_str)
 

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -298,7 +298,7 @@ def install_stdlib(venv_bin: Path) -> None:
                 from pyodide_js import loadPackage
                 from pyodide_js._api import lockfile_packages
                 from pyodide_js._api import lockfile_unvendored_stdlibs_and_test
-                shared_libs = [pkgname for (pkgname,pkg) in lockfile_packages.object_entries() if getattr(pkg, "package_type") == "shared_library"]
+                shared_libs = [pkgname for (pkgname,pkg) in lockfile_packages.object_entries() if getattr(pkg, "package_type", None) == "shared_library"]
 
                 to_load = [*lockfile_unvendored_stdlibs_and_test, *shared_libs, *{to_load!r}]
                 loadPackage(to_load);


### PR DESCRIPTION
1. We intended to say `getattr(pkg, "package_type", None) == "shared_library"`
2. If the lock file has a url in the filename field, put the url directly into the simple index.