### PR TITLE
Pin click version in tests temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ruamel.yaml",
     "packaging",
     "virtualenv",
-    "requests", 
+    "requests",
     "click",
     "rich",
     "platformdirs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ruamel.yaml",
     "packaging",
     "virtualenv",
-    "requests",
+    "requests", 
     "click",
     "rich",
     "platformdirs",
@@ -68,6 +68,9 @@ test = [
     "pytest-httpserver",
     "pytest-cov",
     "types-requests",
+    # click 8.3.3 has a regression where
+    # pytest giving OSError: [Errno 29] Illegal seek error
+    "click>=8.0,<8.3.3",
 ]
 docs = [
     "sphinx>=5.3.0",


### PR DESCRIPTION
Click 8.3.3 seems to have a regression breaking pytest. I was able to reproduce it locally but haven't got a simple reproducer that I can upstream yet. For now, pinning the click version so we can land other changes