### PR TITLE
Add verbosity handling and pass through to pypa/build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.34.5] - 2026/05/20
+## [0.35.0] - 2026/XX/XX
 
 ### Added
 
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `--debug` flags to search and install nightly and nightly-debug cross-build
   environments respectively.
   [#350](https://github.com/pyodide/pyodide-build/pull/350)
+
+- `pyodide build` now accepts `-v`/`--verbose` flags (stackable twice up to `-vv`)
+  to increase build verbosity. At `-v`, installer commands and
+  backend hook invocations are shown. At `-vv`, the package installers (`uv`/`pip`)
+  additionally receive a `-v` flag for detailed package resolution output.
+  [#363](https://github.com/pyodide/pyodide-build/pull/363)
 
 ## [0.34.4] - 2026/05/15
 

--- a/docs/how-to/debugging.md
+++ b/docs/how-to/debugging.md
@@ -170,16 +170,25 @@ pyodide build . --no-isolation
 
 ### Verbose output
 
-Use `export EMCC_DEBUG=1` to get more detailed output from the Emscripten compiler.
+Use `-v` or `-vv` to increase pyodide-build's own verbosity:
 
-This can be useful for debugging linker errors and other build issues.
+```bash
+pyodide build . -v    # show installer commands and backend hook invocations
+pyodide build . -vv   # also pass -v to the package installer (uv/pip)
+```
+
+At `-v`, you will see:
+- `> cmd` lines showing the pyproject_hooks invocations (e.g., `build_wheel`)
+- `> cmd` / `< output` lines for the package installer (`uv`/`pip`) when packages are not cached
+
+For even more detailed output from the Emscripten compiler itself, set `EMCC_DEBUG=1`:
 
 ```bash
 export EMCC_DEBUG=1
 pyodide build .
 ```
 
-Increase verbosity to see exactly what commands are being run:
+For backend-specific verbosity, pass flags via `-C`:
 
 ```bash
 # setuptools

--- a/integration_tests/src/numpy.sh
+++ b/integration_tests/src/numpy.sh
@@ -10,4 +10,4 @@ tar -xf numpy-${VERSION}.tar.gz
 cd numpy-${VERSION}
 
 MESON_CROSS_FILE=$(pyodide config get meson_cross_file)
-${UV_RUN_PREFIX} pyodide build -Csetup-args=-Dallow-noblas=true -Csetup-args=--cross-file="${MESON_CROSS_FILE}"
+${UV_RUN_PREFIX} pyodide build -vv -Csetup-args=-Dallow-noblas=true -Csetup-args=--cross-file="${MESON_CROSS_FILE}"

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -35,6 +35,7 @@ class BuildArgs:
     config_settings: ConfigSettingsType
     isolation: bool
     skip_dependency_check: bool
+    verbosity: int = 0
 
 
 def _convert_exports(exports: str) -> _BuildSpecExports:
@@ -76,6 +77,7 @@ def _build_from_source(
         args.config_settings,
         isolation=args.isolation,
         skip_dependency_check=args.skip_dependency_check,
+        verbosity=args.verbosity,
     )
 
 

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -347,6 +347,13 @@ DEFAULT_PATH = default_xbuildenv_path()
     show_envvar=True,
     help="Skip automatic installation of Emscripten if not found.",
 )
+@click.option(
+    "-v",
+    "--verbose",
+    "verbosity",
+    count=True,
+    help="Increase build verbosity. Use -v for verbose output, -vv for very verbose output.",
+)
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -364,6 +371,7 @@ def main(
     config_setting: tuple[str, ...],
     xbuildenv_path: Path,
     skip_emscripten_install: bool,
+    verbosity: int,
 ) -> None:
     """Use pypa/build to build a Python package from source, pypi or url.
 
@@ -389,6 +397,7 @@ def main(
         config_settings=config_settings,
         isolation=not no_isolation,
         skip_dependency_check=skip_dependency_check,
+        verbosity=verbosity,
     )
 
     skip_dependency_list = list(skip_dependency)

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -484,6 +484,7 @@ def source(
     config_settings: ConfigSettingsType,
     isolation: bool = True,
     skip_dependency_check: bool = False,
+    verbosity: int = 0,
 ) -> Path:
     """Use pypa/build to build a Python package from source"""
     args = BuildArgs(
@@ -491,5 +492,6 @@ def source(
         config_settings=config_settings,
         isolation=isolation,
         skip_dependency_check=skip_dependency_check,
+        verbosity=verbosity,
     )
     return _build_from_source(source_location, output_directory, args)

--- a/pyodide_build/out_of_tree/build.py
+++ b/pyodide_build/out_of_tree/build.py
@@ -43,6 +43,7 @@ def run(
     config_settings: ConfigSettingsType,
     isolation: bool = True,
     skip_dependency_check: bool = False,
+    verbosity: int = 0,
 ) -> Path:
     outdir = outdir.resolve()
     cflags = build_env.get_build_flag("SIDE_MODULE_CFLAGS")
@@ -80,6 +81,7 @@ def run(
             config_settings,
             isolation=isolation,
             skip_dependency_check=skip_dependency_check,
+            verbosity=verbosity,
         )
 
     wheel_path = Path(built_wheel)

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -165,6 +165,7 @@ def _build_in_isolated_env(
     outdir: str,
     distribution: Literal["sdist", "wheel"],
     config_settings: ConfigSettingsType,
+    verbosity: int = 0,
 ) -> str:
     # For debugging: The following line disables removal of the isolated venv.
     # It will be left in the /tmp folder and can be inspected or entered as
@@ -176,7 +177,7 @@ def _build_in_isolated_env(
         builder = ProjectBuilder.from_isolated_env(
             env,
             srcdir,
-            runner=_gen_runner(build_env, env),
+            runner=_gen_runner(build_env, env, verbosity=verbosity),
         )
 
         # first install the build dependencies
@@ -222,9 +223,10 @@ def _build_in_current_env(
     distribution: Literal["sdist", "wheel"],
     config_settings: ConfigSettingsType,
     skip_dependency_check: bool = False,
+    verbosity: int = 0,
 ) -> str:
     with common.replace_env(build_env):
-        builder = ProjectBuilder(srcdir, runner=_gen_runner(build_env))
+        builder = ProjectBuilder(srcdir, runner=_gen_runner(build_env, verbosity=verbosity))
 
         if not skip_dependency_check:
             missing = builder.check_dependencies(distribution, config_settings or {})
@@ -375,30 +377,44 @@ def build(
     config_settings: ConfigSettingsType,
     isolation: bool = True,
     skip_dependency_check: bool = False,
+    verbosity: int = 0,
 ) -> str:
-    try:
-        with _handle_build_error():
-            if isolation:
-                built = _build_in_isolated_env(
-                    build_env, srcdir, str(outdir), "wheel", config_settings
+    import logging
+
+    from build import _ctx as _build_ctx
+
+    _build_ctx.VERBOSITY.set(verbosity)
+    log_level = logging.DEBUG if verbosity >= 1 else logging.INFO
+    with set_log_level(logger, log_level):
+        try:
+            with _handle_build_error():
+                if isolation:
+                    built = _build_in_isolated_env(
+                        build_env,
+                        srcdir,
+                        str(outdir),
+                        "wheel",
+                        config_settings,
+                        verbosity=verbosity,
+                    )
+                else:
+                    built = _build_in_current_env(
+                        build_env,
+                        srcdir,
+                        str(outdir),
+                        "wheel",
+                        config_settings,
+                        skip_dependency_check,
+                        verbosity=verbosity,
+                    )
+                print(
+                    "{bold}{green}Successfully built {}{reset}".format(
+                        built, **_styles.get()
+                    )
                 )
-            else:
-                built = _build_in_current_env(
-                    build_env,
-                    srcdir,
-                    str(outdir),
-                    "wheel",
-                    config_settings,
-                    skip_dependency_check,
-                )
-            print(
-                "{bold}{green}Successfully built {}{reset}".format(
-                    built, **_styles.get()
-                )
-            )
-            return built
-    except Exception as e:  # pragma: no cover
-        tb = traceback.format_exc().strip("\n")
-        print("\n{dim}{}{reset}\n".format(tb, **_styles.get()))
-        _error(str(e))
-        sys.exit(1)
+                return built
+        except Exception as e:  # pragma: no cover
+            tb = traceback.format_exc().strip("\n")
+            print("\n{dim}{}{reset}\n".format(tb, **_styles.get()))
+            _error(str(e))
+            sys.exit(1)

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -190,7 +190,7 @@ def _build_in_isolated_env(
         except BuildBackendException:
             pass
 
-        if build_reqs is None:
+        if not build_reqs:
             # get_requires_for_build in native env failed. Maybe trying to
             # execute get_requires_for_build in the cross build environment will
             # work?

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -28,6 +28,7 @@ from pyodide_build.build_env import (
 from pyodide_build.spec import _BuildSpecExports
 from pyodide_build.vendor._pypabuild import (
     _configure_build_verbosity,
+    _DefaultIsolatedEnv,
     _error,
     _handle_build_error,
     _styles,
@@ -408,42 +409,36 @@ def build(
     skip_dependency_check: bool = False,
     verbosity: int = 0,
 ) -> str:
-    from build import _ctx as _build_ctx
-
-    token_verbosity = _build_ctx.VERBOSITY.set(verbosity)
-    token_logger = _build_ctx.LOGGER.set(_make_pypa_build_logger())
-    try:
-        with _handle_build_error():
-            if isolation:
-                built = _build_in_isolated_env(
-                    build_env,
-                    srcdir,
-                    str(outdir),
-                    "wheel",
-                    config_settings,
-                    verbosity=verbosity,
+    with _configure_build_verbosity(verbosity, _make_pypa_build_logger(verbosity)):
+        try:
+            with _handle_build_error():
+                if isolation:
+                    built = _build_in_isolated_env(
+                        build_env,
+                        srcdir,
+                        str(outdir),
+                        "wheel",
+                        config_settings,
+                        verbosity=verbosity,
+                    )
+                else:
+                    built = _build_in_current_env(
+                        build_env,
+                        srcdir,
+                        str(outdir),
+                        "wheel",
+                        config_settings,
+                        skip_dependency_check,
+                        verbosity=verbosity,
+                    )
+                print(
+                    "{bold}{green}Successfully built {}{reset}".format(
+                        built, **_styles.get()
+                    )
                 )
-            else:
-                built = _build_in_current_env(
-                    build_env,
-                    srcdir,
-                    str(outdir),
-                    "wheel",
-                    config_settings,
-                    skip_dependency_check,
-                    verbosity=verbosity,
-                )
-            print(
-                "{bold}{green}Successfully built {}{reset}".format(
-                    built, **_styles.get()
-                )
-            )
-            return built
-    except Exception as e:  # pragma: no cover
-        tb = traceback.format_exc().strip("\n")
-        print("\n{dim}{}{reset}\n".format(tb, **_styles.get()))
-        _error(str(e))
-        sys.exit(1)
-    finally:
-        _build_ctx.VERBOSITY.reset(token_verbosity)
-        _build_ctx.LOGGER.reset(token_logger)
+                return built
+        except Exception as e:  # pragma: no cover
+            tb = traceback.format_exc().strip("\n")
+            print("\n{dim}{}{reset}\n".format(tb, **_styles.get()))
+            _error(str(e))
+            sys.exit(1)

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -27,7 +27,7 @@ from pyodide_build.build_env import (
 )
 from pyodide_build.spec import _BuildSpecExports
 from pyodide_build.vendor._pypabuild import (
-    _DefaultIsolatedEnv,
+    _configure_build_verbosity,
     _error,
     _handle_build_error,
     _styles,
@@ -371,7 +371,7 @@ def get_build_env(
         yield env
 
 
-def _make_pypa_build_logger() -> Callable[[str], None]:
+def _make_pypa_build_logger(verbosity: int) -> Callable[[str], None]:
     """
     Returns a logger function compatible with build._ctx.LOGGER.
 
@@ -387,10 +387,12 @@ def _make_pypa_build_logger() -> Callable[[str], None]:
         if not msg:
             return
         match kind:
-            case ("subprocess", "cmd"):
+            case ("subprocess", "cmd") if verbosity >= 1:
                 print(f"> {msg}", file=sys.stderr, flush=True)
-            case ("subprocess", *_):
+            case ("subprocess", *_) if verbosity >= 1:
                 print(f"< {msg}", file=sys.stderr, flush=True)
+            case ("subprocess", *_):
+                pass  # verbosity=0: installer output is not shown
             case _:
                 print(msg, file=sys.stderr, flush=True)
 

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -191,7 +191,7 @@ def _build_in_isolated_env(
         except BuildBackendException:
             pass
 
-        if not build_reqs:
+        if build_reqs is None:
             # get_requires_for_build in native env failed. Maybe trying to
             # execute get_requires_for_build in the cross build environment will
             # work?

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -372,6 +372,8 @@ def get_build_env(
         yield env
 
 
+# Based on pypa/build's reference logger implementation. See
+# https://github.com/pypa/build/blob/615d04cfc52ac3c1592a463f0afe484fee1cc368/src/build/__main__.py#L99-L123
 def _make_pypa_build_logger(verbosity: int) -> Callable[[str], None]:
     """
     Returns a logger function compatible with build._ctx.LOGGER.
@@ -380,7 +382,18 @@ def _make_pypa_build_logger(verbosity: int) -> Callable[[str], None]:
     at INFO level, but that logger has no handlers and an effective level of WARNING,
     so all output is silently dropped when we use pypa/build as a library.
 
-    We mirror pypa/build's CLI logger where everything goes to stderr.
+    We mirror pypa/build's CLI logger, where all messages go to stderr. The subprocess
+    commands are prefixed by "> " and subprocess output is prefixed by "< ".
+
+    The ``message`` is a plain string. ``kind`` is a tuple tag that is set by pypa/build:
+      - ``('step',)``                  --> this is a high-level build step (such as "Building wheel...")
+      - ``('subprocess', 'cmd')``      --> the installer command that is being run
+      - ``('subprocess', 'stdout')``   --> a line of the installer's stdout
+      - ``('subprocess', 'stderr')``   --> a line of the installer's stderr
+      - ``None``                       --> some untagged informational message
+
+    pypa/build only calls this logger with the subprocess's content when
+    _ctx.VERBOSITY is greater than zero.
     """
 
     def _log(message: str, *, kind: tuple[str, ...] | None = None) -> None:

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -25,6 +25,7 @@ from pyodide_build.build_env import (
     in_xbuildenv,
     platform,
 )
+from pyodide_build.logger import logger, set_log_level
 from pyodide_build.spec import _BuildSpecExports
 from pyodide_build.vendor._pypabuild import (
     _DefaultIsolatedEnv,
@@ -51,6 +52,7 @@ SYMLINK_ENV_VARS = {
 def _gen_runner(
     cross_build_env: Mapping[str, str],
     isolated_build_env: _DefaultIsolatedEnv = None,
+    verbosity: int = 0,
 ) -> Callable[[Sequence[str], str | None, Mapping[str, str] | None], None]:
     """
     This returns a slightly modified version of default subprocess runner that pypa/build uses.
@@ -66,6 +68,8 @@ def _gen_runner(
         The cross build environment for pywasmcross.
     isolated_build_env
         The isolated build environment created by pypa/build.
+    verbosity
+        Verbosity level. When >= 1, the build backend command is logged.
     """
 
     def _runner(cmd, cwd=None, extra_environ=None):
@@ -85,8 +89,8 @@ def _gen_runner(
             env["BUILD_ENV_SCRIPTS_DIR"] = scripts_dir
 
         env["PATH"] = f"{cross_build_env['COMPILER_WRAPPER_DIR']}:{env['PATH']}"
-        # For debugging: Uncomment the following line to print the build command
-        # print("Build backend call:", " ".join(str(x) for x in cmd), file=sys.stderr)
+        if verbosity >= 1:
+            logger.debug("Build backend call: %s", " ".join(str(x) for x in cmd))
         sp.check_call(cmd, cwd=cwd, env=env)
 
     return _runner

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -25,7 +25,6 @@ from pyodide_build.build_env import (
     in_xbuildenv,
     platform,
 )
-from pyodide_build.logger import logger, set_log_level
 from pyodide_build.spec import _BuildSpecExports
 from pyodide_build.vendor._pypabuild import (
     _DefaultIsolatedEnv,
@@ -90,7 +89,7 @@ def _gen_runner(
 
         env["PATH"] = f"{cross_build_env['COMPILER_WRAPPER_DIR']}:{env['PATH']}"
         if verbosity >= 1:
-            logger.debug("Build backend call: %s", " ".join(str(x) for x in cmd))
+            print(f"> {' '.join(str(x) for x in cmd)}", file=sys.stderr, flush=True)
         sp.check_call(cmd, cwd=cwd, env=env)
 
     return _runner
@@ -372,6 +371,32 @@ def get_build_env(
         yield env
 
 
+def _make_pypa_build_logger() -> Callable[[str], None]:
+    """
+    Returns a logger function compatible with build._ctx.LOGGER.
+
+    pypa/build's default _log_default sends messages to logging.getLogger('build')
+    at INFO level, but that logger has no handlers and an effective level of WARNING,
+    so all output is silently dropped when we use pypa/build as a library.
+
+    We mirror pypa/build's CLI logger where everything goes to stderr.
+    """
+
+    def _log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
+        msg = message.rstrip()
+        if not msg:
+            return
+        match kind:
+            case ("subprocess", "cmd"):
+                print(f"> {msg}", file=sys.stderr, flush=True)
+            case ("subprocess", *_):
+                print(f"< {msg}", file=sys.stderr, flush=True)
+            case _:
+                print(msg, file=sys.stderr, flush=True)
+
+    return _log
+
+
 def build(
     srcdir: Path,
     outdir: Path,
@@ -381,42 +406,42 @@ def build(
     skip_dependency_check: bool = False,
     verbosity: int = 0,
 ) -> str:
-    import logging
-
     from build import _ctx as _build_ctx
 
-    _build_ctx.VERBOSITY.set(verbosity)
-    log_level = logging.DEBUG if verbosity >= 1 else logging.INFO
-    with set_log_level(logger, log_level):
-        try:
-            with _handle_build_error():
-                if isolation:
-                    built = _build_in_isolated_env(
-                        build_env,
-                        srcdir,
-                        str(outdir),
-                        "wheel",
-                        config_settings,
-                        verbosity=verbosity,
-                    )
-                else:
-                    built = _build_in_current_env(
-                        build_env,
-                        srcdir,
-                        str(outdir),
-                        "wheel",
-                        config_settings,
-                        skip_dependency_check,
-                        verbosity=verbosity,
-                    )
-                print(
-                    "{bold}{green}Successfully built {}{reset}".format(
-                        built, **_styles.get()
-                    )
+    token_verbosity = _build_ctx.VERBOSITY.set(verbosity)
+    token_logger = _build_ctx.LOGGER.set(_make_pypa_build_logger())
+    try:
+        with _handle_build_error():
+            if isolation:
+                built = _build_in_isolated_env(
+                    build_env,
+                    srcdir,
+                    str(outdir),
+                    "wheel",
+                    config_settings,
+                    verbosity=verbosity,
                 )
-                return built
-        except Exception as e:  # pragma: no cover
-            tb = traceback.format_exc().strip("\n")
-            print("\n{dim}{}{reset}\n".format(tb, **_styles.get()))
-            _error(str(e))
-            sys.exit(1)
+            else:
+                built = _build_in_current_env(
+                    build_env,
+                    srcdir,
+                    str(outdir),
+                    "wheel",
+                    config_settings,
+                    skip_dependency_check,
+                    verbosity=verbosity,
+                )
+            print(
+                "{bold}{green}Successfully built {}{reset}".format(
+                    built, **_styles.get()
+                )
+            )
+            return built
+    except Exception as e:  # pragma: no cover
+        tb = traceback.format_exc().strip("\n")
+        print("\n{dim}{}{reset}\n".format(tb, **_styles.get()))
+        _error(str(e))
+        sys.exit(1)
+    finally:
+        _build_ctx.VERBOSITY.reset(token_verbosity)
+        _build_ctx.LOGGER.reset(token_logger)

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -226,7 +226,9 @@ def _build_in_current_env(
     verbosity: int = 0,
 ) -> str:
     with common.replace_env(build_env):
-        builder = ProjectBuilder(srcdir, runner=_gen_runner(build_env, verbosity=verbosity))
+        builder = ProjectBuilder(
+            srcdir, runner=_gen_runner(build_env, verbosity=verbosity)
+        )
 
         if not skip_dependency_check:
             missing = builder.check_dependencies(distribution, config_settings or {})

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -926,3 +926,62 @@ def test_build_combined_flags(
     assert len(build_calls) == 1
     assert build_calls[0]["isolation"] == isolation
     assert build_calls[0]["skip_dependency_check"] == skip_check
+
+
+@pytest.mark.parametrize(
+    "verbosity_args,expected_verbosity",
+    [
+        ([], 0),
+        (["-v"], 1),
+        (["-vv"], 2),
+        (["--verbose"], 1),
+        (["-v", "-v"], 2),
+    ],
+)
+def test_build_verbosity_flag(
+    tmp_path,
+    monkeypatch,
+    dummy_xbuildenv,
+    mock_emscripten,
+    verbosity_args,
+    expected_verbosity,
+):
+    """Test that -v/-vv verbosity flags are accepted and propagate correctly."""
+    from pyodide_build import pypabuild
+
+    build_calls = []
+
+    def mocked_build(
+        srcdir,
+        outdir,
+        env,
+        config_settings,
+        isolation=True,
+        skip_dependency_check=False,
+        verbosity=0,
+    ):
+        build_calls.append({"verbosity": verbosity})
+        dummy_wheel = outdir / "package-1.0.0-py3-none-any.whl"
+        return str(dummy_wheel)
+
+    monkeypatch.setattr(pypabuild, "build", mocked_build)
+    monkeypatch.setattr(build_env, "ensure_emscripten", lambda skip_install=False: None)
+    monkeypatch.setattr(build_env, "replace_so_abi_tags", lambda whl: None)
+    monkeypatch.setattr(
+        common, "retag_wheel", lambda wheel_path, platform: Path(wheel_path)
+    )
+
+    from contextlib import nullcontext
+
+    monkeypatch.setattr(common, "modify_wheel", lambda whl: nullcontext())
+
+    srcdir = tmp_path / "in"
+    outdir = tmp_path / "out"
+    srcdir.mkdir()
+
+    args = [str(srcdir), "--outdir", str(outdir)] + verbosity_args
+    result = runner.invoke(build.main, args)
+
+    assert result.exit_code == 0, result.output
+    assert len(build_calls) == 1
+    assert build_calls[0]["verbosity"] == expected_verbosity

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -440,6 +440,7 @@ def test_build1(tmp_path, monkeypatch, dummy_xbuildenv, mock_emscripten):
         backend_flags: Any,
         isolation=True,
         skip_dependency_check=False,
+        verbosity=0,
     ) -> str:
         results["srcdir"] = srcdir
         results["outdir"] = outdir
@@ -521,6 +522,7 @@ def test_build_exports(monkeypatch, dummy_xbuildenv):
         backend_flags,
         isolation=True,
         skip_dependency_check=False,
+        verbosity=0,
     ):
         nonlocal exports_
         exports_ = exports
@@ -576,6 +578,7 @@ def test_build_config_settings(monkeypatch, dummy_xbuildenv):
         config_settings,
         isolation=True,
         skip_dependency_check=False,
+        verbosity=0,
     ):
         nonlocal config_settings_passed
         config_settings_passed = config_settings
@@ -757,6 +760,7 @@ def test_build_isolation_flags(
         config_settings,
         isolation=True,
         skip_dependency_check=False,
+        verbosity=0,
     ):
         build_calls.append(
             {
@@ -819,6 +823,7 @@ def test_build_skip_dependency_check(
         config_settings,
         isolation=True,
         skip_dependency_check=False,
+        verbosity=0,
     ):
         build_calls.append(
             {
@@ -882,6 +887,7 @@ def test_build_combined_flags(
         config_settings,
         isolation=True,
         skip_dependency_check=False,
+        verbosity=0,
     ):
         build_calls.append(
             {

--- a/pyodide_build/tests/test_oot_build.py
+++ b/pyodide_build/tests/test_oot_build.py
@@ -43,34 +43,54 @@ def test_non_platformed_build(dummy_xbuildenv, fake_pkg):
 @pytest.mark.parametrize("verbosity", [0, 1, 2])
 def test_build_verbosity_output(dummy_xbuildenv, fake_pkg, capfd, verbosity):
     """
-    This test checks for two things:
+    This test checks that the stderr output at each verbosity level is correct.
     1. Building at any verbosity level from 0 to 2 must succeed in producing a wheel,
        and show the expected pypa/build step messages (like "Building wheel...") on stderr.
-    2. At verbosity level 1 or higher, the backend subprocess command lines, i.e., the
-       pyproject_hook invocations that are printed with a "> " prefix to stderr, should
-       appear. At verbosity 0, they should not.
+    2.a. At verbosity level 1 or higher, the backend subprocess command lines (i.e., the
+       PEP 517 pyproject_hook invocations) and the installer commands should appear and be
+       printed as a "> cmd" prefix to stderr.
+    2.b. The output from the installer should appear as "< output" lines.
+    3. At build verbosity level 2 or higher, the installer command should include the "-v" flag
+    that pypa/build
+       passes along to the installer. See:
+       - _UvBackend: https://github.com/pypa/build/blob/615d04cfc52ac3c1592a463f0afe484fee1cc368/src/build/env.py#L418-L419
+       - _PipBackend: https://github.com/pypa/build/blob/dcfa865c7150426e01eccc494dc22a55849ecad2/src/build/env.py#L352-L353
+    4. At verbosity 0, nothing should happen, except for the step messages from point 1.
     """
     dst = fake_pkg / "dist"
     build.run(fake_pkg, dst, "pyinit", {}, verbosity=verbosity)
     captured = capfd.readouterr()
     err = captured.err
+    stderr_lines = err.splitlines()
 
     wheels = list(dst.glob("*.whl"))
     assert len(wheels) == 1, "build must produce a wheel at every verbosity level"
 
+    # Both step messages must appear at every verbosity level.
+    assert "Getting build dependencies for wheel" in err, (
+        f"Expected 'Getting build dependencies for wheel' at verbosity={verbosity}"
+    )
     assert "Building wheel" in err, (
         f"Expected 'Building wheel' step message at verbosity={verbosity}"
     )
 
-    # The pyproject_hooks invocation is printed with "> " prefix to stderr only
-    # when verbosity >= 1 (mirrors pypa/build's "> cmd" formatting).
+    cmd_lines = [line for line in stderr_lines if line.startswith("> ")]
+    out_lines = [line for line in stderr_lines if line.startswith("< ")]
+
     if verbosity >= 1:
-        assert "> " in err, (
-            f"Expected '> cmd' backend call line on stderr at verbosity={verbosity}"
-        )
+        # Both PEP 517 hooks must appear
+        assert any("get_requires_for_build_wheel" in line for line in cmd_lines)
+        assert any("build_wheel" in line for line in cmd_lines)
+        # Installer command must appear
+        assert any("pip" in line or "uv" in line for line in cmd_lines)
+        # Output from the installer must appear
+        assert out_lines
+    # At zero verbosity, nothing should appear except the step messages (which we check above).
     else:
-        # At verbosity=0, no subprocess command lines should appear on stderr
-        # (step messages appear, but not the "> cmd" prefix lines)
-        assert not any(line.startswith("> ") for line in err.splitlines()), (
-            "Did not expect '> cmd' lines on stderr at 0 verbosity"
+        assert not cmd_lines
+        assert not out_lines
+
+    if verbosity >= 2:
+        assert any(
+            ("-v" in line) and ("pip" in line or "uv" in line) for line in cmd_lines
         )

--- a/pyodide_build/tests/test_oot_build.py
+++ b/pyodide_build/tests/test_oot_build.py
@@ -1,15 +1,10 @@
 from typing import Literal
 
+import pytest
+
 from pyodide_build.out_of_tree import build
 
-
-def test_non_platformed_build(dummy_xbuildenv, tmp_path):
-    """Check that we don't accidentally attach Pyodide platform to non
-    platformed wheels.
-    """
-
-    (tmp_path / "pyproject.toml").write_text(
-        """\
+FAKE_PYPROJECT_TOML = """\
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling<1.22"]
@@ -21,15 +16,61 @@ version = "1.0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["fake_pkg"]
-        """
-    )
+"""
+
+
+@pytest.fixture
+def fake_pkg(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(FAKE_PYPROJECT_TOML)
     (tmp_path / "fake_pkg.py").write_text("print('hi from fake_pkg!')")
-    src = tmp_path
-    dst = tmp_path / "dist"
+    return tmp_path
+
+
+def test_non_platformed_build(dummy_xbuildenv, fake_pkg):
+    """Check that we don't accidentally attach Pyodide platform to non
+    platformed wheels.
+    """
+    dst = fake_pkg / "dist"
     exports: Literal["pyinit"] = "pyinit"
     config_settings = {}  # type:ignore[var-annotated]
-    build.run(src, dst, exports, config_settings)
+    build.run(fake_pkg, dst, exports, config_settings)
 
     wheels = list(dst.glob("*.whl"))
     assert len(wheels) == 1
     assert wheels[0].name == "fake_pkg-1.0-py3-none-any.whl"
+
+
+@pytest.mark.parametrize("verbosity", [0, 1, 2])
+def test_build_verbosity_output(dummy_xbuildenv, fake_pkg, capfd, verbosity):
+    """
+    This test checks for two things:
+    1. Building at any verbosity level from 0 to 2 must succeed in producing a wheel,
+       and show the expected pypa/build step messages (like "Building wheel...") on stderr.
+    2. At verbosity level 1 or higher, the backend subprocess command lines, i.e., the
+       pyproject_hook invocations that are printed with a "> " prefix to stderr, should
+       appear. At verbosity 0, they should not.
+    """
+    dst = fake_pkg / "dist"
+    build.run(fake_pkg, dst, "pyinit", {}, verbosity=verbosity)
+    captured = capfd.readouterr()
+    err = captured.err
+
+    wheels = list(dst.glob("*.whl"))
+    assert len(wheels) == 1, "build must produce a wheel at every verbosity level"
+
+    assert "Building wheel" in err, (
+        f"Expected 'Building wheel' step message at verbosity={verbosity}"
+    )
+
+    # The pyproject_hooks invocation is printed with "> " prefix to stderr only
+    # when verbosity >= 1 (mirrors pypa/build's "> cmd" formatting).
+    if verbosity >= 1:
+        assert "> " in err, (
+            f"Expected '> cmd' backend call line on stderr at verbosity={verbosity}"
+        )
+    else:
+        # At verbosity=0, no subprocess command lines should appear on stderr
+        # (step messages appear, but not the "> cmd" prefix lines)
+        assert not any(line.startswith("> ") for line in err.splitlines()), (
+            "Did not expect '> cmd' lines on stderr at 0 verbosity"
+        )

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -215,3 +215,34 @@ class TestHandleBuildErrorSubprocessOutput:
                 raise BuildBackendException(cpe)
         captured = capsys.readouterr()
         assert "backend install error" in captured.out
+
+
+@pytest.mark.parametrize("verbosity", [0, 1, 2])
+def test_build_sets_ctx_verbosity(tmp_path, dummy_xbuildenv, monkeypatch, verbosity):
+    """pypabuild.build() must set build._ctx.VERBOSITY before calling the builder."""
+    from build import _ctx as _build_ctx
+
+    observed: list[int] = []
+
+    def _fake_isolated(
+        build_env, srcdir, outdir, distribution, config_settings, verbosity=0
+    ):
+        observed.append(_build_ctx.VERBOSITY.get())
+        return str(outdir / "pkg-1.0-py3-none-any.whl")
+
+    monkeypatch.setattr(pypabuild, "_build_in_isolated_env", _fake_isolated)
+
+    build_env_ctx = pypabuild.get_build_env(
+        env={"PATH": ""},
+        pkgname="",
+        cflags="",
+        cxxflags="",
+        ldflags="",
+        target_install_dir=str(tmp_path),
+        exports="pyinit",
+        build_dir=tmp_path,
+    )
+    with build_env_ctx as env:
+        pypabuild.build(tmp_path, tmp_path / "dist", env, {}, verbosity=verbosity)
+
+    assert observed == [verbosity]

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -228,7 +229,7 @@ def test_build_sets_ctx_verbosity(tmp_path, dummy_xbuildenv, monkeypatch, verbos
         build_env, srcdir, outdir, distribution, config_settings, verbosity=0
     ):
         observed.append(_build_ctx.VERBOSITY.get())
-        return str(outdir / "pkg-1.0-py3-none-any.whl")
+        return os.path.join(outdir, "pkg-1.0-py3-none-any.whl")
 
     monkeypatch.setattr(pypabuild, "_build_in_isolated_env", _fake_isolated)
 

--- a/pyodide_build/vendor/_pypabuild.py
+++ b/pyodide_build/vendor/_pypabuild.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 import traceback
 import warnings
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import NoReturn, TextIO
 
 from build import (
@@ -102,6 +102,25 @@ def _find_called_process_error(
     if isinstance(inner, subprocess.CalledProcessError):
         return inner
     return None
+
+
+@contextlib.contextmanager
+def _configure_build_verbosity(
+    verbosity: int,
+    logger_fn: Callable[..., None],
+) -> Iterator[None]:
+    """
+    Set build._ctx.VERBOSITY and build._ctx.LOGGER for the duration of a build.
+    """
+    from build import _ctx
+
+    token_verbosity = _ctx.VERBOSITY.set(verbosity)
+    token_logger = _ctx.LOGGER.set(logger_fn)
+    try:
+        yield
+    finally:
+        _ctx.VERBOSITY.reset(token_verbosity)
+        _ctx.LOGGER.reset(token_logger)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
I finally decided to take up #222. This PR exposes verbosity via `-v` and `-vv` CLI flags (stackable). They are passed along to pypa/build's `_ctx.VERBOSITY`. It controls pypa/build's own subprocess calls for uv/pip installs. Build backend commands (meson, cmake, gcc wrappers, etc.) are always visible regardless of verbosity.

Closes #222

TODO:
- [x] Update docs
- [x] Add some basic tests