### PR TITLE
Add 'pyodide config get interpreter'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added `pyodide config get interpreter`.
+  [#199](https://github.com/pyodide/pyodide-build/pull/199)
+
 ## [0.30.2] - 2025/05/05
 
 - Fixed a regression in `pyodide venv` installation of shell entryppints introduced in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Added `pyodide config get interpreter`.
+- Added `interpreter` and `pacakge_index` to the variables available via `pyodide config get`.
   [#199](https://github.com/pyodide/pyodide-build/pull/199)
 
 ## [0.30.2] - 2025/05/05

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -202,7 +202,6 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "default_cross_build_env_url": "DEFAULT_CROSS_BUILD_ENV_URL",
     "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
-    "pyodide_interpreter": "PYODIDE_INTERPRETER",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -268,7 +268,7 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "host_install_dir": "$(PYODIDE_ROOT)/packages/.artifacts",
     "host_site_packages": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages",
     "numpy_lib": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/",
-    "pyodide_interpreter": "$(PYODIDE_ROOT)/dist/python"
+    "pyodide_interpreter": "$(PYODIDE_ROOT)/dist/python",
 }
 
 
@@ -288,5 +288,5 @@ PYODIDE_CLI_CONFIGS = {
     "pyodide_root": "PYODIDE_ROOT",
     "python_include_dir": "PYTHONINCLUDE",
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
-    "interpreter": "PYODIDE_INTERPRETER"
+    "interpreter": "PYODIDE_INTERPRETER",
 }

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -162,7 +162,8 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "host_install_dir": "HOSTINSTALLDIR",
     "host_site_packages": "HOSTSITEPACKAGES",
     "numpy_lib": "NUMPY_LIB",
-    "pyodide_interpreter": "PYODIDE_INTERPETER",
+    "pyodide_interpreter": "PYODIDE_INTERPRETER",
+    "pyodide_package_index": "PYODIDE_PACKAGE_INDEX",
     "platform_triplet": "PLATFORM_TRIPLET",
     "pip_constraint": "PIP_CONSTRAINT",
     "pymajor": "PYMAJOR",
@@ -268,6 +269,7 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "host_site_packages": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages",
     "numpy_lib": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/",
     "pyodide_interpreter": "$(PYODIDE_ROOT)/dist/python",
+    "pyodide_package_index": "$(PYODIDE_ROOT)/package_index",
 }
 
 
@@ -288,4 +290,5 @@ PYODIDE_CLI_CONFIGS = {
     "python_include_dir": "PYTHONINCLUDE",
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
     "interpreter": "PYODIDE_INTERPRETER",
+    "package_index": "PYODIDE_PACKAGE_INDEX",
 }

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -162,6 +162,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "host_install_dir": "HOSTINSTALLDIR",
     "host_site_packages": "HOSTSITEPACKAGES",
     "numpy_lib": "NUMPY_LIB",
+    "pyodide_interpreter": "PYODIDE_INTERPETER",
     "platform_triplet": "PLATFORM_TRIPLET",
     "pip_constraint": "PIP_CONSTRAINT",
     "pymajor": "PYMAJOR",
@@ -201,6 +202,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "default_cross_build_env_url": "DEFAULT_CROSS_BUILD_ENV_URL",
     "xbuildenv_path": "PYODIDE_XBUILDENV_PATH",
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
+    "pyodide_interpreter": "PYODIDE_INTERPRETER",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
 }
@@ -266,6 +268,7 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "host_install_dir": "$(PYODIDE_ROOT)/packages/.artifacts",
     "host_site_packages": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages",
     "numpy_lib": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/",
+    "pyodide_interpreter": "$(PYODIDE_ROOT)/dist/python"
 }
 
 
@@ -285,4 +288,5 @@ PYODIDE_CLI_CONFIGS = {
     "pyodide_root": "PYODIDE_ROOT",
     "python_include_dir": "PYTHONINCLUDE",
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
+    "interpreter": "PYODIDE_INTERPRETER"
 }


### PR DESCRIPTION
Returns the path in the xbuildenv to the interpreter.