### PR TITLE
NFC some perf changes for pywasmcross

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -110,10 +110,7 @@ def replay_genargs_handle_dashl(arg: str, used_libs: set[str], abi: str) -> str 
     """
     assert arg.startswith("-l")
 
-    if arg == "-lffi":
-        return None
-
-    if arg == "-lgfortran":
+    if arg in ("-lffi", "-lgfortran"):
         return None
 
     # Some Emscripten libraries that use setjmp/longjmp.

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -116,7 +116,7 @@ def replay_genargs_handle_dashl(arg: str, used_libs: set[str], abi: str) -> str 
     # Some Emscripten libraries that use setjmp/longjmp.
     # The Emscripten linker should automatically know to use these variants so
     # this shouldn't be necessary.
-    if abi > "2025" and arg in ["-lfreetype", "-lpng"]:
+    if abi > "2025" and arg in ("-lfreetype", "-lpng"):
         arg += "-legacysjlj"
 
     # WASM link doesn't like libraries being included twice

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -8,10 +8,17 @@ with wrappers that adjusting include paths and flags as necessary for
 cross-compiling and then pass the command long to emscripten.
 """
 
+import functools
 import json
 import os
+import re
+import shutil
+import subprocess
 import sys
+import tempfile
+from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import Literal, NamedTuple
 
 from __main__ import __file__ as INVOKED_PATH_STR
 
@@ -55,11 +62,6 @@ if IS_COMPILER_INVOCATION:
     )
     # restore __name__ so that relative imports work as we expect
     __name__ = PYWASMCROSS_ARGS.pop("orig__name__")
-
-
-import subprocess
-from collections.abc import Iterable, Iterator
-from typing import Literal, NamedTuple
 
 
 class CrossCompileArgs(NamedTuple):
@@ -349,8 +351,6 @@ def _calculate_object_exports_readobj_parse(output: str) -> list[str]:
 
 
 def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
-    import shutil
-
     # This works for bootstrapped Emscripten via GitHub sources.
     # llvm-readobj might not be available this way with Homebrew
     # or conda-forge distributions of Emscripten.
@@ -458,8 +458,6 @@ def get_export_flags(
         export_list = exports
 
     prefixed_exports = ["_" + x for x in export_list]
-
-    import tempfile
 
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         # Use a response file to avoid command line length limits

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -145,16 +145,19 @@ def replay_genargs_handle_dashI(arg: str, target_install_dir: str) -> str | None
     """
     assert arg.startswith("-I")
 
+    include_path_str = arg[2:]
+
     # Don't include any system directories
-    if arg[2:].startswith("/usr"):
+    if include_path_str.startswith("/usr"):
         return None
 
     # Replace local Python include paths with the cross compiled ones
-    include_path = str(Path(arg[2:]).resolve())
-    if include_path.startswith(sys.prefix + "/include/python"):
+    include_path = str(Path(include_path_str).resolve())
+
+    if include_path.startswith(SYS_PREFIX_INCLUDE):
         return arg.replace("-I" + sys.prefix, "-I" + target_install_dir)
 
-    if include_path.startswith(sys.base_prefix + "/include/python"):
+    if include_path.startswith(SYS_BASE_PREFIX_INCLUDE):
         return arg.replace("-I" + sys.base_prefix, "-I" + target_install_dir)
 
     return arg

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -270,11 +270,13 @@ def replay_genargs_handle_argument(arg: str) -> str | None:
     return arg
 
 
+@functools.cache
 def get_cmake_compiler_flags() -> list[str]:
     """
-    GeneraTe cmake compiler flags.
+    Generate cmake compiler flags.
     emcmake will set these values to emcc, em++, ...
     but we need to set them to cc, c++, in order to make them pass to pywasmcross.
+
     Returns
     -------
     The commandline flags to pass to cmake.

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -22,7 +22,7 @@ from typing import Literal, NamedTuple
 
 from __main__ import __file__ as INVOKED_PATH_STR
 
-INVOKED_PATH = Path(INVOKED_PATH_STR)
+SHAREDLIB_REGEX = re.compile(r"\.so(.\d+)*$")
 
 SYMLINKS = {
     "cc",
@@ -88,14 +88,7 @@ def is_link_cmd(line: list[str]) -> bool:
     """
     Check if the command is a linker invocation.
     """
-    import re
-
-    SHAREDLIB_REGEX = re.compile(r"\.so(.\d+)*$")
-    for arg in line:
-        if not arg.startswith("-") and SHAREDLIB_REGEX.search(arg):
-            return True
-
-    return False
+    return any(not arg.startswith("-") and SHAREDLIB_REGEX.search(arg) for arg in line)
 
 
 def replay_genargs_handle_dashl(arg: str, used_libs: set[str], abi: str) -> str | None:


### PR DESCRIPTION
Closes #215

A lot of these are very minor changes and are not intended to change the cross-compilation behaviour in any way. I've added in-line comments about them below. The idea is that it's not a bottleneck anywhere, so even if we end up saving 2-5 seconds per compilation, it is a win for us.