### PR TITLE
refactor: remove dead code and apply Python 3.11+ modernizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Removed dead `_remove_path` helper from `recipe/cleanup.py` (never called; cleanup
+  delegates entirely to `RecipeBuilder.clean()`).
+- Simplified `_create_symlink_dir` in `pypabuild.py`: dropped the unused `env`
+  parameter and converted it from a context manager to a plain function.
+- Replaced the hand-rolled `chdir` context manager in `common.py` with a re-export
+  of `contextlib.chdir` (Python 3.11+).
+- Replaced the manual chunked SHA-256 loop in `common._get_sha256_checksum` with
+  `hashlib.file_digest` (Python 3.11+).
+- Made `PythonPackage`, `SharedLibrary`, and `StaticLibrary` use
+  `@dataclasses.dataclass(eq=False)` so they inherit `BasePackage`'s hand-written
+  `__hash__`/`__eq__` rather than having `__hash__` silently set to `None` by the
+  generated `__eq__`.
+- Extracted `_zip_compression` helper in `common.py` to deduplicate the
+  `compression_level > 0 → ZIP_DEFLATED/ZIP_STORED` logic shared by
+  `make_zip_archive`, `repack_zip_archive`, and `_py_compile._compile`.
+- Updated a stale comment in `build_env.py` about the manual `cpXY-none-any` Tag:
+  `packaging.tags.cpython_tags` still does not emit this tag as of packaging 26.x,
+  so the manual yield is still required.
+
+Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `packaging.tags.cpython_tags` still does not emit this tag as of packaging 26.x,
   so the manual yield is still required.
 
-Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
+Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+([#379](https://github.com/pyodide/pyodide-build/pull/379)).
 
 ## [0.35.1] - 2026/06/13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,32 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- Removed dead `_remove_path` helper from `recipe/cleanup.py` (never called; cleanup
-  delegates entirely to `RecipeBuilder.clean()`).
-- Simplified `_create_symlink_dir` in `pypabuild.py`: dropped the unused `env`
-  parameter and converted it from a context manager to a plain function.
-- Replaced the hand-rolled `chdir` context manager in `common.py` with a re-export
-  of `contextlib.chdir` (Python 3.11+).
-- Replaced the manual chunked SHA-256 loop in `common._get_sha256_checksum` with
-  `hashlib.file_digest` (Python 3.11+).
-- Made `PythonPackage`, `SharedLibrary`, and `StaticLibrary` use
-  `@dataclasses.dataclass(eq=False)` so they inherit `BasePackage`'s hand-written
-  `__hash__`/`__eq__` rather than having `__hash__` silently set to `None` by the
-  generated `__eq__`.
-- Extracted `_zip_compression` helper in `common.py` to deduplicate the
-  `compression_level > 0 → ZIP_DEFLATED/ZIP_STORED` logic shared by
-  `make_zip_archive`, `repack_zip_archive`, and `_py_compile._compile`.
-- Updated a stale comment in `build_env.py` about the manual `cpXY-none-any` Tag:
-  `packaging.tags.cpython_tags` still does not emit this tag as of packaging 26.x,
-  so the manual yield is still required.
-
-Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
-([#379](https://github.com/pyodide/pyodide-build/pull/379)).
-
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/pyodide_build/_py_compile.py
+++ b/pyodide_build/_py_compile.py
@@ -11,7 +11,7 @@ from typing import Any
 from packaging.tags import Tag
 from packaging.utils import parse_wheel_filename
 
-from pyodide_build.common import _get_sha256_checksum
+from pyodide_build.common import _get_sha256_checksum, _zip_compression
 from pyodide_build.logger import logger, set_log_level
 
 
@@ -116,10 +116,7 @@ def _compile(
     with set_log_level(logger, verbose):
         logger.debug("Running py-compile on %s to %s", input_path, output_path)
 
-        if compression_level > 0:
-            compression = zipfile.ZIP_DEFLATED
-        else:
-            compression = zipfile.ZIP_STORED
+        compression = _zip_compression(compression_level)
 
         with (
             zipfile.ZipFile(input_path) as fh_zip_in,

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -277,7 +277,7 @@ def pyodide_tags_() -> Iterator[Tag]:
     python_version = (int(PYMAJOR), int(PYMINOR))
     yield from cpython_tags(platforms=PLATFORMS, python_version=python_version)
     yield from compatible_tags(platforms=PLATFORMS, python_version=python_version)
-    # packaging's cpython_tags does not emit cpXY-none-any (checked against packaging 26.x); keep this manual tag.
+    # packaging's cpython_tags does not emit cpXY-none-any
     yield Tag(interpreter=f"cp{PYMAJOR}{PYMINOR}", abi="none", platform="any")
 
 

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -277,7 +277,7 @@ def pyodide_tags_() -> Iterator[Tag]:
     python_version = (int(PYMAJOR), int(PYMINOR))
     yield from cpython_tags(platforms=PLATFORMS, python_version=python_version)
     yield from compatible_tags(platforms=PLATFORMS, python_version=python_version)
-    # Following line can be removed once packaging 22.0 is released and we update to it.
+    # packaging's cpython_tags does not emit cpXY-none-any (checked against packaging 26.x); keep this manual tag.
     yield Tag(interpreter=f"cp{PYMAJOR}{PYMINOR}", abi="none", platform="any")
 
 

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -333,9 +333,6 @@ def find_missing_executables(executables: list[str]) -> list[str]:
     return list(filter(lambda exe: shutil.which(exe) is None, executables))
 
 
-chdir = contextlib.chdir
-
-
 def get_num_cores() -> int:
     """
     Return the number of CPUs the current process can use.

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -333,14 +333,7 @@ def find_missing_executables(executables: list[str]) -> list[str]:
     return list(filter(lambda exe: shutil.which(exe) is None, executables))
 
 
-@contextmanager
-def chdir(new_dir: Path) -> Generator[None, None, None]:
-    orig_dir = Path.cwd()
-    try:
-        os.chdir(new_dir)
-        yield
-    finally:
-        os.chdir(orig_dir)
+chdir = contextlib.chdir
 
 
 def get_num_cores() -> int:
@@ -351,6 +344,11 @@ def get_num_cores() -> int:
     from pyodide_build.vendor.loky import cpu_count
 
     return cpu_count()
+
+
+def _zip_compression(compression_level: int) -> int:
+    """Return the zipfile compression constant for the given compression level."""
+    return zipfile.ZIP_DEFLATED if compression_level > 0 else zipfile.ZIP_STORED
 
 
 def make_zip_archive(
@@ -369,10 +367,7 @@ def make_zip_archive(
     compression_level
        compression level of the resulting zip file.
     """
-    if compression_level > 0:
-        compression = zipfile.ZIP_DEFLATED
-    else:
-        compression = zipfile.ZIP_STORED
+    compression = _zip_compression(compression_level)
 
     with zipfile.ZipFile(
         archive_path, "w", compression=compression, compresslevel=compression_level
@@ -383,10 +378,7 @@ def make_zip_archive(
 
 def repack_zip_archive(archive_path: Path, compression_level: int = 6) -> None:
     """Repack zip archive with a different compression level"""
-    if compression_level > 0:
-        compression = zipfile.ZIP_DEFLATED
-    else:
-        compression = zipfile.ZIP_STORED
+    compression = _zip_compression(compression_level)
 
     with TemporaryDirectory() as temp_dir:
         input_path = Path(temp_dir) / archive_path.name
@@ -417,15 +409,8 @@ def _get_sha256_checksum(archive: Path) -> str:
     checksum
          sha256 checksum of the archive
     """
-    CHUNK_SIZE = 1 << 16
-    h = hashlib.sha256()
     with open(archive, "rb") as fd:
-        while True:
-            chunk = fd.read(CHUNK_SIZE)
-            h.update(chunk)
-            if len(chunk) < CHUNK_SIZE:
-                break
-    return h.hexdigest()
+        return hashlib.file_digest(fd, "sha256").hexdigest()
 
 
 def _format_dep_chain(dep_chain: Sequence[str]) -> str:

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -304,17 +304,12 @@ def make_command_wrapper_symlinks(symlink_dir: Path) -> dict[str, str]:
     return env
 
 
-# TODO: a context manager is no longer needed here
-@contextmanager
-def _create_symlink_dir(
-    env: dict[str, str],
-    build_dir: Path,
-):
+def _create_symlink_dir(build_dir: Path) -> Path:
     # Leave the symlinks in the build directory. This helps with reproducing.
     symlink_dir = build_dir / "pywasmcross_symlinks"
     shutil.rmtree(symlink_dir, ignore_errors=True)
     symlink_dir.mkdir()
-    yield symlink_dir
+    return symlink_dir
 
 
 @contextmanager
@@ -348,28 +343,28 @@ def get_build_env(
     args["exports"] = exports
     env = env.copy()
 
-    with _create_symlink_dir(env, build_dir) as symlink_dir:
-        env.update(make_command_wrapper_symlinks(symlink_dir))
-        sysconfig_dir = Path(get_build_flag("TARGETINSTALLDIR")) / "sysconfigdata"
-        args["PYTHONPATH"] = sys.path + [str(symlink_dir), str(sysconfig_dir)]
-        args["orig__name__"] = __name__
-        args["pythoninclude"] = get_build_flag("PYTHONINCLUDE")
-        args["PATH"] = env["PATH"]
-        args["abi"] = get_build_flag("PYODIDE_ABI_VERSION")
+    symlink_dir = _create_symlink_dir(build_dir)
+    env.update(make_command_wrapper_symlinks(symlink_dir))
+    sysconfig_dir = Path(get_build_flag("TARGETINSTALLDIR")) / "sysconfigdata"
+    args["PYTHONPATH"] = sys.path + [str(symlink_dir), str(sysconfig_dir)]
+    args["orig__name__"] = __name__
+    args["pythoninclude"] = get_build_flag("PYTHONINCLUDE")
+    args["PATH"] = env["PATH"]
+    args["abi"] = get_build_flag("PYODIDE_ABI_VERSION")
 
-        pywasmcross_env = json.dumps(args)
-        # Store into environment variable and to disk. In most cases we will
-        # load from the environment variable but if some other tool filters
-        # environment variables we will load from disk instead.
-        env["PYWASMCROSS_ARGS"] = pywasmcross_env
-        (symlink_dir / "pywasmcross_env.json").write_text(pywasmcross_env)
+    pywasmcross_env = json.dumps(args)
+    # Store into environment variable and to disk. In most cases we will
+    # load from the environment variable but if some other tool filters
+    # environment variables we will load from disk instead.
+    env["PYWASMCROSS_ARGS"] = pywasmcross_env
+    (symlink_dir / "pywasmcross_env.json").write_text(pywasmcross_env)
 
-        env["_PYTHON_HOST_PLATFORM"] = platform()
-        env["_PYTHON_SYSCONFIGDATA_NAME"] = get_build_flag("SYSCONFIG_NAME")
-        env["PYTHONPATH"] = str(sysconfig_dir)
-        env["COMPILER_WRAPPER_DIR"] = str(symlink_dir)
+    env["_PYTHON_HOST_PLATFORM"] = platform()
+    env["_PYTHON_SYSCONFIGDATA_NAME"] = get_build_flag("SYSCONFIG_NAME")
+    env["PYTHONPATH"] = str(sysconfig_dir)
+    env["COMPILER_WRAPPER_DIR"] = str(symlink_dir)
 
-        yield env
+    yield env
 
 
 # Based on pypa/build's reference logger implementation. See

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Iterator
+from contextlib import chdir
 from datetime import datetime
 from email.message import Message
 from functools import cache
@@ -35,7 +36,6 @@ from pyodide_build.build_env import (
 from pyodide_build.common import (
     _environment_substitute_str,
     _get_sha256_checksum,
-    chdir,
     find_matching_wheel,
     make_zip_archive,
     modify_wheel,

--- a/pyodide_build/recipe/cleanup.py
+++ b/pyodide_build/recipe/cleanup.py
@@ -1,9 +1,7 @@
-import shutil
 from collections.abc import Iterable
 from pathlib import Path
 
 from pyodide_build.build_env import BuildArgs
-from pyodide_build.logger import logger
 from pyodide_build.recipe import loader
 from pyodide_build.recipe.builder import RecipeBuilder
 
@@ -26,28 +24,6 @@ def resolve_targets(
         names_or_tags,
     )
     return list(recipes.keys())
-
-
-def _remove_path(path: Path) -> None:
-    """
-    Remove a file or directory if it exists. Best-effort, ignore errors.
-    """
-    try:
-        if path.is_dir():
-            if path.exists():
-                logger.info("Removing %s", str(path))
-                shutil.rmtree(path, ignore_errors=True)
-        elif path.is_file():
-            logger.info("Removing %s", str(path))
-            path.unlink(missing_ok=True)
-        else:
-            # Path does not exist; nothing to do
-            logger.debug("Path does not exist: %s", str(path))
-            return
-    except Exception as exc:
-        # Best-effort cleanup; ignore failures
-        logger.debug("Failed to remove %s: %s", str(path), exc, exc_info=True)
-        return
 
 
 def clean_recipes(

--- a/pyodide_build/recipe/graph_builder.py
+++ b/pyodide_build/recipe/graph_builder.py
@@ -212,7 +212,7 @@ class BasePackage:
         raise NotImplementedError()
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(eq=False)
 class PythonPackage(BasePackage):
     def __init__(self, pkgdir: Path, config: MetaConfig) -> None:
         super().__init__(pkgdir, config)
@@ -229,7 +229,7 @@ class PythonPackage(BasePackage):
         return wheel
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(eq=False)
 class SharedLibrary(BasePackage):
     install_dir: str = "dynlib"
 
@@ -248,7 +248,7 @@ class SharedLibrary(BasePackage):
         return candidates[0]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(eq=False)
 class StaticLibrary(BasePackage):
     def __init__(self, pkgdir: Path, config: MetaConfig) -> None:
         super().__init__(pkgdir, config)

--- a/pyodide_build/recipe/unvendor.py
+++ b/pyodide_build/recipe/unvendor.py
@@ -1,15 +1,13 @@
 import fnmatch
 import os
 import shutil
+from contextlib import chdir
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from packaging.utils import parse_wheel_filename
 
-from pyodide_build.common import (
-    chdir,
-    modify_wheel,
-)
+from pyodide_build.common import modify_wheel
 
 
 def unvendor_tests_in_wheel(

--- a/pyodide_build/tests/recipe/test_graph_builder.py
+++ b/pyodide_build/tests/recipe/test_graph_builder.py
@@ -15,6 +15,28 @@ RECIPE_DIR = Path(__file__).parent / "_test_recipes"
 BUILD_DIR = RECIPE_DIR
 
 
+def test_subclass_hashable_and_eq():
+    """
+    Subclasses of BasePackage must remain hashable and use BasePackage's
+    name/version equality, not a dataclass-generated __eq__ that would
+    reset __hash__ to None.
+    """
+    pkg_map = graph_builder.generate_dependency_graph(RECIPE_DIR, {"pkg_1", "pkg_2"})
+
+    # All concrete subclass instances must be hashable (usable in sets/dicts).
+    pkg_set: set[graph_builder.BasePackage] = set(pkg_map.values())
+    assert len(pkg_set) == len(pkg_map)
+
+    # Equality is name+version based (inherited from BasePackage.__eq__).
+    pkg1 = pkg_map["pkg_1"]
+    pkg1_copy = graph_builder.BasePackage.from_recipe(pkg1.pkgdir, pkg1.meta)
+    assert pkg1 == pkg1_copy
+    assert hash(pkg1) == hash(pkg1_copy)
+
+    # Instances with different names must not be equal.
+    assert pkg1 != pkg_map["pkg_2"]
+
+
 def test_generate_dependency_graph():
     # beautifulsoup4 has a circular dependency on soupsieve
     pkg_map = graph_builder.generate_dependency_graph(RECIPE_DIR, {"beautifulsoup4"})

--- a/pyodide_build/tests/test_cli_xbuildenv.py
+++ b/pyodide_build/tests/test_cli_xbuildenv.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+from contextlib import chdir
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,6 @@ from pyodide_lock import PyodideLockSpec
 from pyodide_build.cli import (
     xbuildenv,
 )
-from pyodide_build.common import chdir
 from pyodide_build.xbuildenv_releases import CROSS_BUILD_ENV_METADATA_URL_ENV_VAR
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376.

This PR applies several verified code simplifications and modernizations to the `pyodide-build` codebase:

1. **Remove dead `_remove_path`** (`recipe/cleanup.py`): This helper was defined but never called anywhere in the repo. Cleanup is handled exclusively by `RecipeBuilder.clean()`.

2. **Simplify `_create_symlink_dir`** (`pypabuild.py`): Dropped the unused `env: dict[str, str]` parameter and converted the function from a `@contextmanager` (noted with a TODO comment) to a plain function returning the symlink directory path.

3. **Use `contextlib.chdir`** (`common.py`): Replaced the hand-rolled `chdir` context manager with a re-export of `contextlib.chdir` (available since Python 3.11).

4. **Use `hashlib.file_digest`** (`common.py`): Replaced the manual chunked SHA-256 loop in `_get_sha256_checksum` with `hashlib.file_digest(fd, "sha256").hexdigest()` (available since Python 3.11).

5. **Fix latent dataclass eq/hash break** (`recipe/graph_builder.py`): `PythonPackage`, `SharedLibrary`, and `StaticLibrary` were decorated with plain `@dataclasses.dataclass`, which regenerates `__eq__` and silently sets `__hash__ = None`, overriding `BasePackage`'s hand-written `__hash__`/`__eq__`. Changed to `@dataclasses.dataclass(eq=False)`. Added a test to verify subclass instances are hashable and use name/version equality.

6. **Deduplicate compression logic** (`common.py`, `_py_compile.py`): Extracted a `_zip_compression(level)` helper to remove the identical `if compression_level > 0: ZIP_DEFLATED else ZIP_STORED` block that appeared in three places.

7. **Update stale comment** (`build_env.py`): The comment said the manual `cpXY-none-any` Tag yield could be removed "once packaging 22.0" — but `cpython_tags` still does not emit this tag in packaging 26.x, so it is still required. Updated the comment to reflect this.