### PR TITLE
Print inner subprocess error when installing build requirements fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.4] - 2026/05/15
+
+### Added
+
+- We now show better error message when `pyodide build` fails to install build dependencies.
+  [#346](https://github.com/pyodide/pyodide-build/pull/346)
+
+## [0.34.3] - 2026/04/30
+
+### Fixed
+
+- Fixed compatibility issue with newer pypa/build >= 1.4.4
+  [#345](https://github.com/pyodide/pyodide-build/pull/345)
+
+## [0.34.2] - 2026/04/29
+
+### Fixed
+
+- Fixed error when undefined environment variables are used in `meta.yaml`.
+  [#331](https://github.com/pyodide/pyodide-build/pull/331)
+
+- `pyodide venv` now works with new pip 26.1.
+  [#341](https://github.com/pyodide/pyodide-build/pull/341)
+
 ## [0.34.1] - 2026/04/03
 
 ### Added

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -1,5 +1,15 @@
+import subprocess
+
+import pytest
+from build import BuildBackendException, BuildException, FailedProcessError
+
 from pyodide_build import pypabuild, pywasmcross
 from pyodide_build.constants import BASE_IGNORED_REQUIREMENTS
+from pyodide_build.vendor._pypabuild import (
+    _find_called_process_error,
+    _handle_build_error,
+    _log_subprocess_output,
+)
 
 
 class MockIsolatedEnv:
@@ -121,3 +131,87 @@ def test_symlink_unisolated_packages_triggers_lazy_install(
 
     pypabuild.symlink_unisolated_packages(DummyEnv(), reqs={"numpy>=1.0"})
     assert called["count"] == 1
+
+
+def _make_cpe(
+    stdout: str | bytes | None = None, stderr: str | bytes | None = None
+) -> subprocess.CalledProcessError:
+    exc = subprocess.CalledProcessError(1, ["pip", "install", "bad-pkg"])
+    exc.stdout = stdout
+    exc.stderr = stderr
+    return exc
+
+
+class TestFindCalledProcessError:
+    def test_direct_called_process_error(self):
+        cpe = _make_cpe()
+        assert _find_called_process_error(cpe) is cpe
+
+    def test_wrapped_in_failed_process_error(self):
+        cpe = _make_cpe()
+        fpe = FailedProcessError(cpe, "install failed")
+        assert _find_called_process_error(fpe) is cpe
+
+    def test_wrapped_in_build_backend_exception(self):
+        cpe = _make_cpe()
+        bbe = BuildBackendException(cpe)
+        assert _find_called_process_error(bbe) is cpe
+
+    def test_unrelated_exception(self):
+        assert _find_called_process_error(RuntimeError("boom")) is None
+
+    def test_build_exception_without_inner(self):
+        assert _find_called_process_error(BuildException("bad")) is None
+
+
+class TestLogSubprocessOutput:
+    def test_logs_str_output(self, capsys):
+        cpe = _make_cpe(stdout="pkg not found\n", stderr="ERROR: no match\n")
+        _log_subprocess_output(cpe)
+        captured = capsys.readouterr().out
+        assert "pkg not found" in captured
+        assert "ERROR: no match" in captured
+        assert "stdout:" in captured
+        assert "stderr:" in captured
+
+    def test_logs_bytes_output(self, capsys):
+        cpe = _make_cpe(stdout=b"bytes stdout\n", stderr=b"bytes stderr\n")
+        _log_subprocess_output(cpe)
+        captured = capsys.readouterr().out
+        assert "bytes stdout" in captured
+        assert "bytes stderr" in captured
+
+    def test_no_output(self, capsys):
+        cpe = _make_cpe()
+        _log_subprocess_output(cpe)
+        captured = capsys.readouterr().out
+        assert captured == ""
+
+
+class TestHandleBuildErrorSubprocessOutput:
+    def test_called_process_error_surfaces_output(self, capsys):
+        with pytest.raises(SystemExit):
+            with _handle_build_error():
+                raise _make_cpe(
+                    stdout="Collecting bad-pkg\n",
+                    stderr="ERROR: No matching distribution found for bad-pkg\n",
+                )
+        captured = capsys.readouterr()
+        assert "Collecting bad-pkg" in captured.out
+        assert "No matching distribution found for bad-pkg" in captured.out
+
+    def test_failed_process_error_surfaces_output(self, capsys):
+        cpe = _make_cpe(stderr="pip resolution failed\n")
+        with pytest.raises(SystemExit):
+            with _handle_build_error():
+                raise FailedProcessError(cpe, "Failed to install deps")
+        captured = capsys.readouterr()
+        assert "pip resolution failed" in captured.out
+
+    def test_build_backend_exception_with_cpe_surfaces_output(self, capsys):
+        cpe = _make_cpe(stderr="backend install error\n")
+        with pytest.raises(SystemExit):
+            with _handle_build_error():
+                raise BuildBackendException(cpe)
+        captured = capsys.readouterr()
+        assert "backend install error" in captured.out

--- a/pyodide_build/vendor/_pypabuild.py
+++ b/pyodide_build/vendor/_pypabuild.py
@@ -85,30 +85,50 @@ class _DefaultIsolatedEnv(DefaultIsolatedEnv):
         return self._env_backend.scripts_dir
 
 
+def _log_subprocess_output(error: subprocess.CalledProcessError) -> None:
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(error, stream_name, None)
+        if stream:
+            decoded = stream.decode() if isinstance(stream, bytes) else stream
+            _cprint("{bold}{red}" + stream_name + ":{reset}\n{dim}{}{reset}", decoded)
+
+
+def _find_called_process_error(
+    exc: Exception,
+) -> subprocess.CalledProcessError | None:
+    if isinstance(exc, subprocess.CalledProcessError):
+        return exc
+    inner = getattr(exc, "exception", None)
+    if isinstance(inner, subprocess.CalledProcessError):
+        return inner
+    return None
+
+
 @contextlib.contextmanager
 def _handle_build_error() -> Iterator[None]:
     try:
         yield
-    except (BuildException, FailedProcessError) as e:
-        _error(str(e))
-    except BuildBackendException as e:
-        if isinstance(e.exception, subprocess.CalledProcessError):
-            _cprint()
-            _error(str(e))
+    except Exception as e:
+        if isinstance(e, BuildBackendException) and not isinstance(
+            e.exception, subprocess.CalledProcessError
+        ):
+            if e.exc_info:
+                tb_lines = traceback.format_exception(
+                    e.exc_info[0],
+                    e.exc_info[1],
+                    e.exc_info[2],
+                    limit=-1,
+                )
+                tb = "".join(tb_lines)
+            else:
+                tb = traceback.format_exc(-1)  # type: ignore[unreachable]
+            _cprint("\n{dim}{}{reset}\n", tb.strip("\n"))
+        elif not isinstance(e, (BuildException, FailedProcessError)):
+            tb = traceback.format_exc().strip("\n")
+            _cprint("\n{dim}{}{reset}\n", tb)
 
-        if e.exc_info:
-            tb_lines = traceback.format_exception(
-                e.exc_info[0],
-                e.exc_info[1],
-                e.exc_info[2],
-                limit=-1,
-            )
-            tb = "".join(tb_lines)
-        else:
-            tb = traceback.format_exc(-1)  # type: ignore[unreachable]
-        _cprint("\n{dim}{}{reset}\n", tb.strip("\n"))
-        _error(str(e))
-    except Exception as e:  # pragma: no cover
-        tb = traceback.format_exc().strip("\n")
-        _cprint("\n{dim}{}{reset}\n", tb)
+        cpe = _find_called_process_error(e)
+        if cpe is not None:
+            _log_subprocess_output(cpe)
+
         _error(str(e))


### PR DESCRIPTION
This is a quality-of-life improvement that prints better error message when build requirements are fail to install.

Currently, when build requirements are fail to install, we don't get what kind of errors happen in the subprocess pip call, for example, recently `pplpy` was failing to build in pyodide-recipes main branch, but all the log we see is:

```
Traceback (most recent call last):                                           
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/pyodide_b
uild/vendor/_pypabuild.py", line 91, in _handle_build_error                     
    yield                                                                       
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/pyodide_b
uild/pypabuild.py", line 378, in build                                          
    built = _build_in_isolated_env(                                             
        build_env, srcdir, str(outdir), "wheel", config_settings                
    )                                                                           
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/pyodide_b
uild/pypabuild.py", line 180, in _build_in_isolated_env                         
    install_reqs(build_env, env, builder.build_system_requires)                 
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                 
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/pyodide_b
uild/pypabuild.py", line 150, in install_reqs                                   
    env.install(                                                                
    ~~~~~~~~~~~^                                                                
        remove_avoided_requirements(                                            
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                            
    ...<2 lines>...                                                             
        )                                                                       
        ^                                                                       
    )                                                                           
    ^                                                                           
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/build/env
.py", line 186, in install                                                      
    self._env_backend.install_dependencies(requirements, constraints,           
_fresh=_fresh)                                                                  
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^^^                                                                            
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/build/env
.py", line 379, in install_dependencies                                         
    run_subprocess(cmd, env=_pip_env())                                         
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^                                         
  File                                                                          
"/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/site-packages/build/_ct
x.py", line 78, in run_subprocess                                               
    subprocess.run(cmd, capture_output=True, check=True, cwd=cwd, env=env)  #   
noqa: S603                                                                      
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      
  File "/home/runner/miniconda3/envs/pyodide-env/lib/python3.14/subprocess.py", 
line 577, in run                                                                
    raise CalledProcessError(retcode, process.args,                             
                             output=stdout, stderr=stderr)                      
subprocess.CalledProcessError: Command                                          
'['/home/runner/miniconda3/envs/pyodide-env/bin/python', '-m', 'pip',           
'--python', '/tmp/build-env-mrntle35/bin/python', 'install', '--use-pep517',    
'--no-warn-script-location', '--no-compile', '--no-input', '-r',                
'/tmp/build-requirements-5c8l6sst.txt']' returned non-zero exit status 1.    
                                                                                
ERROR Command '['/home/runner/miniconda3/envs/pyodide-env/bin/python',   
'-m', 'pip', '--python', '/tmp/build-env-mrntle35/bin/python', 'install',       
'--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input', '-r',
'/tmp/build-requirements-5c8l6sst.txt']' returned non-zero exit status 1.       
[2026-05-14 17:03:06] Failed building package pplpy in 11.4 seconds.      
```

which doesn't actually show what happened inside. This change hopefully will surface the real error message.
