### PR TITLE
Fix regression in cross build package installation

### DIFF
--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -605,7 +605,29 @@ class RecipeBuilderPackage(RecipeBuilder):
                     [
                         "pip",
                         "install",
+                        # Upgrade the package in the host environment if there is a
+                        # older or newer version of the package already installed.
+                        # However, we don't want to replace the dependencies of the package,
+                        # since they may contain cross-build files as well.
+                        # For instance, numpy and scipy are both cross-build packages, but scipy depends on numpy.
+                        # Therefore, if we install numpy first and then scipy, installing scipy
+                        # will overwrite the cross build files in numpy.
                         "--upgrade",
+                        "--no-deps",
+                        "-t",
+                        str(host_site_packages),
+                        f"{name}=={ver}",
+                    ],
+                    check=True,
+                )
+
+                # Call the same pip command again to install the dependencies
+                # but without the --upgrade flag. This will prevent pip from
+                # overwriting the dependencies in the host environment.
+                subprocess.run(
+                    [
+                        "pip",
+                        "install",
                         "-t",
                         str(host_site_packages),
                         f"{name}=={ver}",


### PR DESCRIPTION
This fixes a bug that cross build packages were not correctly installed in the hostsitepackages. It was introduced in #167.

```
/tmp/build-env-gqqhqr9x/lib/python3.13/site-packages/numpy/_core/include/../lib/
libnpymath.a: archive member 'meson-generated_ieee754.c.o' is neither Wasm      
object file nor LLVM bitcode    
```

Think about this scenario:

1. We are building statsmodels (that depends on scipy) in-tree.
2. numpy is built first, as it is a dependency of scipy.
3. numpy is built. After the build, the cross build files of numpy are installed in hostsitepackages.
4. scipy is built, After the build, the cross build files of scipy are installed in hostsitepackages.
  4.a. Becuase of the `--upgrade` option, installing scipy will trigger numpy installation as well, overwriting the numpy package installed in step 3.
5. numpy in the hostsitepackages now contain native header files and libraries
6. statsmodels try to use numpy during the build step, but it finds native files, rasing an error.