### PR TITLE
Add correct Python version when generating lockfile

### DIFF
--- a/pyodide_build/recipe/graph_builder.py
+++ b/pyodide_build/recipe/graph_builder.py
@@ -904,7 +904,7 @@ def generate_lockfile(
         "arch": arch,
         "platform": platform,
         "version": build_env.get_build_flag("PYODIDE_VERSION"),
-        "python": sys.version.partition(" ")[0],
+        "python": build_env.get_build_flag("PYVERSION"),
         "abi_version": build_env.get_build_flag("PYODIDE_ABI_VERSION"),
     }
     packages = generate_packagedata(output_dir, pkg_map)

--- a/pyodide_build/tests/recipe/test_graph_builder.py
+++ b/pyodide_build/tests/recipe/test_graph_builder.py
@@ -98,6 +98,7 @@ def test_generate_lockfile(tmp_path, dummy_xbuildenv):
     assert package_data.info.arch == "wasm32"
     assert package_data.info.platform.startswith("emscripten")
     assert package_data.info.version == build_env.get_build_flag("PYODIDE_VERSION")
+    assert package_data.info.python == build_env.get_build_flag("PYVERSION")
 
     assert set(package_data.packages) == {
         "pkg-1",


### PR DESCRIPTION
The `info` block in our lockfiles was constructed with `"python": sys.version.partition(" ")[0]`, which is the host Python and not our cross-compiled CPython.

I noticed this when inspecting `pyodide-lock.json` included in https://github.com/pyodide/pyodide-build-environment-nightly/releases/tag/20260601, where the Python version is reported as 3.14.5 instead of 3.14.2. I did this while working on https://github.com/pyodide/pyodide-build-environment-nightly/pull/79.

So I guess the CI machine happened to have Python 3.14.5, while `PYVERSION` in `Makefile.envs` is the more correct value.

I am actually not very familiar with our pyodide-lock code to know if this is a consequential change or breaks any workflow there, so LMKWYT about this @ryanking13 – Thanks! 