### PR TITLE
Expose the cross-Python `sysconfig` include directory via `pyodide config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `pyodide config list` now exposes `sysconfig` path variables computed
-  from the cross-build environment.
+- `pyodide config list` now exposes the `sysconfig_include` path variable computed
+  from the cross-build environment. This variable can also be accessed through
+  `pyodide config get sysconfig_include` for use in out-of-tree builds.
   [#286](https://github.com/pyodide/pyodide-build/pull/286)
 
 ## [0.31.1] - 2026/01/05

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -110,14 +110,7 @@ class CrossBuildEnvConfigManager(ConfigManager):
         self, makefile_vars: Mapping[str, str]
     ) -> dict[str, str]:
         empty_res = {
-            "sysconfig_stdlib": "",
-            "sysconfig_platstdlib": "",
-            "sysconfig_purelib": "",
-            "sysconfig_platlib": "",
             "sysconfig_include": "",
-            "sysconfig_platinclude": "",
-            "sysconfig_scripts": "",
-            "sysconfig_data": "",
         }
 
         target_install_dir = makefile_vars.get("TARGETINSTALLDIR", "")
@@ -136,25 +129,10 @@ class CrossBuildEnvConfigManager(ConfigManager):
         if not build_time_vars:
             return empty_res
 
-        # Map sysconfigdata variables to sysconfig path names
-        # - LIBDEST points to stdlib, BINLIBDEST points to platstdlib
-        # - INCLUDEPY points to include, CONFINCLUDEPY points to platinclude (or we fall back to INCLUDEPY)
-        # - BINDIR points to scripts, prefix points to data
-        # and for purelib/platlib, we append site-packages to LIBDEST/BINLIBDEST respectively
-        libdest = build_time_vars.get("LIBDEST", "")
-        binlibdest = build_time_vars.get("BINLIBDEST", "")
         includepy = build_time_vars.get("INCLUDEPY", "")
-        confincludepy = build_time_vars.get("CONFINCLUDEPY", "") or includepy
 
         return {
-            "sysconfig_stdlib": libdest,
-            "sysconfig_platstdlib": binlibdest,
-            "sysconfig_purelib": f"{libdest}/site-packages" if libdest else "",
-            "sysconfig_platlib": f"{binlibdest}/site-packages" if binlibdest else "",
             "sysconfig_include": includepy,
-            "sysconfig_platinclude": confincludepy,
-            "sysconfig_scripts": build_time_vars.get("BINDIR", ""),
-            "sysconfig_data": build_time_vars.get("prefix", ""),
         }
 
     def _load_sysconfigdata(self, sysconfigdata_path: Path) -> dict[str, str]:
@@ -361,14 +339,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
     # maintainer only
     "_f2c_fixes_wrapper": "_F2C_FIXES_WRAPPER",
-    "sysconfig_stdlib": "SYSCONFIG_STDLIB",
-    "sysconfig_platstdlib": "SYSCONFIG_PLATSTDLIB",
-    "sysconfig_purelib": "SYSCONFIG_PURELIB",
-    "sysconfig_platlib": "SYSCONFIG_PLATLIB",
     "sysconfig_include": "SYSCONFIG_INCLUDE",
-    "sysconfig_platinclude": "SYSCONFIG_PLATINCLUDE",
-    "sysconfig_scripts": "SYSCONFIG_SCRIPTS",
-    "sysconfig_data": "SYSCONFIG_DATA",
 }
 
 BUILD_VAR_TO_KEY = {v: k for k, v in BUILD_KEY_TO_VAR.items()}
@@ -457,12 +428,5 @@ PYODIDE_CLI_CONFIGS = {
     "ignored_build_requirements": "IGNORED_BUILD_REQUIREMENTS",
     "interpreter": "PYODIDE_INTERPRETER",
     "package_index": "PYODIDE_PACKAGE_INDEX",
-    "sysconfig_stdlib": "SYSCONFIG_STDLIB",
-    "sysconfig_platstdlib": "SYSCONFIG_PLATSTDLIB",
-    "sysconfig_purelib": "SYSCONFIG_PURELIB",
-    "sysconfig_platlib": "SYSCONFIG_PLATLIB",
     "sysconfig_include": "SYSCONFIG_INCLUDE",
-    "sysconfig_platinclude": "SYSCONFIG_PLATINCLUDE",
-    "sysconfig_scripts": "SYSCONFIG_SCRIPTS",
-    "sysconfig_data": "SYSCONFIG_DATA",
 }

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -220,17 +220,6 @@ def test_cli_config_subset():
 
 
 class TestComputeSysconfigPaths:
-    SYSCONFIG_PATH_KEYS = [
-        "sysconfig_stdlib",
-        "sysconfig_platstdlib",
-        "sysconfig_purelib",
-        "sysconfig_platlib",
-        "sysconfig_include",
-        "sysconfig_platinclude",
-        "sysconfig_scripts",
-        "sysconfig_data",
-    ]
-
     def test_compute_sysconfig_paths(
         self, dummy_xbuildenv, reset_env_vars, reset_cache
     ):
@@ -244,17 +233,11 @@ class TestComputeSysconfigPaths:
         makefile_vars = config_manager._get_make_environment_vars()
         sysconfig_paths = config_manager._compute_sysconfig_paths(makefile_vars)
 
-        for key in self.SYSCONFIG_PATH_KEYS:
-            assert key in sysconfig_paths
-            assert sysconfig_paths[key]
+        assert "sysconfig_include" in sysconfig_paths
+        assert sysconfig_paths["sysconfig_include"]
 
         pyodide_root = str(xbuildenv_manager.pyodide_root)
-        assert pyodide_root in sysconfig_paths["sysconfig_stdlib"]
         assert pyodide_root in sysconfig_paths["sysconfig_include"]
-        assert pyodide_root in sysconfig_paths["sysconfig_scripts"]
-        assert pyodide_root in sysconfig_paths["sysconfig_data"]
-        assert sysconfig_paths["sysconfig_purelib"].endswith("/site-packages")
-        assert sysconfig_paths["sysconfig_platlib"].endswith("/site-packages")
 
     def test_compute_sysconfig_paths_in_cross_build_envs(
         self, dummy_xbuildenv, reset_env_vars, reset_cache
@@ -268,12 +251,10 @@ class TestComputeSysconfigPaths:
 
         cross_build_envs = config_manager._load_cross_build_envs()
 
-        for key in self.SYSCONFIG_PATH_KEYS:
-            assert key in cross_build_envs
+        assert "sysconfig_include" in cross_build_envs
 
     def test_sysconfig_paths_in_cli_configs(self):
-        for key in self.SYSCONFIG_PATH_KEYS:
-            assert key in PYODIDE_CLI_CONFIGS
+        assert "sysconfig_include" in PYODIDE_CLI_CONFIGS
 
 
 class TestParseMakefileEnvs:


### PR DESCRIPTION
This PR is a successor to #14; we can include these paths based on locations in the sysconfig for the Pyodide root that we compute.