### PR TITLE
Install new xbuildenv if existing is for the wrong Python version

### DIFF
--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -86,10 +86,10 @@ def _init_xbuild_env(
     context = redirect_stdout(StringIO()) if quiet else nullcontext()
     with context:
         manager = CrossBuildEnvManager(xbuildenv_path)
-        matches, _ = manager.check_version_marker()
+        matches, _ = manager.version_marker_matches()
         if not matches:
             manager.install()
-        matches, errmsg = manager.check_version_marker()
+        matches, errmsg = manager.version_marker_matches()
         if not matches:
             raise ValueError(errmsg)
 

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -86,10 +86,13 @@ def _init_xbuild_env(
     context = redirect_stdout(StringIO()) if quiet else nullcontext()
     with context:
         manager = CrossBuildEnvManager(xbuildenv_path)
-        if manager.current_version is None:
+        matches, _ = manager.check_version_marker()
+        if not matches:
             manager.install()
+        matches, errmsg = manager.check_version_marker()
+        if not matches:
+            raise ValueError(errmsg)
 
-        manager.check_version_marker()
 
         return manager.pyodide_root
 

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -93,7 +93,6 @@ def _init_xbuild_env(
         if not matches:
             raise ValueError(errmsg)
 
-
         return manager.pyodide_root
 
 

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -390,12 +390,10 @@ class TestCrossBuildEnvManager:
     def test__init_xbuild_env(
         self, monkeypatch, monkeypatch_subprocess_run_pip, tmp_path
     ):
-        build_env._init_xbuild_env(xbuildenv_path=tmp_path)
         manager = CrossBuildEnvManager(tmp_path)
-
         VersionInfo = namedtuple("VersionInfo", ("major", "minor"))
-
         monkeypatch.setattr(sys, "version_info", VersionInfo(3, 13))
+        build_env._init_xbuild_env(xbuildenv_path=tmp_path)
         assert manager.current_version >= "0.28.2"
         monkeypatch.setattr(sys, "version_info", VersionInfo(3, 12))
         build_env._init_xbuild_env(xbuildenv_path=tmp_path)

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -393,13 +393,11 @@ class TestCrossBuildEnvManager:
         build_env._init_xbuild_env(xbuildenv_path=tmp_path)
         manager = CrossBuildEnvManager(tmp_path)
 
-        class VersionInfo:
-            major = 3
-            minor = 13
+        VersionInfo = namedtuple("VersionInfo", ("major", "minor"))
 
-        monkeypatch.setattr(sys, "version_info", VersionInfo)
+        monkeypatch.setattr(sys, "version_info", VersionInfo(3, 13))
         assert manager.current_version >= "0.28.2"
-        VersionInfo.minor = 12
+        monkeypatch.setattr(sys, "version_info", VersionInfo(3, 12))
         build_env._init_xbuild_env(xbuildenv_path=tmp_path)
         assert manager.current_version >= "0.27.7"
 

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -414,23 +414,24 @@ class CrossBuildEnvManager:
         version_file = self.symlink_dir / PYTHON_VERSION_MARKER_FILE
         version_file.write_text(build_env.local_versions()["python"])
 
-    def check_version_marker(self):
+    def version_marker_matches(self) -> tuple[bool, str | None]:
         if not self.symlink_dir.is_dir():
-            raise ValueError("cross-build env directory does not exist")
+            return False, "cross-build env directory does not exist"
 
         version_file = self.symlink_dir / PYTHON_VERSION_MARKER_FILE
         if not version_file.exists():
-            raise ValueError("Python version marker file not found")
+            return False, "Python version marker file not found"
 
         version_local = build_env.local_versions()["python"]
         version_on_install = version_file.read_text().strip()
         if version_on_install != version_local:
-            raise ValueError(
+            return False, (
                 f"local Python version ({version_local}) does not match the Python version ({version_on_install}) "
                 "used to create the Pyodide cross-build environment. "
                 "Please switch back to the original Python version, "
                 "or reinstall the xbuildenv, by running `pyodide xbuildenv uninstall` and then `pyodide xbuildenv install`"
             )
+        return True, None
 
 
 def _url_to_version(url: str) -> str:


### PR DESCRIPTION
There is a confusing behavior where depending on global state, the same command will either succeed or fail. If we run the first time and there is no installed xbuildenv, we will install an appropriate one. However, if we have an existing xbuildenv for the wrong Python version, we fail.

Resolves #238.