### PR TITLE
Fix cross-build-environment lifecycle bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed several bugs in the cross-build-environment (xbuildenv) lifecycle
-  [#376](https://github.com/pyodide/pyodide-build/issues/376):
+  [#376](https://github.com/pyodide/pyodide-build/issues/376),
+  [#378](https://github.com/pyodide/pyodide-build/pull/378):
   - A Python-version marker mismatch on an already-installed xbuildenv no longer
     silently overwrites the marker with the current Python version. A reinstall
     now actually refreshes the host packages (or surfaces the intended error)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed several bugs in the cross-build-environment (xbuildenv) lifecycle
+  [#376](https://github.com/pyodide/pyodide-build/issues/376):
+  - A Python-version marker mismatch on an already-installed xbuildenv no longer
+    silently overwrites the marker with the current Python version. A reinstall
+    now actually refreshes the host packages (or surfaces the intended error)
+    instead of letting builds proceed with packages installed under the old Python.
+  - Installing via `DEFAULT_CROSS_BUILD_ENV_URL` is now treated like an explicit
+    `--url` install, so it no longer bakes a mangled, URL-derived version into the
+    generated package index.
+  - `use_version()` no longer raises `FileExistsError` when the `xbuildenv`
+    symlink is dangling (its target was removed); the stale symlink is now
+    cleaned up first.
+  - A failure during a later installation step no longer deletes a pre-existing,
+    valid cached xbuildenv: only a directory created by the current `install()`
+    call is removed on failure, and the cleanup no longer masks the original error.
+  - `_find_latest_version()` now reports the correct newest/oldest supported
+    Python versions on a mismatch (sorting by Python version) and raises a clear
+    error instead of an `IndexError` when the releases metadata is empty.
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 from collections import namedtuple
 
@@ -423,6 +424,194 @@ class TestCrossBuildEnvManager:
 
         marker = manager.symlink_dir.resolve() / ".cross-build-packages-installed"
         assert marker.exists()
+
+    def test_use_version_dangling_symlink(self, tmp_path):
+        # Regression test: a dangling xbuildenv symlink (target removed) must be
+        # cleaned up so that use_version() does not raise FileExistsError.
+        manager = CrossBuildEnvManager(tmp_path)
+
+        (tmp_path / "0.25.0").mkdir()
+        (tmp_path / "0.26.0").mkdir()
+
+        # Point the symlink at a directory and then delete that directory,
+        # leaving a dangling symlink behind.
+        manager.use_version("0.25.0")
+        shutil.rmtree(tmp_path / "0.25.0")
+
+        assert manager.symlink_dir.is_symlink()
+        assert not manager.symlink_dir.exists()  # dangling
+
+        # This previously raised FileExistsError.
+        manager.use_version("0.26.0")
+
+        assert manager.symlink_dir.is_symlink()
+        assert manager.symlink_dir.resolve() == tmp_path / "0.26.0"
+
+    def test_install_preexisting_not_deleted_on_failure(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch,
+        monkeypatch_subprocess_run_pip,
+    ):
+        # Regression test: if a valid xbuildenv is already installed and a later
+        # step (e.g. use_version) of a subsequent install() fails, the existing
+        # installation must NOT be deleted.
+        manager = CrossBuildEnvManager(tmp_path)
+
+        manager.install(version=None, url=dummy_xbuildenv_url)
+        version = _url_to_version(dummy_xbuildenv_url)
+        download_path = tmp_path / version
+        assert download_path.exists()
+
+        # Make a later step fail on the second install() call.
+        def boom(_version):
+            raise OSError("simulated symlink failure (e.g. Windows privilege)")
+
+        monkeypatch.setattr(manager, "use_version", boom)
+
+        with pytest.raises(OSError, match="simulated symlink failure"):
+            manager.install(version=None, url=dummy_xbuildenv_url)
+
+        # The pre-existing installation must still be present.
+        assert download_path.exists()
+        assert (download_path / ".installed").exists()
+
+    def test_install_new_deleted_on_failure(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch,
+        monkeypatch_subprocess_run_pip,
+    ):
+        # Complement: when THIS call created the directory and a later step
+        # fails, the freshly downloaded directory should be removed.
+        manager = CrossBuildEnvManager(tmp_path)
+        version = _url_to_version(dummy_xbuildenv_url)
+        download_path = tmp_path / version
+
+        def boom(_version):
+            raise OSError("simulated symlink failure")
+
+        monkeypatch.setattr(manager, "use_version", boom)
+
+        with pytest.raises(OSError, match="simulated symlink failure"):
+            manager.install(version=None, url=dummy_xbuildenv_url)
+
+        assert not download_path.exists()
+
+    def test_install_url_default_no_mangled_package_index(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch,
+        monkeypatch_subprocess_run_pip,
+        reset_cache,
+        reset_env_vars,
+    ):
+        # Regression test: installing via DEFAULT_CROSS_BUILD_ENV_URL must be
+        # treated like an explicit-url install and NOT create a package index
+        # baked with a mangled (URL-derived) version string.
+        manager = CrossBuildEnvManager(tmp_path)
+
+        os.environ["DEFAULT_CROSS_BUILD_ENV_URL"] = dummy_xbuildenv_url
+        manager.install(version=None)
+
+        assert not (
+            manager.symlink_dir / "xbuildenv" / "pyodide-root" / "package_index"
+        ).exists()
+
+    def test_install_version_marker_mismatch_triggers_reinstall(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch,
+        monkeypatch_subprocess_run_pip,
+    ):
+        # Regression test: when an already-installed xbuildenv has a Python
+        # version marker that does not match the current Python, a subsequent
+        # install() must rewrite the marker (and refresh host packages) rather
+        # than skipping work and leaving the stale marker / silently passing.
+        manager = CrossBuildEnvManager(tmp_path)
+
+        manager.install(
+            version=None,
+            url=dummy_xbuildenv_url,
+            skip_install_cross_build_packages=True,
+        )
+        version = _url_to_version(dummy_xbuildenv_url)
+        download_path = tmp_path / version
+
+        # Simulate the env having been installed under a different Python and
+        # mark cross-build packages as already installed.
+        marker_file = download_path / ".build-python-version"
+        marker_file.write_text("2.7.10")
+        cross_build_marker = download_path / ".cross-build-packages-installed"
+        cross_build_marker.touch()
+
+        matches, _ = manager.version_marker_matches()
+        assert not matches
+
+        # Reinstall should rewrite the marker to the current Python version.
+        manager.install(
+            version=None,
+            url=dummy_xbuildenv_url,
+            skip_install_cross_build_packages=True,
+        )
+
+        matches, err = manager.version_marker_matches()
+        assert matches, err
+        assert (
+            marker_file.read_text()
+            == f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
+        # Host-package marker dropped so packages get reinstalled lazily.
+        assert not cross_build_marker.exists()
+
+    def test_install_version_marker_match_no_marker_rewrite(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch,
+        monkeypatch_subprocess_run_pip,
+    ):
+        # When the marker already matches, a repeat install() should be a no-op
+        # and must not re-run installation work or drop the cross-build marker.
+        manager = CrossBuildEnvManager(tmp_path)
+
+        manager.install(
+            version=None,
+            url=dummy_xbuildenv_url,
+            skip_install_cross_build_packages=True,
+        )
+        version = _url_to_version(dummy_xbuildenv_url)
+        download_path = tmp_path / version
+        cross_build_marker = download_path / ".cross-build-packages-installed"
+        cross_build_marker.touch()
+
+        manager.install(
+            version=None,
+            url=dummy_xbuildenv_url,
+            skip_install_cross_build_packages=True,
+        )
+
+        # Marker preserved (install did no work).
+        assert cross_build_marker.exists()
+
+    def test_find_latest_version_empty_releases(self, tmp_path):
+        # Regression test: empty releases metadata must produce a clear error,
+        # not an IndexError.
+        import json
+
+        metadata_path = tmp_path / "empty-metadata.json"
+        metadata_path.write_text(json.dumps({"releases": {}}))
+
+        manager = CrossBuildEnvManager(tmp_path, str(metadata_path))
+
+        with pytest.raises(
+            ValueError, match="No cross-build environment releases are available"
+        ):
+            manager._find_latest_version()
 
 
 @pytest.mark.parametrize(

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from packaging.version import Version
 from pyodide_lock import PyodideLockSpec
 
 from pyodide_build import build_env, uv_helper
@@ -157,17 +158,21 @@ class CrossBuildEnvManager:
 
         symlink_dir = self.symlink_dir
 
-        if symlink_dir.exists():
-            if symlink_dir.is_symlink():
-                # symlink to a directory, expected case
-                symlink_dir.unlink()
-            elif symlink_dir.is_dir():
-                # real directory, for backwards compatibility
-                shutil.rmtree(symlink_dir)
-            else:
-                # file. This should not happen unless the user manually created a file
-                # but we will remove it anyway
-                symlink_dir.unlink()
+        # Use is_symlink() / exists() with lexists semantics so that a dangling
+        # symlink (one whose target no longer exists) is also removed. A plain
+        # exists() check follows the link and returns False for dangling links,
+        # which would leave the stale symlink in place and make symlink_to()
+        # raise FileExistsError.
+        if symlink_dir.is_symlink():
+            # symlink (possibly dangling), expected case
+            symlink_dir.unlink()
+        elif symlink_dir.is_dir():
+            # real directory, for backwards compatibility
+            shutil.rmtree(symlink_dir)
+        elif symlink_dir.exists():
+            # file. This should not happen unless the user manually created a file
+            # but we will remove it anyway
+            symlink_dir.unlink()
 
         symlink_dir.symlink_to(version_path)
 
@@ -208,13 +213,20 @@ class CrossBuildEnvManager:
         if url and version:
             raise ValueError("Cannot specify both version and url")
 
+        # Whether we are installing from an arbitrary URL (explicit or default).
+        # In that case the "version" is a mangled URL string rather than a real
+        # release version, so we must not bake it into the package index.
+        installed_from_url = False
+
         if url:
             version = _url_to_version(url)
             download_url = url
+            installed_from_url = True
         # if default version is specified in the configuration, use that
         elif not version and (default_url := self._get_default_xbuildenv_url()):
             version = _url_to_version(default_url)
             download_url = default_url
+            installed_from_url = True
         else:
             version = version or self._find_latest_version()
 
@@ -232,7 +244,11 @@ class CrossBuildEnvManager:
 
         download_path = self._path_for_version(version)
 
-        if download_path.exists():
+        # Track whether THIS call created the directory, so that a failure later
+        # in this method does not delete a previously-good cached installation.
+        download_path_preexisted = download_path.exists()
+
+        if download_path_preexisted:
             logger.info(
                 "The cross-build environment already exists at '%s', skipping download",
                 download_path,
@@ -248,28 +264,54 @@ class CrossBuildEnvManager:
             xbuildenv_root = download_path / "xbuildenv"
             xbuildenv_pyodide_root = xbuildenv_root / "pyodide-root"
             install_marker = download_path / ".installed"
-            if not install_marker.exists():
+
+            # Detect a Python-version mismatch on an already-installed env so we
+            # can refresh the host packages that were installed under the old
+            # Python version.
+            version_marker_mismatch = False
+            if install_marker.exists():
+                matches, _ = self._version_marker_matches_for(download_path)
+                version_marker_mismatch = not matches
+
+            did_install_work = False
+            if not install_marker.exists() or version_marker_mismatch:
                 logger.info(
                     "Installing Pyodide cross-build environment to %s", download_path
+                )
+                did_install_work = True
+
+                cross_build_packages_marker = self._cross_build_packages_marker_path(
+                    download_path
                 )
 
                 if not skip_install_cross_build_packages:
                     self._install_cross_build_packages(
                         xbuildenv_root, xbuildenv_pyodide_root
                     )
-                    self._cross_build_packages_marker_path(download_path).touch()
+                    cross_build_packages_marker.touch()
+                elif version_marker_mismatch:
+                    # The host packages were installed under a different Python
+                    # version. Drop the marker so they get reinstalled lazily.
+                    cross_build_packages_marker.unlink(missing_ok=True)
 
-                if not url:
-                    # If installed from url, skip creating the PyPI index (version is not known)
+                if not installed_from_url:
+                    # If installed from url, skip creating the PyPI index
+                    # (version is a mangled URL string, not a real version)
                     self._create_package_index(xbuildenv_pyodide_root, version)
 
             install_marker.touch()
             self.use_version(version)
-            self._add_version_marker()
-        except Exception as e:
-            # if the installation failed, remove the downloaded directory
-            shutil.rmtree(download_path)
-            raise e
+            # Only (re)write the Python version marker when we actually performed
+            # installation work, so a mismatch on a skipped install is not
+            # silently masked by overwriting the marker with the current Python.
+            if did_install_work:
+                self._add_version_marker()
+        except Exception:
+            # If THIS call created the download directory and the installation
+            # failed, remove it. Do not delete a pre-existing cached install.
+            if not download_path_preexisted:
+                shutil.rmtree(download_path, ignore_errors=True)
+            raise
 
         return xbuildenv_pyodide_root
 
@@ -285,21 +327,37 @@ class CrossBuildEnvManager:
         )
 
         if not latest:
-            # Check for Python version mismatch
-            python_versions = [
-                v.python_version_tuple[:2] for v in metadata.list_compatible_releases()
-            ]
+            # Check for Python version mismatch. The releases are sorted by
+            # Pyodide version, so we must re-sort the Python versions explicitly
+            # (by Python version) before comparing newest/oldest.
+            python_versions = sorted(
+                {
+                    release.python_version_tuple[:2]
+                    for release in metadata.list_compatible_releases()
+                },
+                key=lambda v: Version(".".join(str(x) for x in v)),
+            )
+
+            if not python_versions:
+                raise ValueError(
+                    "No cross-build environment releases are available in the "
+                    f"metadata at {self.metadata_url}."
+                )
+
             pyver = tuple(int(x) for x in local["python"].split("."))
-            if pyver > python_versions[0]:
-                latest_supported = ".".join(str(x) for x in python_versions[0])
+            newest_supported = python_versions[-1]
+            oldest_supported = python_versions[0]
+
+            if pyver > newest_supported:
+                latest_supported = ".".join(str(x) for x in newest_supported)
                 raise ValueError(
                     f"Python version {local['python']} is not yet supported. The newest supported version of Python is {latest_supported}."
                 )
 
-            if pyver < python_versions[-1]:
-                oldest_supported = ".".join(str(x) for x in python_versions[-1])
+            if pyver < oldest_supported:
+                oldest_supported_str = ".".join(str(x) for x in oldest_supported)
                 raise ValueError(
-                    f"Python version {local['python']} is too old. The oldest supported version of Python is {oldest_supported}."
+                    f"Python version {local['python']} is too old. The oldest supported version of Python is {oldest_supported_str}."
                 )
 
             raise ValueError(
@@ -602,7 +660,21 @@ class CrossBuildEnvManager:
         if not self.symlink_dir.is_dir():
             return False, "cross-build env directory does not exist"
 
-        version_file = self.symlink_dir / PYTHON_VERSION_MARKER_FILE
+        return self._version_marker_matches_for(self.symlink_dir)
+
+    def _version_marker_matches_for(
+        self, version_path: Path
+    ) -> tuple[bool, str | None]:
+        """
+        Check whether the Python version marker stored in ``version_path``
+        matches the local Python version.
+
+        Parameters
+        ----------
+        version_path
+            Path to an xbuildenv version directory (or the active symlink).
+        """
+        version_file = version_path / PYTHON_VERSION_MARKER_FILE
         if not version_file.exists():
             return False, "Python version marker file not found"
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376.

This PR fixes five verified bugs in the cross-build-environment (xbuildenv) lifecycle in `pyodide_build/xbuildenv.py`.

### Bug 1 — Python-version compatibility check was self-defeating
On a version-marker mismatch, `build_env._init_xbuild_env` calls `install()` and re-checks. But `install()` skipped all work when the resolved version directory already existed, then unconditionally called `_add_version_marker()`, rewriting the marker with the *current* Python version. The re-check then passed and builds proceeded with `HOSTSITEPACKAGES` contents installed under the *old* Python (the cross-build-packages marker still existed so they were never refreshed), and the intended "please switch back / reinstall" error was unreachable.

**Fix:** `install()` now detects a marker mismatch on an already-installed env (`_version_marker_matches_for(download_path)`), treats it as installation work, and: refreshes host packages (or drops the cross-build-packages marker so they're reinstalled lazily) and rewrites the version marker. The marker is now written **only when installation work was actually performed**, so a skipped install can no longer silently mask a mismatch.

### Bug 2 — broken package index when installing via `default_cross_build_env_url`
The explicit-`url` branch correctly skipped `_create_package_index` (the "version" is a mangled URL string). The `default_url` branch left `url=None`, so the index was created with hrefs like `CDN_BASE.format(version="https_example_com_...")`, which `pyodide venv` pip installs later consume.

**Fix:** both URL branches now set an `installed_from_url` flag, and index creation is skipped for either.

### Bug 3 — `use_version()` crashed on a dangling `xbuildenv` symlink
`if symlink_dir.exists()` follows the link and is `False` for a dangling symlink, so the stale link was never unlinked and `symlink_to()` raised `FileExistsError` on every subsequent install/use.

**Fix:** use `is_symlink()` (lexists semantics) so a dangling symlink is removed first.

### Bug 4 — failure cleanup deleted a pre-existing valid installation
The `except` block ran `shutil.rmtree(download_path)` even when `download_path` existed before this call. Any later failure (e.g. `symlink_to` raising `OSError` on Windows without symlink privilege) wiped the previously-good cached xbuildenv, and the `rmtree` could mask the original exception.

**Fix:** track whether *this* call created the directory and only delete it then; use `shutil.rmtree(..., ignore_errors=True)` so cleanup never masks the original error.

### Bug 5 — `_find_latest_version` mismatch diagnostics: wrong order + `IndexError`
When no compatible release existed, `python_versions` was built from releases sorted by *Pyodide* version, then indexed `[0]`/`[-1]` as if sorted by *Python* version, so newest/oldest messages could be wrong. An empty releases dict raised an uncaught `IndexError`.

**Fix:** sort the distinct Python versions by `packaging.version.Version`, derive newest/oldest from that, and raise a clear error for empty metadata.

### Tests
Added to `pyodide_build/tests/test_xbuildenv.py`:
- `test_use_version_dangling_symlink` — dangling-symlink recovery
- `test_install_preexisting_not_deleted_on_failure` / `test_install_new_deleted_on_failure` — pre-existing install preserved on failure; new install cleaned up
- `test_install_url_default_no_mangled_package_index` — default-URL install creates no mangled package index
- `test_install_version_marker_mismatch_triggers_reinstall` / `test_install_version_marker_match_no_marker_rewrite` — marker mismatch reinstalls and refreshes; matching marker is a no-op
- `test_find_latest_version_empty_releases` — clear error instead of `IndexError`
