### PR TITLE
Pin build 1.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 license = {text = "MPL-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "build~=1.4.0",
+    "build==1.4.3",
     "pyodide-cli>=0.4.1",
     "pyodide-lock~=0.1.0",
     "auditwheel-emscripten~=0.2.0",


### PR DESCRIPTION
Workaround for https://github.com/pypa/build/pull/1040/ installing over our cross numpy and scipy.