### PR TITLE
MNT Replace a few more instances of bare `pip` calls with `sys.executable -m pip`

### DIFF
--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -643,6 +643,8 @@ class RecipeBuilderPackage(RecipeBuilder):
             if self.build_metadata.cross_build_env:
                 subprocess.run(
                     [
+                        sys.executable,
+                        "-m",
                         "pip",
                         "install",
                         # Upgrade the package in the host environment if there is a
@@ -666,6 +668,8 @@ class RecipeBuilderPackage(RecipeBuilder):
                 # overwriting the dependencies in the host environment.
                 subprocess.run(
                     [
+                        sys.executable,
+                        "-m",
                         "pip",
                         "install",
                         "-t",

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -643,8 +643,6 @@ class RecipeBuilderPackage(RecipeBuilder):
             if self.build_metadata.cross_build_env:
                 subprocess.run(
                     [
-                        sys.executable,
-                        "-m",
                         "pip",
                         "install",
                         # Upgrade the package in the host environment if there is a
@@ -668,8 +666,6 @@ class RecipeBuilderPackage(RecipeBuilder):
                 # overwriting the dependencies in the host environment.
                 subprocess.run(
                     [
-                        sys.executable,
-                        "-m",
                         "pip",
                         "install",
                         "-t",

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 from build import BuildBackendException, BuildException, FailedProcessError
@@ -136,7 +137,9 @@ def test_symlink_unisolated_packages_triggers_lazy_install(
 def _make_cpe(
     stdout: str | bytes | None = None, stderr: str | bytes | None = None
 ) -> subprocess.CalledProcessError:
-    exc = subprocess.CalledProcessError(1, ["pip", "install", "bad-pkg"])
+    exc = subprocess.CalledProcessError(
+        1, [sys.executable, "-m", "pip", "install", "bad-pkg"]
+    )
     exc.stdout = stdout
     exc.stderr = stderr
     return exc


### PR DESCRIPTION
I was browsing through what I had discussed on https://github.com/pyodide/pyodide-build/issues/58 and found a few more of these remaining.

I wonder if we should have an agentic style guide of sorts that can catch these kinds of things through custom instructions. I doubt Copilot reads `AGENTS.md` files; I can't get it to do so reliably across conversations.