### PR TITLE
Update `DEFAULT_CROSS_BUILD_ENV_METADATA_URL` to JSON file from GitHub Pages site

### DIFF
--- a/pyodide_build/xbuildenv_releases.py
+++ b/pyodide_build/xbuildenv_releases.py
@@ -6,7 +6,9 @@ from functools import cache
 from packaging.version import Version
 from pydantic import BaseModel, ConfigDict
 
-DEFAULT_CROSS_BUILD_ENV_METADATA_URL = "https://raw.githubusercontent.com/pyodide/pyodide/main/pyodide-cross-build-environments.json"
+DEFAULT_CROSS_BUILD_ENV_METADATA_URL = (
+    "https://pyodide.github.io/pyodide/api/pyodide-cross-build-environments.json"
+)
 CROSS_BUILD_ENV_METADATA_URL_ENV_VAR = "PYODIDE_CROSS_BUILD_ENV_METADATA_URL"
 
 

--- a/pyodide_build/xbuildenv_releases.py
+++ b/pyodide_build/xbuildenv_releases.py
@@ -216,11 +216,13 @@ def cross_build_env_metadata_url() -> str:
     # This has two purposes:
     # 1. When running tests, we can set this variable to use a local metadata file
     # 2. If we change the URL for the metadata file, people can set this variable to use the new URL
-    url = os.environ.get(CROSS_BUILD_ENV_METADATA_URL_ENV_VAR)
-    if url is not None:
-        return url
 
-    return DEFAULT_CROSS_BUILD_ENV_METADATA_URL
+    url = os.environ.get(
+        key=CROSS_BUILD_ENV_METADATA_URL_ENV_VAR,
+        default=DEFAULT_CROSS_BUILD_ENV_METADATA_URL,
+    )
+
+    return url
 
 
 @cache


### PR DESCRIPTION
This PR is related to #203, pyodide/pyodide#5642, and pypa/cibuildwheel#2002; it updates the `DEFAULT_CROSS_BUILD_ENV_METADATA_URL` to use the JSON file from the GitHub Pages site set up just now, rather than the raw GitHub URL. This is being done in order to circumvent rate limits provisioned by the GitHub API. The next step after this, in a follow-up, would be to cache this even further, so that we don't access the URL repeatedly.

I would like to propose that we create a new 0.30.4 release after this PR. I can do it of course, but I'd like to receive reviews on this, i.e., if this URL seems fine to you, or if I should go back to the Pyodide repo and change it to something else. Thank you! :)

cc: @joerick