### PR TITLE
`_environment_substitute_str` - expand undefined variables

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -5,6 +5,7 @@
 import contextlib
 import hashlib
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -240,10 +241,11 @@ def _environment_substitute_str(
     if env is None:
         env = dict(os.environ)
 
-    for e_name, e_value in env.items():
-        string = string.replace(f"$({e_name})", e_value)
+    def repl(match_: re.Match[str]) -> str:
+        name = match_.group(1)
+        return env.get(name, "")
 
-    return string
+    return re.sub(r"\$\(([^)]+)\)", repl, string)
 
 
 def environment_substitute_args(

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -64,12 +64,15 @@ def test_environment_var_substitution(monkeypatch):
             "ldflags": '"-l$(PYODIDE_BASE)"',
             "cxxflags": "$(BOB)",
             "cflags": "$(FRED)",
+            "test_var": "$(BOB)$(UNDEFINED_VAR)",
         }
     )
     assert (
         args["cflags"] == "Frederick F. Freddertson Esq."
         and args["cxxflags"] == "Robert Mc Roberts"
         and args["ldflags"] == '"-lpyodide_build_dir"'
+        # Emulate expanding undefined variables to empty strings.
+        and args["test_var"] == "Robert Mc Roberts"
     )
 
 


### PR DESCRIPTION
To resolve the issue below on Windows when running `pyodide build` without `--no-isolation` (wasn't using it for building yet, just for packing the wheels).

The issue is that in `Makefile.envs` `SYSCONFIG_NAME` is defined with `CPYTHON_ABI_FLAGS`, which is undefined by default and typically is expanded to nothing, so `_environment_substitute_str` should emulate this by replacing missing env variables with empty string.

https://github.com/pyodide/pyodide/blob/a50f088296c9258f7f643009d0ac7378099ed51d/Makefile.envs#L19-L24

```makefile
ifdef CPYTHON_DEBUG
	export CPYTHON_ABI_FLAGS=d
endif

export PLATFORM_TRIPLET=wasm32-emscripten
export SYSCONFIG_NAME=_sysconfigdata_$(CPYTHON_ABI_FLAGS)_emscripten_$(PLATFORM_TRIPLET)
```

----

Traceback:
```
Traceback (most recent call last):
  File "L:\pyodide-build\pyodide_build\vendor\_pypabuild.py", line 91, in _handle_build_error
    yield
  File "L:\pyodide-build\pyodide_build\pypabuild.py", line 378, in build
    built = _build_in_isolated_env(
        build_env, srcdir, str(outdir), "wheel", config_settings
    )
  File "L:\pyodide-build\pyodide_build\pypabuild.py", line 179, in _build_in_isolated_env
    symlink_unisolated_packages(env, builder.build_system_requires)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "L:\pyodide-build\pyodide_build\pypabuild.py", line 110, in symlink_unisolated_packages
    shutil.copy(sysconfigdata_path, env_site_packages)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "L:\cpython-3.13.2-windows-x86_64-none\Lib\shutil.py", line 428, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "L:\cpython-3.13.2-windows-x86_64-none\Lib\shutil.py", line 260, in copyfile
    with open(src, 'rb') as fsrc:
         ~~~~^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Username\\AppData\\Local\\.pyodide-xbuildenv-0.34.1\\0.29.3\\xbuildenv\\pyodide-root\\cpython\\installs\\python-3.13.2\\sysconfigdata\\_sysconfigdata_$(CPYTHON_ABI_FLAGS)_emscripten_wasm32-emscripten.py'

ERROR [Errno 2] No such file or directory: 'C:\\Users\\Username\\AppData\\Local\\.pyodide-xbuildenv-0.34.1\\0.29.3\\xbuildenv\\pyodide-root\\cpython\\installs\\python-3.13.2\\sysconfigdata\\_sysconfigdata_$(CPYTHON_ABI_FLAGS)_emscripten_wasm32-emscripten.py'
```