### PR TITLE
Avoid double logging of PEP 517 `get_requires_for_build_wheel` build hook

### DIFF
--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -186,7 +186,7 @@ def _build_in_isolated_env(
         except BuildBackendException:
             pass
 
-        if not build_reqs:
+        if build_reqs is None:
             # get_requires_for_build in native env failed. Maybe trying to
             # execute get_requires_for_build in the cross build environment will
             # work?

--- a/pyodide_build/tests/test_oot_build.py
+++ b/pyodide_build/tests/test_oot_build.py
@@ -33,3 +33,43 @@ packages = ["fake_pkg"]
     wheels = list(dst.glob("*.whl"))
     assert len(wheels) == 1
     assert wheels[0].name == "fake_pkg-1.0-py3-none-any.whl"
+
+
+def test_get_requires_for_build_not_retried_on_empty_result(
+    dummy_xbuildenv, tmp_path, monkeypatch
+):
+    """Regression test for https://github.com/pyodide/pyodide-build/pull/364"""
+    from build import ProjectBuilder
+
+    orig = ProjectBuilder.get_requires_for_build
+    call_count = [0]
+
+    def get_count_for_pep517_requires(self, distribution, config_settings=None):
+        call_count[0] += 1
+        return orig(self, distribution, config_settings)
+
+    monkeypatch.setattr(
+        ProjectBuilder, "get_requires_for_build", get_count_for_pep517_requires
+    )
+
+    (tmp_path / "pyproject.toml").write_text(
+        """\
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling<1.22"]
+
+[project]
+requires-python = ">=3.10"
+name = "fake-pkg"
+version = "1.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["fake_pkg"]
+        """
+    )
+    (tmp_path / "fake_pkg.py").write_text("")
+    build.run(tmp_path, tmp_path / "dist", "pyinit", {})
+
+    assert call_count[0] == 1, (
+        f"get_requires_for_build called {call_count[0]} times but expected 1"
+    )


### PR DESCRIPTION
See explanation in https://github.com/pyodide/pyodide-build/pull/363#discussion_r3368207822. Split off from #363.