### PR TITLE
Relax `pyodide-cli` constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "MPL-2.0"}
 requires-python = ">=3.12"
 dependencies = [
     "build~=1.2.0",
-    "pyodide-cli~=0.2.1",
+    "pyodide-cli!=0.2.1,>=0.3.0",
     "pyodide-lock==0.1.0a7",
     "auditwheel-emscripten==0.1.0",
     "pydantic>=2,<3",


### PR DESCRIPTION
## Description

See https://github.com/pyodide/pyodide-build/issues/163#issuecomment-2772523259. I've kept it unpinned as `pyodide-cli` is not updated often. Please feel free to change it if needed!
