### PR TITLE
Test against a minimum version of Pyodide, and document how to update it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
   integration-test:
-    name: integration-test (${{ matrix.task.name }}, ${{ matrix.task.installer }}, ${{ matrix.pyodide-version }}, ${{ matrix.os }})
+    name: integration-test (${{ matrix.task.name }}, ${{ matrix.task.installer }}, ${{ matrix.pyodide-version }}-pyodide, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: [check-integration-test-trigger]
     strategy:
@@ -103,11 +103,16 @@ jobs:
             { name: test-src, installer: uv },
             { name: test-integration-marker, installer: pip }, # installer doesn't matter
           ]
-        pyodide-version: [
-            "minimum",
-            "", # stable
-          ]
         os: [ubuntu-latest, macos-latest]
+        # Run Pyodide minimum version testing only for the pip installer and on Linux
+        include:
+          - task: { name: test-recipe, installer: pip }
+            os: ubuntu-latest
+            pyodide-version: minimum
+          - task: { name: test-src, installer: pip }
+            os: ubuntu-latest
+            pyodide-version: minimum
+
     if: needs.check-integration-test-trigger.outputs.run-integration-test
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   FORCE_COLOR: 3
   # Increase this value to reset cache if emscripten_version has not changed
-  EMSDK_CACHE_FOLDER: 'emsdk-cache'
+  EMSDK_CACHE_FOLDER: "emsdk-cache"
   EMSDK_CACHE_NUMBER: 0
 
 jobs:
@@ -90,18 +90,23 @@ jobs:
           fi
 
   integration-test:
+    name: integration-test (${{ matrix.task.name }}, ${{ matrix.task.installer }}, ${{ matrix.pyodide-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: [check-integration-test-trigger]
     strategy:
       fail-fast: false
       matrix:
         task: [
-          {name: test-recipe, installer: pip},
-          {name: test-src, installer: pip},
-          {name: test-recipe, installer: uv},
-          {name: test-src, installer: uv},
-          {name: test-integration-marker, installer: pip},  # installer doesn't matter
-        ]
+            { name: test-recipe, installer: pip },
+            { name: test-src, installer: pip },
+            { name: test-recipe, installer: uv },
+            { name: test-src, installer: uv },
+            { name: test-integration-marker, installer: pip }, # installer doesn't matter
+          ]
+        pyodide-version: [
+            "minimum",
+            "", # stable
+          ]
         os: [ubuntu-latest, macos-latest]
     if: needs.check-integration-test-trigger.outputs.run-integration-test
     steps:
@@ -127,7 +132,13 @@ jobs:
 
       - name: Install xbuildenv
         run: |
-          pyodide xbuildenv install
+          if [[ "${{ matrix.pyodide-version }}" == "minimum" ]]; then
+            MIN_VERSION=$(pyodide xbuildenv search --json | jq -r '.environments | sort_by(.version) | .[0].version')
+            echo "Installing Pyodide xbuildenv version: $MIN_VERSION"
+            pyodide xbuildenv install $MIN_VERSION
+          else
+            pyodide xbuildenv install
+          fi
           echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
 
       - name: Cache emsdk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,7 @@ jobs:
             { name: test-integration-marker, installer: pip }, # installer doesn't matter
           ]
         os: [ubuntu-latest, macos-latest]
+        pyodide-version: [stable]
         # Run Pyodide minimum version testing only for the pip installer and on Linux
         include:
           - task: { name: test-recipe, installer: pip }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
         if: matrix.task.name == 'test-integration-marker'
         run: pytest --junitxml=test-results/junit.xml --cov=pyodide-build pyodide_build -m "integration"
 
-      - name: Run the recipe integration tests (${{ matrix.task }})
+      - name: Run the recipe integration tests (${{ matrix.task.name }})
         if: matrix.task.name != 'test-integration-marker'
         env:
           PYODIDE_JOBS: ${{ steps.get-cores.outputs.CORES }}

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -596,7 +596,7 @@ class RecipeBuilderPackage(RecipeBuilder):
             )
             if self.build_metadata.cross_build_env:
                 subprocess.run(
-                    ["pip", "install", "-t", str(host_site_packages), f"{name}=={ver}"],
+                    ["pip", "install", "--upgrade", "-t", str(host_site_packages), f"{name}=={ver}"],
                     check=True,
                 )
 

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -596,7 +596,14 @@ class RecipeBuilderPackage(RecipeBuilder):
             )
             if self.build_metadata.cross_build_env:
                 subprocess.run(
-                    ["pip", "install", "--upgrade", "-t", str(host_site_packages), f"{name}=={ver}"],
+                    [
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        "-t",
+                        str(host_site_packages),
+                        f"{name}=={ver}",
+                    ],
                     check=True,
                 )
 

