### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ license = {text = "MPL-2.0"}
 requires-python = ">=3.12"
 dependencies = [
     "build~=1.2.0",
-    "pyodide-cli!=0.2.1,>=0.3.0",
-    "pyodide-lock==0.1.0a7",
-    "auditwheel-emscripten==0.1.0",
+    "pyodide-cli>=0.3.0",
+    "pyodide-lock~=0.1.0",
+    "auditwheel-emscripten~=0.2.0",
     "pydantic>=2,<3",
     "wheel",
     "ruamel.yaml",


### PR DESCRIPTION
- pyodide-cli: removed redundant version identifier
- pyodide-lock: relaxed the version restriction
- auditwheel-emscripten: updated version and also relaxed version restriction