### PR TITLE
Ensure installation of cross-build packages before the build script runs

### DIFF
--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -291,6 +291,13 @@ class RecipeBuilder:
         ):
             self._build_package(bash_runner)
 
+    # Some packages such as RobotRaconteur and opencv-python reach into
+    # $HOSTINSTALLDIR/host site-packages directly from their build scripts
+    # which run before the isolated build environment is set up. The lazy
+    # install normally triggered from there would be too late for them, so
+    # we trigger it here instead, based on the package's declared host
+    # requirements. See https://github.com/pyodide/pyodide-build/issues/365
+    # for reference.
     def _ensure_cross_build_packages_for_host_requirements(self) -> None:
         """
         Make sure cross-build packages (numpy, scipy, etc.) are installed into

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -25,9 +25,12 @@ from pyodide_build.build_env import (
     _create_constraints_file,
     get_build_environment_vars,
     get_build_flag,
+    get_current_xbuildenv_manager,
     get_pyodide_root,
     get_pyversion_major,
     get_pyversion_minor,
+    get_unisolated_packages,
+    in_xbuildenv,
     pyodide_tags,
     replace_so_abi_tags,
     wheel_platform,
@@ -280,11 +283,28 @@ class RecipeBuilder:
             self._prepare_source()
             self._patch()
 
+        self._ensure_cross_build_packages_for_host_requirements()
+
         with (
             chdir(self.pkg_root),
             get_bash_runner(self._get_helper_vars() | os.environ.copy()) as bash_runner,
         ):
             self._build_package(bash_runner)
+
+    def _ensure_cross_build_packages_for_host_requirements(self) -> None:
+        """
+        Make sure cross-build packages (numpy, scipy, etc.) are installed into
+        the host site-packages before the build starts, if this package's host
+        requirements need them.
+        """
+        if not in_xbuildenv():
+            return
+
+        unisolated_packages = set(get_unisolated_packages())
+        host_requirements = {req.lower() for req in self.recipe.requirements.host}
+
+        if unisolated_packages & host_requirements:
+            get_current_xbuildenv_manager().ensure_cross_build_packages_installed()
 
     def _check_executables(self) -> None:
         """

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -165,7 +165,7 @@ def test_ensure_cross_build_packages_for_host_requirements(tmp_path, monkeypatch
             called["count"] += 1
 
     monkeypatch.setattr(_builder, "in_xbuildenv", lambda: True)
-    monkeypatch.setattr(_builder, "get_current_xbuildenv_manager", DummyManager())
+    monkeypatch.setattr(_builder, "get_current_xbuildenv_manager", DummyManager)
 
     # one of the host requirements is an unisolated package, so the install is triggered
     monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: ["pkg_3"])

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -150,6 +150,40 @@ def test_check_executables(tmp_path, monkeypatch):
         builder._check_executables()
 
 
+def test_ensure_cross_build_packages_for_host_requirements(tmp_path, monkeypatch):
+    builder = RecipeBuilder.get_builder(
+        recipe=RECIPE_DIR / "pkg_1",
+        build_args=BuildArgs(),
+        build_dir=tmp_path,
+    )
+    assert builder.recipe.requirements.host == ["pkg_1_1", "pkg_3", "libtest_shared"]
+
+    called = {"count": 0}
+
+    class DummyManager:
+        def ensure_cross_build_packages_installed(self) -> None:
+            called["count"] += 1
+
+    monkeypatch.setattr(_builder, "in_xbuildenv", lambda: True)
+    monkeypatch.setattr(_builder, "get_current_xbuildenv_manager", DummyManager())
+
+    # one of the host requirements is an unisolated package, so the install is triggered
+    monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: ["pkg_3"])
+    builder._ensure_cross_build_packages_for_host_requirements()
+    assert called["count"] == 1
+
+    # none of the host requirements are unisolated packages, so nothing should happen
+    monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: ["numpy"])
+    builder._ensure_cross_build_packages_for_host_requirements()
+    assert called["count"] == 1
+
+    # outside of an xbuildenv, the install is never triggered
+    monkeypatch.setattr(_builder, "in_xbuildenv", lambda: False)
+    monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: ["pkg_3"])
+    builder._ensure_cross_build_packages_for_host_requirements()
+    assert called["count"] == 1
+
+
 def test_get_helper_vars(tmp_path):
     builder = RecipeBuilder.get_builder(
         recipe=RECIPE_DIR / "pkg_1",


### PR DESCRIPTION
Closes #365

In our builder code, I've added a new method called `_ensure_cross_build_packages_for_host_requirements` to the base `RecipeBuilder`, and I am calling it before `self._build_package(bash_runner)` runs.

The idea is that we need to check whether the package's declared host requirements, say, `numpy` for RobotRaconteur) intersect with `get_unisolated_packages()`, and if so (and we are in an xbuildenv), we call our lazy-install machinery established via #302 a little earlier, to ensure that they get installed and the cross-build files are available when the build script runs.

I don't think I've found a better way to do this, as our build pipeline is pretty tricky to understand and test in isolation anyway.

There is an explanation in #365 for where this bug comes up in practice.