### PR TITLE
Ignore `-headerpad_max_install_names` and `-dead_strip_dylibs` for `wasm-ld`

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -188,6 +188,9 @@ def replay_genargs_handle_linker_opts(arg: str) -> str | None:
             # wasm-ld does not recognize some link flags
             "--sort-common",
             "--as-needed",
+            # macOS-specific linker flags that wasm-ld doesn't understand
+            "-headerpad_max_install_names",
+            "-dead_strip_dylibs",
         ]:
             continue
 


### PR DESCRIPTION
## Description

These arguments are inserted by Meson when compiling on a macOS machine on a few occasions; see numpy/numpy#28642 for greater discussion. This PR filters them out, as `wasm-ld` raises errors if it sees them.

This PR does not address the original issue, i.e., as to why Meson adds these arguments. The apparent cause is the use of shared libraries, `libopenblas.so` in this case + the fact that we are "mocking" cross compilation in a way through pywasmcross and therefore Meson isn't smart enough to not add them. This PR is not strictly required; however, this PR is useful in its own right, as it helps compilation succeed on macOS on some occasions.

## Reference

https://manp.gs/mac/1/ld#dead_strip_dylibs
https://manp.gs/mac/1/ld#headerpad_max_install_names

## PR stack

Please review the following PRs in the order listed below:

- https://github.com/pyodide/pyodide-build/pull/168 ➡️ **you are here**
- https://github.com/pyodide/pyodide-build/pull/213 
- https://github.com/pyodide/pyodide-recipes/pull/140
- https://github.com/pyodide/pyodide-recipes/pull/141 