### PR TITLE
DOC disable pdf format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
-formats: all
+formats: []
 
 python:
   install:


### PR DESCRIPTION
readthedocs is not happy with this formats setting

<img width="1041" height="66" alt="image" src="https://github.com/user-attachments/assets/edf0e04c-f922-452c-adb7-782f500d5b7b" />

We can re-enable it when there is any request. For now, this unblocks doc build.
