### PR TITLE
Fix tests on Windows that use `dummy_xbuildenv_url` fixture

### DIFF
--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -611,5 +611,5 @@ class CrossBuildEnvManager:
 
 
 def _url_to_version(url: str) -> str:
-    # ; - invalid character on Windows.
+    # : - invalid character on Windows.
     return url.replace("://", "_").replace(".", "_").replace("/", "_").replace(":", "_")

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -611,4 +611,5 @@ class CrossBuildEnvManager:
 
 
 def _url_to_version(url: str) -> str:
-    return url.replace("://", "_").replace(".", "_").replace("/", "_")
+    # ; - invalid character on Windows.
+    return url.replace("://", "_").replace(".", "_").replace("/", "_").replace(":", "_")


### PR DESCRIPTION
Fixing the tests that were using `http_localhost:60644_xbuildenv-test_tar_gz` as dir name and failing on Windows. E.g. `test_xbuildenv_install` was failing with
```
 tmp_path = WindowsPath('C:/Users/Username/AppData/Local/Temp/pytest-of-Username/pytest-133/test_xbuildenv_install0')
  mock_xbuildenv_url = 'http://localhost:50146/xbuildenv-mock.tar'

      def test_xbuildenv_install(tmp_path, mock_xbuildenv_url):
          envpath = Path(tmp_path) / ".xbuildenv"

          result = runner.invoke(
              xbuildenv.app,
              [
                  "install",
                  "--path",
                  str(envpath),
                  "--url",
                  mock_xbuildenv_url,
              ],
          )

  >
  >       assert result.exit_code == 0, result.output

  E       AssertionError: Downloading Pyodide cross-build environment from
  E         http://localhost:50146/xbuildenv-mock.tar
  E
  E       assert 1 == 0
  E        +  where 1 = <Result NotADirectoryError(20, 'The directory name is invalid')>.exit_code

  pyodide_build\tests\test_cli_xbuildenv.py:93: AssertionError`
```