### PR TITLE
Fix `ruff format` after ruff 0.15.0

### DIFF
--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -148,8 +148,9 @@ def test_supported_virtualenv_options():
     [
         (
             [],
-            lambda path: (path / "bin" / "python").exists()
-            and (path / "bin" / "pip").exists(),
+            lambda path: (
+                (path / "bin" / "python").exists() and (path / "bin" / "pip").exists()
+            ),
         ),
         (["--clear"], lambda path: (path / "bin" / "python").exists()),
         (["--no-vcs-ignore"], lambda path: (path / "bin" / "python").exists()),


### PR DESCRIPTION
Reformatting is triggered automatically by `pre-commit`, submitting it separately to avoid unrelated change in https://github.com/pyodide/pyodide-build/pull/328

Apparently this comes from improved lambda formatting - https://astral.sh/blog/ruff-v0.15.0#improved-lambda-formatting
