### PR TITLE
Exclude bots from release CHANGELOG

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
I recently found out that [GitHub allows configuring how the CHANGELOG is generated](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options), which means that we can exclude @dependabot and @pre-commit-ci from them.