### PR TITLE
Fix virtual environment cli entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixed a regression in `pyodide venv` installation of shell entryppints introduced in
+  [#185](https://github.com/pyodide/pyodide-build/pull/185)
+  [#197](https://github.com/pyodide/pyodide-build/pull/197)
+
 ## [0.30.1] - 2025/04/25
 
 ### Added

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -134,8 +134,11 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         # to return the value with the host suffix removed.
         """
         from pip._vendor.distlib import scripts
+        EXECUTABLE_SUFFIX = "-host-link"
         def get_executable():
-            return sys.executable.removesuffix("-host")
+            if not sys.executable.endswith(EXECUTABLE_SUFFIX):
+                raise RuntimeError(f'Internal Pyodide error: expected sys.executable="{sys.executable}" to end with "{EXECUTABLE_SUFFIX}"')
+            return sys.executable.removesuffix(EXECUTABLE_SUFFIX)
 
         scripts.get_executable = get_executable
 

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -260,6 +260,7 @@ def test_pip_downgrade(base_test_dir):
     assert venv_pip_path.readlink() == venv_pip_path.with_name("pip_patched")
 
 
+@pytest.mark.integration
 def test_pytest_invoke(base_test_dir):
     if platform.system() == "Darwin":
         pytest.skip("TODO: Why doesn't this work on Mac OS?")

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shutil
 import subprocess
 from textwrap import dedent
@@ -260,6 +261,8 @@ def test_pip_downgrade(base_test_dir):
 
 
 def test_pytest_invoke(base_test_dir):
+    if platform.system() == "Darwin":
+        pytest.skip("TODO: Why doesn't this work on Mac OS?")
     venv_path = base_test_dir / "test_venv"
     venv.create_pyodide_venv(venv_path, [])
     pip = venv_path / "bin" / "pip"
@@ -271,7 +274,7 @@ def test_pytest_invoke(base_test_dir):
         ],
         check=True,
     )
-    pytest = venv_path / "bin" / "pytest"
+    venv_pytest = venv_path / "bin" / "pytest"
 
     (base_test_dir / "test_a.py").write_text(
         dedent(
@@ -284,7 +287,7 @@ def test_pytest_invoke(base_test_dir):
         )
     )
     subprocess.run(
-        [pytest, base_test_dir / "test_a.py"],
+        [venv_pytest, base_test_dir / "test_a.py"],
         check=True,
         env=os.environ | {"_PYODIDE_EXTRA_MOUNTS": str(base_test_dir)},
     )


### PR DESCRIPTION
This fixes a regression introduced in #185. `sys.executable` for `pytest` changed value from `python-host` to `python-host-link`.
When we install a cli entrypoint, we need to set the shebang appropriately to `venv/bin/python` not to `venv/bin/python-host-link`.