### PR TITLE
Use a global pip configuration inside xbuildenv

### DIFF
--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -94,7 +94,7 @@ def create_pip_conf(venv_root: Path) -> None:
     (venv_root / "pip.conf").write_text(
         dedent(
             f"""
-            [install]
+            [global]
             only-binary=:all:
             {repo}
             """


### PR DESCRIPTION
Modifies the pip configuration generated by `xbuildenv` to use a global configuration, rather than a specific configuration of the `install` command. 

This means that `pip wheel numpy`, `pip download numpy` and `pip lock numpy` will download a binary wheel, rather than downloading a source wheel and trying to compile it.

Fixes #271.