### PR TITLE
Allow running integration tests with an "integration" label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,10 +82,13 @@ jobs:
 
           COMMIT_MSG=$(git log --no-merges -1 --oneline)
 
-          # The integration tests will be triggered on push or on pull_request when the commit
-          # message contains "[integration]" or if it is pushed to main branch.
+          # The integration tests will be triggered on push or on pull_request, when:
+          # the commit message contains "[integration]", or
+          # if it is pushed to main branch, or
+          # if the PR has the "integration" label.
           if [[ "$GITHUB_EVENT_NAME" == push && "$GITHUB_REF" == refs/heads/main ||
-                "$COMMIT_MSG" =~ \[integration\] ]]; then
+                "$COMMIT_MSG" =~ \[integration\] ||
+                "${{ contains(github.event.pull_request.labels.*.name, 'integration') }}" == "true" ]]; then
               echo "trigger=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
At the moment, we run the integration tests only when the last the message of the last pushed commit to a PR's branch contains the `[integration]` in its string, and sometimes we might forget to add it, meaning that the integration tests are either not run or that we need to push another commit solely to trigger them again (and sometimes this commit is empty – I frequently do it). This PR makes them run on a persistent basis – the introduced condition will allow us to run them without an explicit commit, and the tests will keep running until the label exists. Removing the label and pushing a subsequent commit will not run them again.