### PR TITLE
Add stable-debug release variant installation handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#349](https://github.com/pyodide/pyodide-build/pull/349)
 
 - `pyodide xbuildenv search` and `pyodide xbuildenv install` now support `--nightly`
-  and `--debug` flags to search and install nightly and nightly-debug cross-build
-  environments respectively.
-  [#350](https://github.com/pyodide/pyodide-build/pull/350)
+  and `--debug` flags to search and install stable-debug, nightly, and nightly-debug
+  cross-build environments respectively.
+  [#350](https://github.com/pyodide/pyodide-build/pull/350), [#354](https://github.com/pyodide/pyodide-build/pull/371)
 
 - `pyodide build` now accepts `-v`/`--verbose` flags (stackable twice up to `-vv`)
   to increase build verbosity. At `-v`, installer commands and

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -29,10 +29,12 @@ When you run `pyodide build`, pyodide-build automatically downloads and sets up 
 You can also manage the cross-build environment explicitly:
 
 ```bash
-pyodide xbuildenv install           # install (or update) the cross-build environment
-pyodide xbuildenv install 0.29.3    # install a specific Pyodide version
-pyodide xbuildenv install --nightly # install the latest nightly release
-pyodide xbuildenv versions          # list installed versions
+pyodide xbuildenv install                  # install (or update) the cross-build environment
+pyodide xbuildenv install 0.29.3           # install a specific Pyodide version
+pyodide xbuildenv install --nightly        # install the latest nightly release
+pyodide xbuildenv install --debug          # install the latest stable debug release
+pyodide xbuildenv install --nightly --debug # install the latest nightly debug release
+pyodide xbuildenv versions                 # list installed versions
 ```
 
 See [Managing Cross-Build Environments](../how-to/xbuildenv.md) for more details.

--- a/docs/how-to/xbuildenv.md
+++ b/docs/how-to/xbuildenv.md
@@ -31,8 +31,11 @@ pyodide xbuildenv install --nightly
 # Install a specific nightly version
 pyodide xbuildenv install 20260520 --nightly
 
-# Install the debug variant of the latest nightly release
+# Install the debug variant of the latest stable release
 pyodide xbuildenv install --debug
+
+# Install the debug variant of the latest nightly release
+pyodide xbuildenv install --nightly --debug
 ```
 
 ## Listing installed versions
@@ -83,10 +86,13 @@ pyodide xbuildenv search --all
 # Search nightly releases
 pyodide xbuildenv search --nightly
 
-# Search nightly debug releases
+# Search stable debug releases
 pyodide xbuildenv search --debug
 
-# Combine flags: show all nightly and debug releases
+# Search nightly debug releases
+pyodide xbuildenv search --nightly --debug
+
+# Search all nightly debug releases, including incompatible ones
 pyodide xbuildenv search --nightly --debug --all
 
 # Output as JSON (useful for scripting)

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -9,6 +9,7 @@ from pyodide_build.xbuildenv import CrossBuildEnvManager
 from pyodide_build.xbuildenv_releases import (
     NIGHTLY_CROSS_BUILD_ENV_METADATA_URL,
     NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
+    STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,
 )
@@ -63,7 +64,7 @@ def check_xbuildenv_root(path: Path) -> None:
     "--debug",
     is_flag=True,
     default=False,
-    help="install the debug variant of the cross-build environment (nightly only).",
+    help="install the debug variant of the cross-build environment. Combine with --nightly to install the nightly debug variant.",
 )
 @click.option(
     "--skip-cross-build-packages",
@@ -94,12 +95,12 @@ def _install(
     Arguments:
         VERSION: version of cross-build environment to install (optional)
     """
-    if nightly or debug:
-        metadata_url = (
-            NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL
-            if debug
-            else NIGHTLY_CROSS_BUILD_ENV_METADATA_URL
-        )
+    if nightly and debug:
+        metadata_url = NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL
+    elif nightly:
+        metadata_url = NIGHTLY_CROSS_BUILD_ENV_METADATA_URL
+    elif debug:
+        metadata_url = STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL
     else:
         metadata_url = None
 
@@ -223,7 +224,7 @@ def _use(version: str, path: Path) -> None:
     "--debug",
     is_flag=True,
     default=False,
-    help="search nightly debug releases instead of stable ones.",
+    help="search debug releases. Searches stable-debug by default. Combine with --nightly to search nightly-debug releases.",
 )
 @click.option(
     "--json",
@@ -275,14 +276,12 @@ def _search(
         )
 
     if nightly or debug:
-        # Nightly and/or debug releases (mutually exclusive with stable)
-        sources = []
-        if nightly:
-            sources.append(("nightly", NIGHTLY_CROSS_BUILD_ENV_METADATA_URL))
-        if debug:
-            sources.append(
-                ("nightly-debug", NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL)
-            )
+        if nightly and debug:
+            sources = [("nightly-debug", NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL)]
+        elif nightly:
+            sources = [("nightly", NIGHTLY_CROSS_BUILD_ENV_METADATA_URL)]
+        else:
+            sources = [("stable-debug", STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL)]
         compat = _compat_kwargs()
         views = [
             _make_view(release, source)

--- a/pyodide_build/tests/test_cli_xbuildenv.py
+++ b/pyodide_build/tests/test_cli_xbuildenv.py
@@ -225,7 +225,48 @@ def test_xbuildenv_install_nightly(tmp_path, mock_xbuildenv_url, monkeypatch):
 
 
 def test_xbuildenv_install_debug(tmp_path, mock_xbuildenv_url, monkeypatch):
-    """Installing with --debug uses the nightly-debug metadata URL, not stable."""
+    """Installing with --debug uses the stable-debug metadata URL, not nightly-debug."""
+    from pyodide_build import build_env
+
+    envpath = Path(tmp_path) / ".xbuildenv"
+    local = build_env.local_versions()
+
+    debug_data = {
+        "releases": {
+            "0.30.0": {
+                "version": "0.30.0",
+                "url": mock_xbuildenv_url,
+                "sha256": None,
+                "python_version": f"{local['python']}.0",
+                "emscripten_version": "5.0.3",
+                "published_at": "2026-05-20T04:40:12Z",
+                "min_pyodide_build_version": None,
+                "max_pyodide_build_version": None,
+            }
+        }
+    }
+    metadata_path = tmp_path / "stable-debug.json"
+    metadata_path.write_text(json.dumps(debug_data))
+
+    monkeypatch.setattr(
+        "pyodide_build.cli.xbuildenv.STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL",
+        str(metadata_path),
+    )
+
+    result = runner.invoke(
+        xbuildenv.app,
+        ["install", "0.30.0", "--path", str(envpath), "--debug"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Pyodide cross-build environment installed at" in result.output
+    assert str(envpath.resolve()) in result.output
+    assert (envpath / "xbuildenv").is_symlink()
+    assert (envpath / "0.30.0").exists()
+
+
+def test_xbuildenv_install_nightly_debug(tmp_path, mock_xbuildenv_url, monkeypatch):
+    """Installing with --nightly --debug uses the nightly-debug metadata URL."""
     from pyodide_build import build_env
 
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -255,7 +296,7 @@ def test_xbuildenv_install_debug(tmp_path, mock_xbuildenv_url, monkeypatch):
 
     result = runner.invoke(
         xbuildenv.app,
-        ["install", "20260520", "--path", str(envpath), "--debug"],
+        ["install", "20260520", "--path", str(envpath), "--nightly", "--debug"],
     )
 
     assert result.exit_code == 0, result.output
@@ -541,8 +582,33 @@ def fake_nightly_release_metadata(tmp_path):
 
 
 @pytest.fixture
+def fake_stable_debug_metadata(tmp_path):
+    """Fake stable-debug metadata — only entries that have a stable debug build."""
+    from pyodide_build import build_env
+
+    local = build_env.local_versions()
+    data = {
+        "releases": {
+            "0.30.0": {
+                "version": "0.30.0",
+                "url": "https://example.com/0.30.0/xbuildenv-debug.tar.bz2",
+                "sha256": "stable_debug_abc123",
+                "python_version": f"{local['python']}.0",
+                "emscripten_version": "5.0.3",
+                "published_at": "2026-05-01T12:00:00Z",
+                "min_pyodide_build_version": "0.26.0",
+                "max_pyodide_build_version": None,
+            },
+        }
+    }
+    path = tmp_path / "stable-debug.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+@pytest.fixture
 def fake_nightly_debug_metadata(tmp_path):
-    """Fake nightly debug metadata — only entries that have a debug build."""
+    """Fake nightly debug metadata — only entries that have a nightly debug build."""
     from pyodide_build import build_env
 
     local = build_env.local_versions()
@@ -609,12 +675,12 @@ def test_xbuildenv_search_nightly(
 
 def test_xbuildenv_search_debug(
     tmp_path,
-    fake_nightly_debug_metadata,
+    fake_stable_debug_metadata,
     monkeypatch,
 ):
     monkeypatch.setattr(
-        "pyodide_build.cli.xbuildenv.NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL",
-        str(fake_nightly_debug_metadata),
+        "pyodide_build.cli.xbuildenv.STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL",
+        str(fake_stable_debug_metadata),
     )
 
     result = runner.invoke(
@@ -628,25 +694,19 @@ def test_xbuildenv_search_debug(
 
     assert result.exit_code == 0, result.output
 
-    # Only nightly-debug entries should be present. Stable and nightly-release versions
-    # are not mixed in. 20250101 is absent because it has no debug build (not in the
-    # debug metadata file).
-    assert "stable" not in result.output
-    assert "nightly-debug" in result.output
-    assert "20260520" in result.output
-    assert "20250101" not in result.output
+    # Only stable-debug entries should be present. Nightly and nightly-debug versions
+    # are not mixed in.
+    assert "stable-debug" in result.output
+    assert "nightly-debug" not in result.output
+    assert "0.30.0" in result.output
+    assert "20260520" not in result.output
 
 
-def test_xbuildenv_search_nightly_json(
+def test_xbuildenv_search_nightly_debug_json(
     tmp_path,
-    fake_nightly_release_metadata,
     fake_nightly_debug_metadata,
     monkeypatch,
 ):
-    monkeypatch.setattr(
-        "pyodide_build.cli.xbuildenv.NIGHTLY_CROSS_BUILD_ENV_METADATA_URL",
-        str(fake_nightly_release_metadata),
-    )
     monkeypatch.setattr(
         "pyodide_build.cli.xbuildenv.NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL",
         str(fake_nightly_debug_metadata),
@@ -668,7 +728,7 @@ def test_xbuildenv_search_nightly_json(
 
     output = json.loads(result.output)
     sources = {env["source"] for env in output["environments"]}
-    assert sources == {"nightly", "nightly-debug"}
+    assert sources == {"nightly-debug"}
 
     for env in output["environments"]:
         assert "debug_url" not in env

--- a/pyodide_build/views.py
+++ b/pyodide_build/views.py
@@ -16,7 +16,7 @@ class MetadataView:
     published_at: str = ""
     source: str = field(
         default="stable"
-    )  # "stable", "nightly", or "nightly-debug" # TODO: add stable-debug builds?
+    )  # "stable", "stable-debug", "nightly", or "nightly-debug"
 
     @classmethod
     def to_table(cls, views: list["MetadataView"], show_source: bool = False) -> str:

--- a/pyodide_build/xbuildenv_releases.py
+++ b/pyodide_build/xbuildenv_releases.py
@@ -15,6 +15,9 @@ NIGHTLY_CROSS_BUILD_ENV_METADATA_URL = (
 NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL = (
     "https://pyodide.github.io/pyodide-build-environment-nightly/api/v2/debug.json"
 )
+STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL = (
+    "https://pyodide.github.io/pyodide/api/v2/debug.json"
+)
 CROSS_BUILD_ENV_METADATA_URL_ENV_VAR = "PYODIDE_CROSS_BUILD_ENV_METADATA_URL"
 
 


### PR DESCRIPTION
- https://github.com/pyodide/pyodide/pull/6257 is now released, so we now have https://pyodide.github.io/pyodide/api/v2/debug.json available.
- Now, we have
	- `xbuildenv search` shows only stable release cross-build environments
	- xbuildenv search --debug shows only stable-debug variants of release cross-build environments
	- `xbuildenv search --nightly` should show only nightly ones
	- `xbuildenv search --nightly --debug` should show only debug variants of nightly ones

I have updated the tests and docs to that effect.