### PR TITLE
Typer>=0.12.4 supports `Union` types

### DIFF
--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from typing import Optional, cast, get_args
+from typing import cast, get_args
 from urllib.parse import urlparse
 
 import requests
@@ -122,7 +122,7 @@ def source(
 
 # simple 'pyodide build' command
 def main(
-    source_location: Optional[str] = typer.Argument(  # noqa: UP007 typer does not accept list[str] | None yet.
+    source_location: str | None = typer.Argument(
         "",
         help="Build source, can be source folder, pypi version specification, "
         "or url to a source dist archive or wheel file. If this is blank, it "
@@ -164,7 +164,7 @@ def main(
     compression_level: int = typer.Option(
         6, help="Compression level to use for the created zip file"
     ),
-    config_setting: Optional[list[str]] = typer.Option(  # noqa: UP007 typer does not accept list[str] | None yet.
+    config_setting: list[str] | None = typer.Option(
         None,
         "--config-setting",
         "-C",


### PR DESCRIPTION
## Description

See #163. Typer now supports union types post https://github.com/fastapi/typer/pull/548. It turns out that we have a lower bound on `typer`, i.e., we already support `typer>0.13`, so this PR just fixes the type annotations.