### PR TITLE
update docs URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ content-type = "text/markdown"
 [project.urls]
 Homepage = "https://github.com/pyodide/pyodide-build"
 "Bug Tracker" = "https://github.com/pyodide/pyodide-build/issues"
-Documentation = "https://pyodide.org/en/stable/"
+Documentation = "https://pyodide-build.readthedocs.io"
 
 [project.entry-points."pipx.run"]
 pyodide = "pyodide_cli.__main__:main"


### PR DESCRIPTION
References:
- https://github.com/pyodide/pyodide-build/issues/11#issuecomment-4615633149

Changes:
- [x] use ReadTheDocs URL for documentation URL on PyPI, etc.