### PR TITLE
Skip non-writable xbuildenv path test on Windows

### DIFF
--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from pyodide_build.common import (
+    IS_WIN,
     check_wasm_magic_number,
     default_xbuildenv_path,
     environment_substitute_args,
@@ -240,8 +241,18 @@ def test_default_xbuildenv_path_env_var(tmp_path, reset_cache, monkeypatch):
     monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", "")
     assert default_xbuildenv_path() == baseline_path
 
-    # non-writable path; should fall back to default
-    reset_cache()
+
+@pytest.mark.skipif(
+    IS_WIN, reason="Permission-based fallback is not reliable on Windows"
+)
+def test_default_xbuildenv_path_env_var_non_writable(
+    tmp_path, reset_cache, monkeypatch
+):
+    import platformdirs
+
+    dirname = xbuildenv_dirname()
+    baseline_path = Path(platformdirs.user_cache_dir()) / dirname
+
     non_writable_path = tmp_path / "non_writable"
     non_writable_path.mkdir(exist_ok=True)
     non_writable_path.chmod(0o444)


### PR DESCRIPTION
Since `os.access(xxx, os.W_OK)` cannot be reliably used on Windows to check writing access, example failing test:

```
tmp_path = WindowsPath('C:/Users/Username/AppData/Local/Temp/pytest-of-Username/pytest-141/test_default_xbuildenv_path_en0')
  reset_cache = <function reset_cache.<locals>._reset at 0x0000022EA983C040>, monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x0000022EA97C68B0>

      def test_default_xbuildenv_path_env_var(tmp_path, reset_cache, monkeypatch):
          from pathlib import Path

          # default case
          monkeypatch.delenv("PYODIDE_XBUILDENV_PATH", raising=False)

          import platformdirs

          dirname = xbuildenv_dirname()

          baseline_path = Path(platformdirs.user_cache_dir()) / dirname

          assert default_xbuildenv_path() == baseline_path

          reset_cache()

          # custom path
          custom_path = tmp_path / "custom_xbuildenv_path"
          custom_path.mkdir(exist_ok=True)

          monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(custom_path))

          assert default_xbuildenv_path() == custom_path.resolve()

          reset_cache()

          # relative path from cwd
          relative_dir = Path("../relative/xbuildenv").resolve()
          monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(relative_dir))

          expected_path = Path.cwd() / relative_dir
          assert default_xbuildenv_path() == expected_path

          reset_cache()

          monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", "")
          assert default_xbuildenv_path() == baseline_path

          # non-writable path; should fall back to default
          reset_cache()
          non_writable_path = tmp_path / "non_writable"
          non_writable_path.mkdir(exist_ok=True)
          non_writable_path.chmod(0o444)

          monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(non_writable_path))

  >
  >       assert default_xbuildenv_path() == baseline_path

  E       AssertionError: assert WindowsPath('C:/Users/Username/AppData/Local/Temp/pytest-of-Username/pytest-141/test_default_xbuildenv_path_en0/non_writable') ==
  WindowsPath('C:/Users/Username/AppData/Local/.pyodide-xbuildenv-0.34.1')
  E        +  where WindowsPath('C:/Users/Username/AppData/Local/Temp/pytest-of-Username/pytest-141/test_default_xbuildenv_path_en0/non_writable') = default_xbuildenv_path()

  pyodide_build\tests\test_common.py:253: AssertionError
  =========================================================================== short test summary info
  ============================================================================
  SKIPPED [1] pyodide_build\tests\test_pypi.py:14: could not import 'resolvelib': No module named 'resolvelib'
  FAILED pyodide_build/tests/test_common.py::test_default_xbuildenv_path_env_var - AssertionError: assert WindowsPath('C:/Users/Username/AppData/Local/Temp/pytest-of-Username/
  pytest-141/test_default_xbuildenv_path_en0/non_writable') == WindowsPath('C:/Users/Username/AppData/Local/...
```