### PR TITLE
Stop seeding `wheel` for `pyodide venv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.30.4] - 2025/05/20
 
+- Fixed compatibility with `virtualenv` 20.31 and later. The Pyodide virtual environment via `pyodide venv` no longer seeds
+  `wheel`, i.e., the `--wheel`/`--no-wheel` options are not available anymore.
+  [#208](https://github.com/pyodide/pyodide-build/pull/208)
+
+
 - The default cross-build metadata URL was changed to https://pyodide.github.io/pyodide/api/pyodide-cross-build-environments.json to
   circumvent rate limits imposed by GitHub. It remains overridable by setting the `PYODIDE_CROSS_BUILD_ENV_METADATA_URL` environment variable.
   [#206](https://github.com/pyodide/pyodide-build/pull/206)

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -30,12 +30,12 @@ def main(
         False,
         "--no-download",
         "--never-download",
-        help="Disable download of the latest pip/setuptools/wheel from PyPI",
+        help="Disable download of the latest pip/setuptools from PyPI",
     ),
     download: bool = typer.Option(
         False,
         "--download/--no-download",
-        help="Enable download of the latest pip/setuptools/wheel from PyPI",
+        help="Enable download of the latest pip/setuptools from PyPI",
     ),
     extra_search_dir: list[str] = typer.Option(
         None,
@@ -55,7 +55,6 @@ def main(
     no_setuptools: bool = typer.Option(
         False, "--no-setuptools", help="Do not install setuptools"
     ),
-    no_wheel: bool = typer.Option(True, "--no-wheel", help="Do not install wheel"),
     no_periodic_update: bool = typer.Option(
         False,
         "--no-periodic-update",
@@ -94,8 +93,6 @@ def main(
         venv_args.extend(["--pip", pip])
     if setuptools is not None:
         venv_args.extend(["--setuptools", setuptools])
-    if no_wheel:
-        venv_args.append("--no-wheel")
     if no_setuptools:
         venv_args.append("--no-setuptools")
 

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -26,7 +26,6 @@ SUPPORTED_VIRTUALENV_OPTIONS = [
     "--pip",
     "--setuptools",
     "--no-setuptools",
-    "--no-wheel",
     "--no-periodic-update",
 ]
 

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -52,7 +52,6 @@ def base_test_dir(tmp_path_factory):
         (["--no-vcs-ignore"], ["--no-vcs-ignore"]),
         (["--pip", "23.0.1"], ["--pip", "23.0.1"]),
         (["--no-setuptools"], ["--no-setuptools"]),
-        (["--no-wheel"], ["--no-wheel"]),
         (["--no-periodic-update"], ["--no-periodic-update"]),
         # TODO: enable when they are supported
         # (["--symlink-app-data"], ["--symlink-app-data"]),
@@ -132,7 +131,6 @@ def test_supported_virtualenv_options():
         "--pip",
         "--setuptools",
         "--no-setuptools",
-        "--no-wheel",
         "--no-periodic-update",
     ]
 
@@ -154,9 +152,8 @@ def test_supported_virtualenv_options():
             ["--no-setuptools"],
             lambda path: not list(path.glob("**/setuptools-*.dist-info")),
         ),
-        (["--no-wheel"], lambda path: not list(path.glob("**/wheel-*.dist-info"))),
     ],
-    ids=["default", "clear", "no-vcs-ignore", "no-setuptools", "no-wheel"],
+    ids=["default", "clear", "no-vcs-ignore", "no-setuptools"],
 )
 def test_venv_creation(base_test_dir, options, check_function):
     venv_path = base_test_dir / "test_venv"
@@ -174,7 +171,6 @@ def test_venv_creation(base_test_dir, options, check_function):
     [
         ("pip", "23.0.1"),
         ("setuptools", "67.6.0"),
-        ("wheel", "0.40.0"),
     ],
 )
 def test_installation_of_seed_package_versions(base_test_dir, package, version):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ module = [
   "tomli",
   "tomllib",
   "typer",
-  "virtualenv",
+  "virtualenv>=20.31.2",
   "auditwheel_emscripten.*"
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
The `--wheel`/`--no-wheel` options for were first removed from `pypa/virtualenv` in pypa/virtualenv#2868, added back in pypa/virtualenv#2876, and both PRs were released in https://github.com/pypa/virtualenv/releases/tag/20.31.0. These were then reintroduced in pypa/virtualenv#2884 via https://github.com/pypa/virtualenv/releases/tag/20.31.2, but are present only when using `virtualenv` on Python 3.8 and earlier versions, and don't show up in the CLI `--help` on later versions altogether as there is no effect. As we support Python >=3.12, we should be fine with dropping this option completely. I've also added a minimum bound for `virtualenv`, and we should be fine with dropping the option as I don't think anyone was using it anyway.

I noticed this as some of the integration tests have been failing on `main` and weren't caught because we didn't need to run them on the last few PRs.