### PR TITLE
Expose pyodide_abi_version, pyodide_root, and python_include_dir in `pyodide config` cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `pyodide config` exposes new variables: `pyodide_root`, `pyodide_abi_version`, and `python_include_dir`
+  [#186](https://github.com/pyodide/pyodide-build/pull/186)
+
 ## [0.30.0] - 2025/04/08
 
 ### Added

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -5,23 +5,9 @@ from pyodide_build.build_env import (
     get_pyodide_root,
     init_environment,
 )
+from pyodide_build.config import PYODIDE_CLI_CONFIGS
 
 app = typer.Typer(help="Manage config variables used in pyodide")
-
-
-# A dictionary of config variables {key: env_var_in_makefile}
-PYODIDE_CONFIGS = {
-    "emscripten_version": "PYODIDE_EMSCRIPTEN_VERSION",
-    "python_version": "PYVERSION",
-    "rustflags": "RUSTFLAGS",
-    "cmake_toolchain_file": "CMAKE_TOOLCHAIN_FILE",
-    "rust_toolchain": "RUST_TOOLCHAIN",
-    "cflags": "SIDE_MODULE_CFLAGS",
-    "cxxflags": "SIDE_MODULE_CXXFLAGS",
-    "ldflags": "SIDE_MODULE_LDFLAGS",
-    "meson_cross_file": "MESON_CROSS_FILE",
-    "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
-}
 
 
 @app.callback(no_args_is_help=True)
@@ -34,7 +20,7 @@ def _get_configs() -> dict[str, str]:
 
     configs: dict[str, str] = get_build_environment_vars(get_pyodide_root())
 
-    configs_filtered = {k: configs[v] for k, v in PYODIDE_CONFIGS.items()}
+    configs_filtered = {k: configs[v] for k, v in PYODIDE_CLI_CONFIGS.items()}
     return configs_filtered
 
 

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -262,3 +262,21 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "host_site_packages": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages",
     "numpy_lib": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/",
 }
+
+
+# A dictionary of config variables that are exposed through pyodide config CLI.
+PYODIDE_CLI_CONFIGS = {
+    "emscripten_version": "PYODIDE_EMSCRIPTEN_VERSION",
+    "python_version": "PYVERSION",
+    "rustflags": "RUSTFLAGS",
+    "cmake_toolchain_file": "CMAKE_TOOLCHAIN_FILE",
+    "rust_toolchain": "RUST_TOOLCHAIN",
+    "cflags": "SIDE_MODULE_CFLAGS",
+    "cxxflags": "SIDE_MODULE_CXXFLAGS",
+    "ldflags": "SIDE_MODULE_LDFLAGS",
+    "meson_cross_file": "MESON_CROSS_FILE",
+    "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
+    "pyodide_abi_version": "PYODIDE_ABI_VERSION",
+    "pyodide_root": "PYODIDE_ROOT",
+    "python_include_dir": "PYTHONINCLUDE",
+}

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -17,6 +17,7 @@ from pyodide_build.cli import (
     py_compile,
     skeleton,
 )
+from pyodide_build.config import PYODIDE_CLI_CONFIGS
 
 runner = CliRunner()
 
@@ -250,11 +251,11 @@ def test_config_list(dummy_xbuildenv):
     envs = result.stdout.splitlines()
     keys = [env.split("=")[0] for env in envs]
 
-    for cfg_name in config.PYODIDE_CONFIGS.keys():
+    for cfg_name in PYODIDE_CLI_CONFIGS:
         assert cfg_name in keys
 
 
-@pytest.mark.parametrize("cfg_name,env_var", config.PYODIDE_CONFIGS.items())
+@pytest.mark.parametrize("cfg_name,env_var", PYODIDE_CLI_CONFIGS.items())
 def test_config_get(cfg_name, env_var, dummy_xbuildenv):
     result = runner.invoke(
         config.app,

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -1,8 +1,10 @@
 from pyodide_build import common
 from pyodide_build.config import (
     BUILD_KEY_TO_VAR,
+    BUILD_VAR_TO_KEY,
     DEFAULT_CONFIG,
     DEFAULT_CONFIG_COMPUTED,
+    PYODIDE_CLI_CONFIGS,
     ConfigManager,
     CrossBuildEnvConfigManager,
 )
@@ -190,3 +192,10 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
         env = config_manager.to_env()
         for env_var in BUILD_KEY_TO_VAR.values():
             assert env_var in env
+
+
+def test_cli_config_subset():
+    for value in PYODIDE_CLI_CONFIGS.values():
+        assert value in BUILD_VAR_TO_KEY, (
+            f"All cli config values should be in build var to key mapping, but {value} is not"
+        )


### PR DESCRIPTION
This PR exposes three new variables in pyodide config CLI. I think they are useful in package builds.

- pyodide_root: We can use it when we need to access some of the files in the xbuildenv.
- pyodide_abi_version: As it is going to be used in PEP 783, I think it is good to expose it in cli.
- python_include_dir: It can be used in some packages that do not follow PEP517 (e.g. [RobotRaconteur](https://github.com/pyodide/pyodide/blob/aa8a92abe7772202460615fa98c996265a8582e0/packages/RobotRaconteur/meta.yaml#L30C28-L30C42))