### PR TITLE
CI: bump `test` job node to 24 for consistency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
As it's already used in all other CI jobs.