### PR TITLE
Allow overriding the list of avoided build requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `pyodide config` exposes new variables: `pyodide_root`, `pyodide_abi_version`, and `python_include_dir`
-  [#186](https://github.com/pyodide/pyodide-build/pull/186)
+- `pyodide config` exposes new variables: `pyodide_root`, `pyodide_abi_version`, and `python_include_dir`,
+  and `ignored_build_requirements`.
+  [#186](https://github.com/pyodide/pyodide-build/pull/186) and [#187](https://github.com/pyodide/pyodide-build/pull/187)
 
 ## [0.30.0] - 2025/04/08
 
 ### Added
 
-- Added basic support for uv. `uv tool install pyodide-cli --with pyodide-build`, or
-  `uvx --from pyodide-cli --with pyodide-build pyodide --help`, or using `pyodide-build`
-  in `uv`-managed virtual environments will now work.
+- Added basic support for uv. `uv tool install pyodide-cli --with pyodide-build`, or `uvx --from pyodide-cli --with pyodide-build pyodide --help`, or using `pyodide-build` in `uv`-managed virtual environments will now work.
   [#132](https://github.com/pyodide/pyodide-build/pull/132)
 
 - `pyodide build` now takes an additional `--xbuildenv-path` argument and corresponding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added basic support for uv. `uv tool install pyodide-cli --with pyodide-build`, or `uvx --from pyodide-cli --with pyodide-build pyodide --help`, or using `pyodide-build` in `uv`-managed virtual environments will now work.
+- Added basic support for uv. `uv tool install pyodide-cli --with pyodide-build`, or
+  `uvx --from pyodide-cli --with pyodide-build pyodide --help`, or using `pyodide-build`
+  in `uv`-managed virtual environments will now work.
   [#132](https://github.com/pyodide/pyodide-build/pull/132)
 
 - `pyodide build` now takes an additional `--xbuildenv-path` argument and corresponding

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -32,7 +32,7 @@ def list_config():
     configs = _get_configs()
 
     for k, v in configs.items():
-        typer.echo(f"{k}={v}")
+        typer.echo(f'{k}="{v}"')
 
 
 @app.command("get")

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -10,8 +10,8 @@ from pyodide_build.common import (
     exit_with_stdio,
     search_pyproject_toml,
 )
+from pyodide_build.constants import BASE_IGNORED_REQUIREMENTS
 from pyodide_build.logger import logger
-from pyodide_build.pypabuild import AVOIDED_REQUIREMENTS
 
 
 class ConfigManager:
@@ -200,7 +200,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "build_dependency_index_url": "BUILD_DEPENDENCY_INDEX_URL",
     "default_cross_build_env_url": "DEFAULT_CROSS_BUILD_ENV_URL",
     "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
-    "avoided_build_requirements": "AVOIDED_BUILD_REQUIREMENTS",
+    "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -220,7 +220,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "build_dependency_index_url",
     "default_cross_build_env_url",
     "xbuildenv_path",
-    "avoided_build_requirements",
+    "ignored_build_requirements",
     # maintainer only
     "_f2c_fixes_wrapper",
 }
@@ -242,7 +242,8 @@ DEFAULT_CONFIG: dict[str, str] = {
     "build_dependency_index_url": "https://pypi.anaconda.org/pyodide/simple",
     "default_cross_build_env_url": "",
     "xbuildenv_path": "",
-    "avoided_build_requirements": " ".join(AVOIDED_REQUIREMENTS),
+    # A list of PEP508 build-time requirements to be ignored when building a wheel
+    "ignored_build_requirements": " ".join(BASE_IGNORED_REQUIREMENTS),
     # maintainer only
     "_f2c_fixes_wrapper": "",
 }

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -238,6 +238,7 @@ DEFAULT_CONFIG: dict[str, str] = {
     "rust_toolchain": "nightly-2025-02-01",
     "rust_emscripten_target_url": "",
     # Other configuration
+    "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",
     "build_dependency_index_url": "https://pypi.anaconda.org/pyodide/simple",
     "default_cross_build_env_url": "",

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -11,6 +11,7 @@ from pyodide_build.common import (
     search_pyproject_toml,
 )
 from pyodide_build.logger import logger
+from pyodide_build.pypabuild import AVOIDED_REQUIREMENTS
 
 
 class ConfigManager:
@@ -199,6 +200,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "build_dependency_index_url": "BUILD_DEPENDENCY_INDEX_URL",
     "default_cross_build_env_url": "DEFAULT_CROSS_BUILD_ENV_URL",
     "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
+    "avoided_build_requirements": "AVOIDED_BUILD_REQUIREMENTS",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -218,6 +220,7 @@ OVERRIDABLE_BUILD_KEYS = {
     "build_dependency_index_url",
     "default_cross_build_env_url",
     "xbuildenv_path",
+    "avoided_build_requirements",
     # maintainer only
     "_f2c_fixes_wrapper",
 }
@@ -235,11 +238,11 @@ DEFAULT_CONFIG: dict[str, str] = {
     "rust_toolchain": "nightly-2025-02-01",
     "rust_emscripten_target_url": "",
     # Other configuration
-    "pyodide_jobs": "1",
     "skip_emscripten_version_check": "0",
     "build_dependency_index_url": "https://pypi.anaconda.org/pyodide/simple",
     "default_cross_build_env_url": "",
     "xbuildenv_path": "",
+    "avoided_build_requirements": " ".join(AVOIDED_REQUIREMENTS),
     # maintainer only
     "_f2c_fixes_wrapper": "",
 }

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -284,4 +284,5 @@ PYODIDE_CLI_CONFIGS = {
     "pyodide_abi_version": "PYODIDE_ABI_VERSION",
     "pyodide_root": "PYODIDE_ROOT",
     "python_include_dir": "PYTHONINCLUDE",
+    "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
 }

--- a/pyodide_build/constants.py
+++ b/pyodide_build/constants.py
@@ -1,0 +1,8 @@
+# Some reusable constants that are used at various sources in our code.
+# TODO: collect and add more constants here.
+
+BASE_IGNORED_REQUIREMENTS: list[str] = [
+    # mesonpy installs patchelf in linux platform but we don't want it.
+    "patchelf",
+    "oldest-supported-numpy",
+]

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -17,6 +17,7 @@ from packaging.requirements import Requirement
 from pyodide_build import _f2c_fixes, common, pywasmcross, uv_helper
 from pyodide_build.build_env import (
     get_build_flag,
+    get_host_build_flag,
     get_hostsitepackages,
     get_pyversion,
     get_unisolated_packages,
@@ -36,6 +37,11 @@ AVOIDED_REQUIREMENTS = [
     "patchelf",
     "oldest-supported-numpy",
 ]
+
+AVOIDED_REQUIREMENTS: list[str] = [
+    "patchelf",
+    "oldest-supported-numpy",
+] + get_host_build_flag("AVOIDED_BUILD_REQUIREMENTS").split()
 
 # corresponding env variables for symlinks
 SYMLINK_ENV_VARS = {

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -128,9 +128,9 @@ def remove_avoided_requirements(
 def install_reqs(
     build_env: Mapping[str, str], env: DefaultIsolatedEnv, reqs: set[str]
 ) -> None:
-    IGNORED_BUILD_REQUIREMENTS = [pkg.strip() for pkg in get_host_build_flag(
-        "IGNORED_BUILD_REQUIREMENTS"
-    ).split()]
+    IGNORED_BUILD_REQUIREMENTS = [
+        pkg.strip() for pkg in get_host_build_flag("IGNORED_BUILD_REQUIREMENTS").split()
+    ]
     # propagate PIP config from build_env to current environment
     with common.replace_env(
         os.environ | {k: v for k, v in build_env.items() if k.startswith("PIP")}

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -128,9 +128,9 @@ def remove_avoided_requirements(
 def install_reqs(
     build_env: Mapping[str, str], env: DefaultIsolatedEnv, reqs: set[str]
 ) -> None:
-    IGNORED_BUILD_REQUIREMENTS = get_host_build_flag(
+    IGNORED_BUILD_REQUIREMENTS = [pkg.strip() for pkg in get_host_build_flag(
         "IGNORED_BUILD_REQUIREMENTS"
-    ).split()
+    ).split()]
     # propagate PIP config from build_env to current environment
     with common.replace_env(
         os.environ | {k: v for k, v in build_env.items() if k.startswith("PIP")}

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -42,6 +42,7 @@ class TestConfigManager:
                                   default_cross_build_env_url = "https://example.com/cross_build_env.tar.gz"
                                   skip_emscripten_version_check = "1"
                                   xbuildenv_path = "my_custom/xbuildenv_path"
+                                  ignored_build_requirements = "cmake foo bar"
                                   """)
 
         config_manager = ConfigManager()
@@ -54,6 +55,7 @@ class TestConfigManager:
         )
         assert config["skip_emscripten_version_check"] == "1"
         assert config["xbuildenv_path"] == "my_custom/xbuildenv_path"
+        assert config["ignored_build_requirements"] == "cmake foo bar"
 
 
 class TestCrossBuildEnvConfigManager_OutOfTree:
@@ -126,12 +128,14 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
             "CMAKE_TOOLCHAIN_FILE": "/path/to/toolchain",
             "MESON_CROSS_FILE": "/path/to/crossfile",
             "PYODIDE_XBUILDENV_PATH": "/path/to/xbuildenv",
+            "IGNORED_BUILD_REQUIREMENTS": "cmake foo bar",
         }
 
         config = config_manager._load_config_from_env(env)
         assert config["cmake_toolchain_file"] == "/path/to/toolchain"
         assert config["meson_cross_file"] == "/path/to/crossfile"
         assert config["xbuildenv_path"] == "/path/to/xbuildenv"
+        assert config["ignored_build_requirements"] == "cmake foo bar"
 
     def test_load_config_from_file(
         self, tmp_path, dummy_xbuildenv, reset_env_vars, reset_cache
@@ -151,6 +155,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
                                   meson_cross_file = "$(MESON_CROSS_FILE)"
                                   build_dependency_index_url = "https://example.com/simple"
                                   xbuildenv_path = "../my_custom/xbuildenv_path" # also helps check relative paths
+                                  ignored_build_requirements = "cmake foo bar"
                                   """)
 
         xbuildenv_manager = CrossBuildEnvManager(
@@ -169,6 +174,7 @@ class TestCrossBuildEnvConfigManager_OutOfTree:
         assert config["meson_cross_file"] == "/path/to/crossfile"
         assert config["build_dependency_index_url"] == "https://example.com/simple"
         assert config["xbuildenv_path"] == "../my_custom/xbuildenv_path"
+        assert config["ignored_build_requirements"] == "cmake foo bar"
 
     def test_config_all(self, dummy_xbuildenv, reset_env_vars, reset_cache):
         xbuildenv_manager = CrossBuildEnvManager(

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -27,8 +27,8 @@ def test_install_reqs(tmp_path, dummy_xbuildenv):
     for req in reqs:
         assert req in env.installed
 
-    pypabuild.install_reqs({}, env, set(pypabuild.AVOIDED_REQUIREMENTS))  # type: ignore[arg-type]
-    for req in pypabuild.AVOIDED_REQUIREMENTS:
+    pypabuild.install_reqs({}, env, set(pypabuild.BASE_IGNORED_REQUIREMENTS))  # type: ignore[arg-type]
+    for req in pypabuild.BASE_IGNORED_REQUIREMENTS:
         assert req not in env.installed
 
 

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -1,4 +1,5 @@
 from pyodide_build import pypabuild, pywasmcross
+from pyodide_build.constants import BASE_IGNORED_REQUIREMENTS
 
 
 class MockIsolatedEnv:
@@ -27,8 +28,8 @@ def test_install_reqs(tmp_path, dummy_xbuildenv):
     for req in reqs:
         assert req in env.installed
 
-    pypabuild.install_reqs({}, env, set(pypabuild.BASE_IGNORED_REQUIREMENTS))  # type: ignore[arg-type]
-    for req in pypabuild.BASE_IGNORED_REQUIREMENTS:
+    pypabuild.install_reqs({}, env, set(BASE_IGNORED_REQUIREMENTS))  # type: ignore[arg-type]
+    for req in BASE_IGNORED_REQUIREMENTS:
         assert req not in env.installed
 
 


### PR DESCRIPTION
This PR adds a new configuration variable in `pyodide config` called `ignored_build_requirements`, which accepts whitespace-separated normalised dependency names, which will be ignored during the wheel build procedure. The default value is `"patchelf oldest-supported-numpy"`.

Users may now utilise the `IGNORED_BUILD_REQUIREMENTS` environment variable or the `ignored_build_requirements` value in a `[tool.pyodide.build]` TOML table in `pyproject.toml` to set to a value of their choice, and the `pyodide config get ignored_build_requirements` CLI invocation to retrieve them.

As a by-product of this PR, the `ConfigManager` is now loaded more lazily in order to avoid circular imports across our build pipeline.

Closes #184