--- a/release.md
+++ b/release.md
@@ -1,0 +1,27 @@
+# pyodide-build release workflow
+
+This document provides maintenance and release instructions for `pyodide-build` project, adapted
+from the [Maintainer information page from the Pyodide project](https://pyodide.org/en/stable/development/maintainers.html)
+
+> [!NOTE]
+> `pyodide-build` is also used as a submodule in-tree within the Pyodide repository, and it is usually acceptable to
+update the submodule to point to a newer commit in most cases and a release isn't always required unless it's needed
+to address bugs or add features for out-of-tree builds.
+>
+> See the [Updating `pyodide-build](https://pyodide.org/en/stable/development/maintainers.html#updating-pyodide-build) for more information.
+
+# Release instructions
+
+- First, create a "Release planning" tracking issue that can list information such as:
+    - the timeline of the release
+    - the scope of the release and the pull requests to be included, ideally by attaching a milestone to them or creating one through the GitHub Issues UI if it doesn't exist
+    - any other relevant resources
+
+- Once a consensus is reached on the release plan, create a new milestone in the GitHub Issues UI. This milestone should have the same name as the release version (e.g., `v0.23.0`) and should be marked as "open". The milestone should also be assigned to the release planning issue.
+
+- Create a tag with the version number (e.g., `v0.X.Y`) while on the `main` branch, and create and publish a GitHub release with the tag and attach a link to the CHANGELOG. Other release notes can be generated with the "Generate release notes" button, which will add a list of all PRs that were merged with the tag. The release notes can be reviewed and edited as necessary at the time of creating the release or edited after it is created.
+
+- If backward-incompatible changes are introduced:
+    - the release notes should be updated to include a "Breaking changes" section, if not already present through the CHANGELOG.
+    - we also test against a minimum version of Pyodide xbuildenvs in the integration tests in `main.yml`. If a new minimum version
+    is required, then update it in the [`tools/update_cross_build_releases.py`](https://github.com/pyodide/pyodide/blob/74bd69b5afa00074580f16a72eae3d7ce5a0817a/tools/update_cross_build_releases.py#L23-L25) file so that cross-build environments metadata for newer versionf of Pyodide will contain the correct minimum and maximum `pyodide-build` versions.

--- a/release.md
+++ b/release.md
@@ -4,9 +4,8 @@ This document provides maintenance and release instructions for `pyodide-build`,
 from the [Maintainer information page from the Pyodide project](https://pyodide.org/en/stable/development/maintainers.html).
 
 > [!NOTE]
-> `pyodide-build` is also used as a submodule in-tree within the Pyodide repository, and it is usually acceptable to
-update the submodule to point to a newer commit in most cases and a release isn't always required unless it's needed
-to address bugs or add features for out-of-tree builds.
+> `pyodide-build` is used as a git submodule by the Pyodide repository. If a change is only required for in-tree builds,
+it is sufficient to update the git submodule. A release is only necessary if the changes are required by out-of-tree builds.
 >
 > See the [Updating `pyodide-build`](https://pyodide.org/en/stable/development/maintainers.html#updating-pyodide-build) section for more information.
 

--- a/release.md
+++ b/release.md
@@ -11,14 +11,11 @@ it is sufficient to update the git submodule. A release is only necessary if the
 
 # Release instructions
 
-- First, create a "Release planning" tracking issue that can list information such as:
-    - the timeline of the release
-    - the scope of the release and the pull requests to be included, ideally by attaching a milestone to them or creating one through the GitHub Issues UI if it doesn't exist
-    - any other relevant resources
+- Decide on a new version number: we follow the [SemVer](https://semver.org/) versioning scheme; which means that we create major/minor versions for feature releases and micro/patch versions for bug fixes. The package uses [Semantic Versioning](https://semver.org/) for versioning. The version number is defined in the `pyproject.toml` file in the root of the repository.
 
-- Once a consensus is reached on the release plan, create a new milestone in the GitHub Issues UI. This milestone should have the same name as the release version (e.g., `v0.23.0`) and should be marked as "open". The milestone should also be assigned to the release planning issue.
+- If there is a compelling reason to discuss or plan a new release before creating it (what is to be included, timeline, planned scope, etc.), open a new "Release planning" tracking issue with the information and any other relevant resources. Optionally, a new milestone for the release can also be created. This is not strictly necessary, but it can help to keep track of the issues and PRs that are planned to be included.
 
-- Create a tag with the version number (e.g., `v0.X.Y`) while on the `main` branch, and create and publish a GitHub release with the tag and attach a link to the CHANGELOG. Other release notes can be generated with the "Generate release notes" button, which will add a list of all PRs that were merged with the tag. The release notes can be reviewed and edited as necessary at the time of creating the release or edited after it is created.
+- Create a tag with the version number (e.g., `v0.X.Y`) while on the `main` branch, and create and publish a GitHub release with the tag and attach a link to the CHANGELOG. Other release notes can be generated with the "Generate release notes" button in the GitHub UI, which will add a list of all PRs that were merged with the tag. The release notes can be reviewed and edited as necessary at the time of creating the release or edited after it is created. The release notes from the previous releases can be used for reference and inspiration.
 
 - If backward-incompatible changes are introduced:
     - the release notes should be updated to include a "Breaking changes" section, if not already present through the CHANGELOG.

--- a/release.md
+++ b/release.md
@@ -17,7 +17,10 @@ it is sufficient to update the git submodule. A release is only necessary if the
 
 - Create a tag with the version number (e.g., `v0.X.Y`) while on the `main` branch, and create and publish a GitHub release with the tag and attach a link to the CHANGELOG. Other release notes can be generated with the "Generate release notes" button in the GitHub UI, which will add a list of all PRs that were merged with the tag. The release notes can be reviewed and edited as necessary at the time of creating the release or edited after it is created. The release notes from the previous releases can be used for reference and inspiration.
 
-- If backward-incompatible changes are introduced:
+- If the release is introducing breaking changes are introduced that will not be compatible with cross-build environments for older versions of Pyodide:
     - the release notes should be updated to include a "Breaking changes" section, if not already present through the CHANGELOG.
     - we also test against a minimum version of Pyodide xbuildenvs in the integration tests in `main.yml`. If a new minimum version
-    is required, then update it in the [`tools/update_cross_build_releases.py`](https://github.com/pyodide/pyodide/blob/74bd69b5afa00074580f16a72eae3d7ce5a0817a/tools/update_cross_build_releases.py#L23-L25) file so that cross-build environments metadata for newer versions of Pyodide will contain the correct minimum and maximum versions of `pyodide-build` they can be used with.
+    is required, then:
+        - update the value of the `MIN_COMPATIBLE_PYODIDE_BUILD_VERSION` variable in the [`tools/update_cross_build_releases.py`](https://github.com/pyodide/pyodide/blob/74bd69b5afa00074580f16a72eae3d7ce5a0817a/tools/update_cross_build_releases.py#L23-L25) file, and
+        - update the `maximum_pyodide_build_version` variable accordingly in the [`pyodide-cross-build-environments.json`](https://github.com/pyodide/pyodide/blob/bc82c83c27527a8e384474df880be6a290fcfbb1/pyodide-cross-build-environments.json) file,
+    so that the cross-build environments metadata for newer versions of Pyodide will contain the correct minimum and maximum versions of `pyodide-build` they can be used with.

--- a/release.md
+++ b/release.md
@@ -1,14 +1,14 @@
-# pyodide-build release workflow
+# `pyodide-build` release workflow
 
-This document provides maintenance and release instructions for `pyodide-build` project, adapted
-from the [Maintainer information page from the Pyodide project](https://pyodide.org/en/stable/development/maintainers.html)
+This document provides maintenance and release instructions for `pyodide-build`, adapted
+from the [Maintainer information page from the Pyodide project](https://pyodide.org/en/stable/development/maintainers.html).
 
 > [!NOTE]
 > `pyodide-build` is also used as a submodule in-tree within the Pyodide repository, and it is usually acceptable to
 update the submodule to point to a newer commit in most cases and a release isn't always required unless it's needed
 to address bugs or add features for out-of-tree builds.
 >
-> See the [Updating `pyodide-build](https://pyodide.org/en/stable/development/maintainers.html#updating-pyodide-build) for more information.
+> See the [Updating `pyodide-build`](https://pyodide.org/en/stable/development/maintainers.html#updating-pyodide-build) section for more information.
 
 # Release instructions
 
@@ -24,4 +24,4 @@ to address bugs or add features for out-of-tree builds.
 - If backward-incompatible changes are introduced:
     - the release notes should be updated to include a "Breaking changes" section, if not already present through the CHANGELOG.
     - we also test against a minimum version of Pyodide xbuildenvs in the integration tests in `main.yml`. If a new minimum version
-    is required, then update it in the [`tools/update_cross_build_releases.py`](https://github.com/pyodide/pyodide/blob/74bd69b5afa00074580f16a72eae3d7ce5a0817a/tools/update_cross_build_releases.py#L23-L25) file so that cross-build environments metadata for newer versionf of Pyodide will contain the correct minimum and maximum `pyodide-build` versions.
+    is required, then update it in the [`tools/update_cross_build_releases.py`](https://github.com/pyodide/pyodide/blob/74bd69b5afa00074580f16a72eae3d7ce5a0817a/tools/update_cross_build_releases.py#L23-L25) file so that cross-build environments metadata for newer versions of Pyodide will contain the correct minimum and maximum versions of `pyodide-build` they can be used with.


### PR DESCRIPTION
## Description

Closes #149. This PR adds two new jobs in the CI matrix for recipe and src tests, respectively, that run against a minimum supported version of Pyodide that we specify in [the `pyodide-cross-build-environments.json` file](https://github.com/pyodide/pyodide/blob/74bd69b5afa00074580f16a72eae3d7ce5a0817a/pyodide-cross-build-environments.json). These run only on Linux for now. The result is that haven't broken compatibility with Pyodide 0.26 xbuildenvs so far.

Brief instructions have also been added to address breaking changes upstream in the Pyodide repository, coupled with general release instructions.