### PR TITLE
Revert #144 for now

### DIFF
--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -234,19 +234,9 @@ def create_pip_script(venv_bin):
         pip.unlink(missing_ok=True)
         pip.symlink_to(pip_path)
 
-    # We used to use a symlink here, but getpath.py failed when used with uv
-    # python. So now we do this instead.
-    host_python_path.write_text(
-        dedent(
-            f"""\
-            #!/bin/sh
-            exec {sys.executable} $@
-            """
-        )
-    )
-    host_python_path.chmod(0o777)
+    host_python_path.symlink_to(sys.executable)
     # in case someone needs a Python-version-agnostic way to refer to python-host
-    (venv_bin / "python-host").symlink_to(host_python_path)
+    (venv_bin / "python-host").symlink_to(sys.executable)
 
     pip_path.write_text(
         # Other than the shebang and the monkey patch, this is exactly what


### PR DESCRIPTION
This reverts commit 8c92fb9c7c486f3add2db65ab5f73aa4075efd98.

This venv was broken in https://github.com/pyodide/pyodide-build/pull/144, but the breakage wasn't noticed there, as the Pyodide venv tests are only executed with `[integration]` and the integration tests didn't run.

This PR temporarily reverts the change. The key issue as pointed out by Hood below is that we get a `OSError: [Errno 8] Exec format error:` – the approach fails because CPython's virtual environment mechanism requires the interpreter to be a symlink, as it uses realpath operations on the executable path to detect the venv's folder structure and locate the `pyvenv.cfg` file. Replacing the symlink with an exec-based script disrupts this detection process when executing `pip`, and we cannot cannot handle the nested shebang resolution required by the script chain.

The relevant error logs are as follows:

<details>
<summary>Details</summary>

```
____________________________ test_pip_install[pure] ____________________________

base_test_dir = PosixPath('/private/var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/pytest-of-runner/pytest-0/pyodide_test_base')
packages = ['six']

    @pytest.mark.integration
    @pytest.mark.parametrize(
        "packages",
        [
            ["six"],  # pure
            ["numpy"],  # compiled
            ["six", "numpy"],  # mixed
        ],
        ids=["pure", "compiled", "both-pure-and-compiled"],
    )
    def test_pip_install(base_test_dir, packages):
        """Test that our monkeypatched pip can install packages into the venv"""
        venv_path = base_test_dir / "test_venv"
    
        venv.create_pyodide_venv(venv_path, [])
        venv_pip_path = venv_path / "bin" / "pip"
        assert venv_pip_path.exists(), "pip wasn't found in the virtual environment"
    
        for package in packages:
>           result = subprocess.run(
                [
                    str(venv_pip_path),
                    "install",
                    package,
                    "-v",
                    "--disable-pip-version-check",
                ],
                capture_output=True,
                text=True,
                check=False,
            )

pyodide_build/tests/test_venv.py:205: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py:[55](https://github.com/pyodide/pyodide-build/actions/runs/14323333032/job/40144265462#step:10:56)0: in run
    with Popen(*popenargs, **kwargs) as process:
/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py:1028: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Popen: returncode: 255 args: ['/private/var/folders/qn/7t0vq3ts721cmgt0tgrt...>
args = ['/private/var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/pytest-of-runner/pytest-0/pyodide_test_base/test_venv/bin/pip', 'install', 'six', '-v', '--disable-pip-version-check']
executable = b'/private/var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/pytest-of-runner/pytest-0/pyodide_test_base/test_venv/bin/pip'
preexec_fn = None, close_fds = True, pass_fds = (), cwd = None, env = None
startupinfo = None, creationflags = 0, shell = False, p2cread = -1
p2cwrite = -1, c2pread = 14, c2pwrite = 15, errread = 16, errwrite = 17
restore_signals = True, gid = None, gids = None, uid = None, umask = -1
start_new_session = False, process_group = -1

    def _execute_child(self, args, executable, preexec_fn, close_fds,
                       pass_fds, cwd, env,
                       startupinfo, creationflags, shell,
                       p2cread, p2cwrite,
                       c2pread, c2pwrite,
                       errread, errwrite,
                       restore_signals,
                       gid, gids, uid, umask,
                       start_new_session, process_group):
        """Execute program (POSIX version)"""
    
        if isinstance(args, (str, bytes)):
            args = [args]
        elif isinstance(args, os.PathLike):
            if shell:
                raise TypeError('path-like args is not allowed when '
                                'shell is true')
            args = [args]
        else:
            args = list(args)
    
        if shell:
            # On Android the default shell is at '/system/bin/sh'.
            unix_shell = ('/system/bin/sh' if
                      hasattr(sys, 'getandroidapilevel') else '/bin/sh')
            args = [unix_shell, "-c"] + args
            if executable:
                args[0] = executable
    
        if executable is None:
            executable = args[0]
    
        sys.audit("subprocess.Popen", executable, args, cwd, env)
    
        if (_USE_POSIX_SPAWN
                and os.path.dirname(executable)
                and preexec_fn is None
                and not close_fds
                and not pass_fds
                and cwd is None
                and (p2cread == -1 or p2cread > 2)
                and (c2pwrite == -1 or c2pwrite > 2)
                and (errwrite == -1 or errwrite > 2)
                and not start_new_session
                and process_group == -1
                and gid is None
                and gids is None
                and uid is None
                and umask < 0):
            self._posix_spawn(args, executable, env, restore_signals,
                              p2cread, p2cwrite,
                              c2pread, c2pwrite,
                              errread, errwrite)
            return
    
        orig_executable = executable
    
        # For transferring possible exec failure from child to parent.
        # Data format: "exception name:hex errno:description"
        # Pickle is not used; it is complex and involves memory allocation.
        errpipe_read, errpipe_write = os.pipe()
        # errpipe_write must not be in the standard io 0, 1, or 2 fd range.
        low_fds_to_close = []
        while errpipe_write < 3:
            low_fds_to_close.append(errpipe_write)
            errpipe_write = os.dup(errpipe_write)
        for low_fd in low_fds_to_close:
            os.close(low_fd)
        try:
            try:
                # We must avoid complex work that could involve
                # malloc or free in the child process to avoid
                # potential deadlocks, thus we do all this here.
                # and pass it to fork_exec()
    
                if env is not None:
                    env_list = []
                    for k, v in env.items():
                        k = os.fsencode(k)
                        if b'=' in k:
                            raise ValueError("illegal environment variable name")
                        env_list.append(k + b'=' + os.fsencode(v))
                else:
                    env_list = None  # Use execv instead of execve.
                executable = os.fsencode(executable)
                if os.path.dirname(executable):
                    executable_list = (executable,)
                else:
                    # This matches the behavior of os._execvpe().
                    executable_list = tuple(
                        os.path.join(os.fsencode(dir), executable)
                        for dir in os.get_exec_path(env))
                fds_to_keep = set(pass_fds)
                fds_to_keep.add(errpipe_write)
                self.pid = _fork_exec(
                        args, executable_list,
                        close_fds, tuple(sorted(map(int, fds_to_keep))),
                        cwd, env_list,
                        p2cread, p2cwrite, c2pread, c2pwrite,
                        errread, errwrite,
                        errpipe_read, errpipe_write,
                        restore_signals, start_new_session,
                        process_group, gid, gids, uid, umask,
                        preexec_fn, _USE_VFORK)
                self._child_created = True
            finally:
                # be sure the FD is closed no matter what
                os.close(errpipe_write)
    
            self._close_pipe_fds(p2cread, p2cwrite,
                                 c2pread, c2pwrite,
                                 errread, errwrite)
    
            # Wait for exec to fail or succeed; possibly raising an
            # exception (limited in size)
            errpipe_data = bytearray()
            while True:
                part = os.read(errpipe_read, 50000)
                errpipe_data += part
                if not part or len(errpipe_data) > 50000:
                    break
        finally:
            # be sure the FD is closed no matter what
            os.close(errpipe_read)
    
        if errpipe_data:
            try:
                pid, sts = os.waitpid(self.pid, 0)
                if pid == self.pid:
                    self._handle_exitstatus(sts)
                else:
                    self.returncode = sys.maxsize
            except ChildProcessError:
                pass
    
            try:
                exception_name, hex_errno, err_msg = (
                        errpipe_data.split(b':', 2))
                # The encoding here should match the encoding
                # written in by the subprocess implementations
                # like _posixsubprocess
                err_msg = err_msg.decode()
            except ValueError:
                exception_name = b'SubprocessError'
                hex_errno = b'0'
                err_msg = 'Bad exception data from child: {!r}'.format(
                              bytes(errpipe_data))
            child_exception_type = getattr(
                    builtins, exception_name.decode('ascii'),
                    SubprocessError)
            if issubclass(child_exception_type, OSError) and hex_errno:
                errno_num = int(hex_errno, 16)
                if err_msg == "noexec:chdir":
                    err_msg = ""
                    # The error must be from chdir(cwd).
                    err_filename = cwd
                elif err_msg == "noexec":
                    err_msg = ""
                    err_filename = None
                else:
                    err_filename = orig_executable
                if errno_num != 0:
                    err_msg = os.strerror(errno_num)
                if err_filename is not None:
>                   raise child_exception_type(errno_num, err_msg, err_filename)
E                   OSError: [Errno 8] Exec format error: '/private/var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/pytest-of-runner/pytest-0/pyodide_test_base/test_venv/bin/pip'

/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py:19[63](https://github.com/pyodide/pyodide-build/actions/runs/14323333032/job/40144265462#step:10:64): OSError
----------------------------- Captured stdout call -----------------------------
Creating Pyodide virtualenv at                                                  
/private/var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/pytest-of-runner/pytest
-0/pyodide_test_base/test_venv                                                  
... Configuring virtualenv                                                      
... Installing standard library                                                 
Successfully created Pyodide virtual environment!
```

</details>

as noticed in https://github.com/pyodide/pyodide-build/actions/runs/14323333032/job/40144265462.

cc: @hoodmane