### PR TITLE
Fix signatures for function pointers passed through `__Pyx_IsSameCFunction`

### DIFF
--- a/pyodide_build/_f2c_fixes.py
+++ b/pyodide_build/_f2c_fixes.py
@@ -76,6 +76,15 @@ def scipy_fix_cfile(path: Path) -> None:
     text = text.replace("void(*)", "int(*)")
     text = text.replace("static void f2py_setup_", "static int f2py_setup_")
 
+    # Fix Cython-generated function pointer casts for __Pyx_IsSameCFunction
+    # for _matfuncs_sqrtm
+    # TODO: not sure if this is the best place to put this, but it works
+    text = re.sub(
+        r"(__Pyx_IsSameCFunction\([^,]+,\s*)\(int\(\*\)\(void\)\)",
+        r"\1(void(*)(void))",
+        text,
+    )
+
     if path.name.endswith("_flapackmodule.c"):
         text = text.replace(",size_t", "")
         text = re.sub(r",slen\([a-z]*\)\)", ")", text)

--- a/pyodide_build/_f2c_fixes.py
+++ b/pyodide_build/_f2c_fixes.py
@@ -77,8 +77,8 @@ def scipy_fix_cfile(path: Path) -> None:
     text = text.replace("static void f2py_setup_", "static int f2py_setup_")
 
     # Fix Cython-generated function pointer casts for __Pyx_IsSameCFunction
-    # for _matfuncs_sqrtm
-    # TODO: not sure if this is the best place to put this, but it works
+    # for _matfuncs_sqrtm for builds of SciPy 1.16.0.
+    # TODO: I'm not sure if this is the best place to put this, but it works
     text = re.sub(
         r"(__Pyx_IsSameCFunction\([^,]+,\s*)\(int\(\*\)\(void\)\)",
         r"\1(void(*)(void))",

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -188,6 +188,9 @@ def replay_genargs_handle_linker_opts(arg: str) -> str | None:
             # wasm-ld does not recognize some link flags
             "--sort-common",
             "--as-needed",
+            # macOS-specific linker flags that wasm-ld doesn't understand
+            "-headerpad_max_install_names",
+            "-dead_strip_dylibs",
         ]:
             continue
 


### PR DESCRIPTION
## Description

The rationale here is that in C code generated by Cython when compiling SciPy, `__Pyx_IsSameCFunction` usually carries `void` types for extension modules, but we need to cast to `int`s instead. As this phenomenon occurs during the code generation steps where the generated files are not addressable via patches or `sed` commands, we therefore handle it via `scipy_fix_cfile()` here.

> [!TIP]
> This PR builds upon the changes made in #168, and it is the second PR in a series of PRs to build newer versions of SciPy; please review that PR first.

## PR stack

Please review the following PRs in the order listed below:

- https://github.com/pyodide/pyodide-build/pull/168
- https://github.com/pyodide/pyodide-build/pull/213 ➡️ **you are here**
- https://github.com/pyodide/pyodide-recipes/pull/140
- https://github.com/pyodide/pyodide-recipes/pull/141 