### PR TITLE
Use external Node.js via PyPI wheels 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,11 +37,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Set up Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version: "20"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -128,11 +123,6 @@ jobs:
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: "3.12"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version: "20"
 
       - name: Install the package
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "ruamel.yaml",
     "packaging",
     "virtualenv",
+    "nodejs-wheel",
     "requests",
     "typer>=0.13",
     "rich",


### PR DESCRIPTION
## Description

This PR swaps out our Node.js dependency by including the (unofficial) binaries from PyPI: https://github.com/njzjz/nodejs-wheel. This means that `pyodide venv`'s Python interpreter should no longer need to rely on an Node.js installation.

Closes #119


