### PR TITLE
Cache wheel metadata and simple-index lookups in the PyPI resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   candidates for a project are cached by name and the `PackageFinder`/HTTP
   session is shared, and wheel metadata is now read via PEP 658
   (`<wheel-url>.metadata`, falling back to the full wheel) and cached per URL.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376),
+  [#380](https://github.com/pyodide/pyodide-build/pull/380)
 
 ## [0.35.1] - 2026/06/13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Performance
+
+- The out-of-tree PyPI dependency resolver (`pyodide build --build-dependencies`
+  / `-r requirements.txt`) no longer re-fetches the simple index page or
+  re-downloads whole wheels on every resolver re-evaluation. The discovered
+  candidates for a project are cached by name and the `PackageFinder`/HTTP
+  session is shared, and wheel metadata is now read via PEP 658
+  (`<wheel-url>.metadata`, falling back to the full wheel) and cached per URL.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/pyodide_build/out_of_tree/pypi.py
+++ b/pyodide_build/out_of_tree/pypi.py
@@ -6,9 +6,9 @@ import sys
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
-from email.message import EmailMessage
-from email.parser import BytesParser
-from functools import cache
+from email.message import EmailMessage, Message
+from email.parser import BytesParser, Parser
+from functools import cache, lru_cache
 from io import BytesIO
 from operator import attrgetter
 from pathlib import Path
@@ -220,18 +220,44 @@ def get_target_python():
     return tp
 
 
-def get_project_from_pypi(package_name, extras):
-    """Return candidates created from the project name and extras."""
+@cache
+def _get_package_finder() -> "PackageFinder":
+    """Return a shared PackageFinder so the HTTP session/connection is reused.
+
+    A single finder reuses its requests session (and therefore HTTP
+    connections) across the whole resolution, instead of building a fresh
+    session every time resolvelib re-evaluates an identifier.
+    """
     _, PackageFinder = _import_unearth()
-    pf = PackageFinder(
+    return PackageFinder(
         index_urls=_PYPI_INDEX,
         trusted_hosts=_PYPI_TRUSTED_HOSTS,
         target_python=get_target_python(),
     )
+
+
+@lru_cache
+def _get_candidates_for_project(
+    package_name: str,
+) -> tuple[tuple[str, Version, str], ...]:
+    """Return the raw (name, version, url) candidates for a project.
+
+    The discovered distributions for a project do not depend on the requested
+    extras (only the ``Candidate`` objects built from them do), so this can be
+    cached by project name across the whole resolution. resolvelib re-evaluates
+    an identifier whenever a new requirement is merged and on every backtrack,
+    so without this cache the simple index page is re-fetched repeatedly.
+    """
+    pf = _get_package_finder()
     matches = pf.find_all_packages(package_name)
-    for i in matches:
-        # TODO: ignore sourcedists if wheel for same version exists
-        yield Candidate(i.name, i.version, url=i.link.url, extras=extras)
+    # TODO: ignore sourcedists if wheel for same version exists
+    return tuple((i.name, i.version, i.link.url) for i in matches)
+
+
+def get_project_from_pypi(package_name, extras):
+    """Return candidates created from the project name and extras."""
+    for name, version, url in _get_candidates_for_project(package_name):
+        yield Candidate(name, version, url=url, extras=extras)
 
 
 def download_or_build_wheel(
@@ -254,8 +280,31 @@ def download_or_build_wheel(
     repack_zip_archive(wheel_path, compression_level=compression_level)
 
 
+def _get_metadata_from_pep658(url: str) -> Message | None:
+    """Try to fetch wheel metadata via PEP 658 (``<wheel-url>.metadata``).
+
+    PyPI serves the wheel's METADATA file at this URL, which is a few KB
+    instead of the whole (potentially tens-of-MB) wheel. Returns ``None`` if
+    the metadata file is not available (e.g. a 404 from indexes that do not
+    support PEP 658), so the caller can fall back to downloading the wheel.
+    """
+    try:
+        resp = requests.get(url + ".metadata")
+    except requests.RequestException:
+        return None
+    if not resp.ok:
+        return None
+    return Parser().parsestr(resp.content.decode("utf-8", "replace"), headersonly=True)
+
+
+@lru_cache
 def get_metadata_for_wheel(url):
     parsed_url = urlparse(url)
+    if parsed_url.path.endswith(".whl"):
+        metadata = _get_metadata_from_pep658(url)
+        if metadata is not None:
+            return metadata
+
     if parsed_url.path.endswith("gz"):
         wheel_file = get_built_wheel(url)
         wheel_stream: BinaryIO = open(wheel_file, "rb")

--- a/pyodide_build/tests/conftest.py
+++ b/pyodide_build/tests/conftest.py
@@ -35,6 +35,15 @@ def reset_cache():
         build_env.pyodide_tags.cache_clear()
         common.default_xbuildenv_path.cache_clear()
 
+        # Caches used by the out-of-tree PyPI resolver. Imported lazily so the
+        # fixture does not depend on the optional [resolve] extras at import
+        # time (the helpers themselves import resolvelib/unearth only on use).
+        from pyodide_build.out_of_tree import pypi
+
+        pypi._get_package_finder.cache_clear()
+        pypi._get_candidates_for_project.cache_clear()
+        pypi.get_metadata_for_wheel.cache_clear()
+
     _reset()
 
     yield _reset

--- a/pyodide_build/tests/test_pypi.py
+++ b/pyodide_build/tests/test_pypi.py
@@ -1,7 +1,9 @@
+import io
 import re
 import subprocess
 import sys
 import tempfile
+import zipfile
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from textwrap import dedent
@@ -15,8 +17,123 @@ pytest.importorskip("resolvelib")
 pytest.importorskip("unearth")
 
 from pyodide_build.cli import build
+from pyodide_build.out_of_tree import pypi
 
 runner = CliRunner()
+
+
+_FAKE_METADATA = (
+    "Metadata-Version: 2.1\nName: pkgx\nVersion: 1.0.0\nRequires-Dist: foo>=1\n\n"
+)
+
+
+def _make_wheel_bytes(metadata: str = _FAKE_METADATA) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("pkgx-1.0.0.dist-info/METADATA", metadata)
+    return buf.getvalue()
+
+
+def _resp(body: str):
+    from werkzeug import Response
+
+    return Response(body, content_type="text/plain")
+
+
+def test_get_metadata_for_wheel_pep658(httpserver, reset_cache):
+    """Metadata is fetched via the PEP 658 ``.metadata`` URL when available,
+    without downloading the whole wheel, and is cached per URL."""
+    meta_requests = []
+    httpserver.expect_request(
+        "/files/pkgx-1.0.0-py3-none-any.whl.metadata"
+    ).respond_with_handler(
+        lambda r: (meta_requests.append(1), _resp(_FAKE_METADATA))[1]
+    )
+    # If the full wheel is downloaded the test fails: no handler is registered
+    # for it, so the request would 500.
+
+    url = httpserver.url_for("/files/pkgx-1.0.0-py3-none-any.whl")
+    metadata = pypi.get_metadata_for_wheel(url)
+    assert metadata.get("Name") == "pkgx"
+    assert metadata.get_all("Requires-Dist") == ["foo>=1"]
+
+    # A second call is served from the cache and does not hit the server again.
+    pypi.get_metadata_for_wheel(url)
+    assert len(meta_requests) == 1
+
+
+def test_get_metadata_for_wheel_fallback_to_wheel(httpserver, reset_cache):
+    """When the ``.metadata`` URL 404s, fall back to downloading the wheel."""
+    from werkzeug import Response
+
+    wheel_requests = []
+    httpserver.expect_request(
+        "/files/pkgx-1.0.0-py3-none-any.whl.metadata"
+    ).respond_with_response(Response("missing", status=404))
+    httpserver.expect_request(
+        "/files/pkgx-1.0.0-py3-none-any.whl"
+    ).respond_with_handler(
+        lambda r: (
+            wheel_requests.append(1),
+            Response(_make_wheel_bytes(), content_type="application/octet-stream"),
+        )[1]
+    )
+
+    url = httpserver.url_for("/files/pkgx-1.0.0-py3-none-any.whl")
+    metadata = pypi.get_metadata_for_wheel(url)
+    assert metadata.get("Name") == "pkgx"
+    assert len(wheel_requests) == 1
+
+    # Cached: the wheel is not downloaded a second time.
+    pypi.get_metadata_for_wheel(url)
+    assert len(wheel_requests) == 1
+
+
+def test_get_project_from_pypi_caches_index(httpserver, reset_cache, monkeypatch):
+    """The simple index is fetched once per project even across repeated
+    find_matches-style lookups (with different extras)."""
+    from unearth.evaluator import TargetPython
+    from werkzeug import Response
+
+    monkeypatch.setattr(
+        pypi,
+        "get_target_python",
+        lambda: TargetPython(
+            py_ver=(3, 12),
+            platforms=["emscripten_3_1_46_wasm32"],
+            abis=["cp312"],
+        ),
+    )
+
+    index_requests = []
+    html = (
+        "<!DOCTYPE html><html><body>"
+        '<a href="../../files/pkgx-1.0.0-py3-none-any.whl">'
+        "pkgx-1.0.0-py3-none-any.whl</a>"
+        "</body></html>"
+    )
+    httpserver.expect_request("/simple/pkgx/").respond_with_handler(
+        lambda r: (index_requests.append(1), Response(html, content_type="text/html"))[
+            1
+        ]
+    )
+
+    base = httpserver.url_for("/simple/")
+    monkeypatch.setattr(pypi, "_PYPI_INDEX", [base])
+    monkeypatch.setattr(
+        pypi, "_PYPI_TRUSTED_HOSTS", [f"{httpserver.host}:{httpserver.port}"]
+    )
+    # reset_cache cleared the finder/candidate caches built from a previous index.
+    reset_cache()
+
+    candidates = list(pypi.get_project_from_pypi("pkgx", set()))
+    assert [str(c) for c in candidates] == ["<pkgx==1.0.0>"]
+
+    # A second lookup with different extras reuses the cached candidate list.
+    candidates_extra = list(pypi.get_project_from_pypi("pkgx", {"docs"}))
+    assert [str(c) for c in candidates_extra] == ["<pkgx[docs]==1.0.0>"]
+
+    assert len(index_requests) == 1
 
 
 def _make_fake_package(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376

## Problem

The out-of-tree PyPI dependency resolver (`pyodide build --build-dependencies` / `-r requirements.txt`, in `pyodide_build/out_of_tree/pypi.py`) does redundant network work during resolution:

- **Whole wheels downloaded just to read `METADATA`.** `get_metadata_for_wheel` did `requests.get(url).content` on the full wheel (potentially tens of MB) to extract a single `METADATA` file, with no caching by URL. Because `Candidate` objects are recreated on every `find_matches` call, the per-instance `_metadata` attribute never helped across resolution rounds/backtracking, so the same wheel could be downloaded repeatedly.
- **Simple index re-fetched and `PackageFinder` rebuilt on every `find_matches` call.** `get_project_from_pypi` constructed a brand-new `unearth.PackageFinder` (new HTTP session, no connection reuse) and re-fetched the package's index page every time resolvelib re-evaluated an identifier — which happens whenever a new requirement is merged and on every backtrack.

## Fix

- `get_metadata_for_wheel` now tries **PEP 658** first: PyPI serves the metadata at `<wheel-url>.metadata` (a few KB), and it falls back to the full-wheel download when that 404s (other indexes may not support it). The parsed metadata is cached per URL via `functools.lru_cache`.
- Candidate discovery for a project is cached by name through an `lru_cache`d helper returning raw `(name, version, url)` tuples — candidates for a project don't depend on extras, only the `Candidate` objects built from them do — and a single shared `PackageFinder`/HTTP session is reused across the whole resolution.
- All three new caches are registered in the `reset_cache` test fixture so tests stay isolated.

These changes are caching layers only; `find_matches`' extras loop and `download_or_build_wheel`'s signature are untouched.

## Tests

Extended `pyodide_build/tests/test_pypi.py` (using `pytest-httpserver` with request counting):

- metadata is fetched via the `.metadata` URL when available, without downloading the wheel, and is cached (server hit once);
- falls back to the full wheel when `.metadata` 404s, then caches it;
- the simple index is fetched only once per project across repeated `get_project_from_pypi` calls with different extras.

The existing `test_pypi.py` suite and the full unit suite (`pytest pyodide_build -m "not integration"`) pass (pre-existing, unrelated failures in `test_cli`/`test_xbuildenv` aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)