### PR TITLE
Fixes temporary file issue on Windows

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -619,8 +619,8 @@ def download_and_unpack_archive(
     #         f"Failed to download cross-build environment from {url} (status code: {r.status_code})"
     #     )
 
-    with NamedTemporaryFile(suffix=".tar") as f:
-        f_path = Path(f.name)
+    with TemporaryDirectory() as temp_dir:
+        f_path = Path(temp_dir) / "temp.tar"
         f_path.write_bytes(data)
         with warnings.catch_warnings():
             # Python 3.12-3.13 emits a DeprecationWarning when using shutil.unpack_archive without a filter,

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -18,7 +18,7 @@ from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from functools import cache
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from typing import Any, NoReturn
 from urllib.request import urlopen
 from zipfile import ZipFile


### PR DESCRIPTION
On Windows we cannot reopen a temp file so we get permission denied errors in this code. This PR resolves this issue.

CC @hoodmane 