### PR TITLE
Reliably find uv binary

### DIFF
--- a/pyodide_build/uv_helper.py
+++ b/pyodide_build/uv_helper.py
@@ -1,28 +1,20 @@
-import functools
-import os
+import contextlib
 import shutil
 
 
-@functools.cache
 def find_uv_bin() -> str | None:
     """
-    Check if the uv executable is available.
-
-    If the uv executable is available, return the path to the executable.
+    Return the path to the uv executable, or None if not found.
+    Prefers the uv Python package over a PATH lookup.
     Otherwise, return None.
     """
-    try:
-        import uv
+    with contextlib.suppress(ImportError, FileNotFoundError):
+        from uv import find_uv_bin as _find_uv_bin
 
-        return uv.find_uv_bin()
-    except (ModuleNotFoundError, FileNotFoundError):
-        return shutil.which("uv")
+        return _find_uv_bin()
 
-    return None
+    return shutil.which("uv")
 
 
 def should_use_uv() -> bool:
-    # UV environ is set to the uv executable path when the script is called with the uv executable.
-    uv_environ = os.environ.get("UV")
-    # double check by comparing the uv executable path with the one found by the uv package.
-    return uv_environ and uv_environ == find_uv_bin()
+    return find_uv_bin() is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ authors = [{name = "Pyodide developers"}]
 description = '"Tools for building Pyodide"'
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Operating System :: OS Independent",
 ]
-license = {text = "MPL-2.0"}
+license = "MPL-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     "build>=1.4,<1.6,!=1.4.4", # keep in sync with uv extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 license = {text = "MPL-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "build>=1.4,<1.6,!=1.4.4",
+    "build>=1.4,<1.6,!=1.4.4", # keep in sync with uv extra
     "pyodide-cli>=0.4.1",
     "pyodide-lock~=0.1.0",
     "auditwheel-emscripten~=0.2.0",
@@ -59,7 +59,7 @@ resolve = [
     "unearth~=0.6",
 ]
 uv = [
-  "build[uv]~=1.4.0",
+  "build[uv]>=1.4,<1.6,!=1.4.4",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
I made our uv helper match what cibuildwheel does to find uv. There's not much of a difference, but I've frequently run into issues with this when developing locally on my macOS machine and it might have been due to the functools cache for all we know.

Also, complies wth PEP 639 and fixes our licensing metadata.