### PR TITLE
fix: correct four small bugs in wheel matching, clean, elapsed time, and config loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `_find_matching_wheels` yielding the same wheel multiple times when its
+  compressed tag set (e.g. `pyodide_2024_0_wasm32.pyemscripten_2024_0_wasm32`)
+  matches more than one entry in `supported_tags`, which caused
+  `find_matching_wheel` to raise `RuntimeError("Found multiple matching
+  wheels")` for a single file. Also corrected the implicit-Optional annotation
+  `version: str = None` to `version: str | None = None` in `find_matching_wheel`.
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
+- Fixed `pyodide clean recipes` incorrectly cleaning packages tagged `always`
+  even when those packages were not in the requested target list. The fix passes
+  `load_always_tag=False` to `loader.load_recipes` inside `resolve_targets`.
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
+- Fixed elapsed-time log messages dropping the hours component for builds
+  lasting ≥ 1 hour (e.g. 3700 s was shown as "1m 40s" instead of "1h 1m 40s").
+  Replaced the `datetime.fromtimestamp` approach with straightforward integer
+  `divmod` arithmetic.
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
+- Fixed a `TypeError: expected string or bytes-like object, got 'bool'` crash
+  that occurred whenever `[tool.pyodide.build]` in `pyproject.toml` contained a
+  TOML boolean (e.g. `skip_emscripten_version_check = true`) or integer value.
+  TOML `true`/`false` are now converted to `"1"`/`"0"` (matching the env-var
+  convention used by `SKIP_EMSCRIPTEN_VERSION_CHECK`); other non-string scalars
+  are cast via `str()`.
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wheels")` for a single file. Also corrected the implicit-Optional annotation
   `version: str = None` to `version: str | None = None` in `find_matching_wheel`.
   Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#381](https://github.com/pyodide/pyodide-build/pull/381)
 
 - Fixed `pyodide clean recipes` incorrectly cleaning packages tagged `always`
   even when those packages were not in the requested target list. The fix passes
   `load_always_tag=False` to `loader.load_recipes` inside `resolve_targets`.
   Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#381](https://github.com/pyodide/pyodide-build/pull/381)
 
 - Fixed elapsed-time log messages dropping the hours component for builds
   lasting ≥ 1 hour (e.g. 3700 s was shown as "1m 40s" instead of "1h 1m 40s").
   Replaced the `datetime.fromtimestamp` approach with straightforward integer
   `divmod` arithmetic.
   Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#381](https://github.com/pyodide/pyodide-build/pull/381)
 
 - Fixed a `TypeError: expected string or bytes-like object, got 'bool'` crash
   that occurred whenever `[tool.pyodide.build]` in `pyproject.toml` contained a
@@ -35,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   convention used by `SKIP_EMSCRIPTEN_VERSION_CHECK`); other non-string scalars
   are cast via `str()`.
   Part of [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#381](https://github.com/pyodide/pyodide-build/pull/381)
 
 ## [0.35.1] - 2026/06/13
 

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -145,11 +145,13 @@ def _find_matching_wheels(
         for supported_tag in supported_tags:
             if supported_tag in wheel_tags:
                 yield wheel_path
-                continue
+                break
 
 
 def find_matching_wheel(
-    wheel_paths: Iterable[Path], supported_tags: Sequence[Tag], version: str = None
+    wheel_paths: Iterable[Path],
+    supported_tags: Sequence[Tag],
+    version: str | None = None,
 ) -> Path | None:
     """
     Find a matching wheel or raise an error if none is present.

--- a/pyodide_build/config.py
+++ b/pyodide_build/config.py
@@ -69,6 +69,15 @@ class ConfigManager:
                         key,
                     )
                     continue
+                if isinstance(v, bool):
+                    # TOML booleans (true/false) are converted to "1"/"0" to
+                    # match the convention used by env vars (e.g.
+                    # SKIP_EMSCRIPTEN_VERSION_CHECK defaults to "0").
+                    v = "1" if v else "0"
+                elif not isinstance(v, str):
+                    # Other non-string scalars (e.g. integers) are cast to str
+                    # so they can be used in environment-variable substitution.
+                    v = str(v)
                 build_config[key] = _environment_substitute_str(v, env)
 
             return build_config

--- a/pyodide_build/recipe/cleanup.py
+++ b/pyodide_build/recipe/cleanup.py
@@ -24,6 +24,7 @@ def resolve_targets(
     recipes = loader.load_recipes(
         recipe_dir,
         names_or_tags,
+        load_always_tag=False,
     )
     return list(recipes.keys())
 

--- a/pyodide_build/recipe/graph_builder.py
+++ b/pyodide_build/recipe/graph_builder.py
@@ -3,7 +3,6 @@ Build all of the packages in a given directory.
 """
 
 import dataclasses
-import datetime
 import shutil
 import subprocess
 import sys
@@ -269,12 +268,15 @@ class PackageStatus:
         self.finished = False
 
     def finish(self, success: bool, elapsed_time: float) -> None:
-        time = datetime.datetime.fromtimestamp(elapsed_time, tz=datetime.UTC)
-        if time.minute == 0:
-            minutes = ""
+        seconds = int(elapsed_time)
+        hours, rem = divmod(seconds, 3600)
+        minutes, secs = divmod(rem, 60)
+        if hours:
+            timestr = f"{hours}h {minutes}m {secs}s"
+        elif minutes:
+            timestr = f"{minutes}m {secs}s"
         else:
-            minutes = f"{time.minute}m "
-        timestr = f"{minutes}{time.second}s"
+            timestr = f"{secs}s"
 
         status = "built" if success else "failed"
         done_message = f"{self.prefix} {status} {self.pkg_name} in {timestr}"

--- a/pyodide_build/tests/recipe/test_graph_builder.py
+++ b/pyodide_build/tests/recipe/test_graph_builder.py
@@ -185,3 +185,40 @@ def test_requirements_executable(monkeypatch):
         m.setattr(shutil, "which", lambda exe: "/bin")
 
         graph_builder.generate_dependency_graph(RECIPE_DIR, {"pkg_test_executable"})
+
+
+# Bug 3: elapsed-time formatting should correctly show hours when >= 3600 s.
+@pytest.mark.parametrize(
+    "elapsed_seconds, expected",
+    [
+        (0, "0s"),
+        (1, "1s"),
+        (59, "59s"),
+        (60, "1m 0s"),
+        (90, "1m 30s"),
+        (3599, "59m 59s"),
+        (3600, "1h 0m 0s"),
+        (3700, "1h 1m 40s"),
+        (7322, "2h 2m 2s"),
+    ],
+)
+def test_package_status_elapsed_time_formatting(elapsed_seconds, expected):
+    status = graph_builder.PackageStatus(name="pkg", idx=1, thread=0, total_packages=1)
+
+    captured = []
+
+    def capture(msg, *args, **kwargs):
+        captured.append(msg)
+
+    original_success = graph_builder.logger.success
+    graph_builder.logger.success = capture  # type: ignore[method-assign]
+    try:
+        status.finish(success=True, elapsed_time=float(elapsed_seconds))
+    finally:
+        graph_builder.logger.success = original_success  # type: ignore[method-assign]
+
+    assert captured, "logger.success was not called"
+    message = captured[0]
+    assert message.endswith(f"in {expected}"), (
+        f"For {elapsed_seconds}s expected suffix 'in {expected}', got: {message!r}"
+    )

--- a/pyodide_build/tests/test_cleanup.py
+++ b/pyodide_build/tests/test_cleanup.py
@@ -103,3 +103,53 @@ def test_resolve_targets_star_selects_all(tmp_path: Path):
     all_targets = set(resolve_targets(recipe_dir, ["*"]))
     assert "pkg_a" in all_targets
     assert "pkg_b" in all_targets
+
+
+def _write_meta_with_tag(recipe_dir: Path, pkg: str, tag: str) -> Path:
+    """Write a minimal meta.yaml with a package tag."""
+    pkg_root = recipe_dir / pkg
+    pkg_root.mkdir(parents=True, exist_ok=True)
+    meta = (
+        f"package:\n"
+        f"  name: {pkg}\n"
+        f"  version: '1.0.0'\n"
+        f"  tag:\n"
+        f"    - {tag}\n"
+        f"source:\n"
+        f"  path: .\n"
+    )
+    (pkg_root / "meta.yaml").write_text(meta, encoding="utf-8")
+    return pkg_root
+
+
+# Bug 2: resolve_targets must not implicitly include packages tagged "always"
+# when a specific subset of packages is requested.
+def test_resolve_targets_does_not_include_always_tagged_packages(tmp_path: Path):
+    recipe_dir = tmp_path / "recipes"
+    _write_meta(recipe_dir, "pkg_explicit")
+    _write_meta_with_tag(recipe_dir, "pkg_always", "always")
+
+    targets = resolve_targets(recipe_dir, ["pkg_explicit"])
+    assert "pkg_explicit" in targets
+    assert "pkg_always" not in targets, (
+        "resolve_targets should not include 'always'-tagged packages when "
+        "a specific target list is given"
+    )
+
+
+def test_clean_recipes_does_not_clean_always_tagged_packages(tmp_path: Path):
+    recipe_dir = tmp_path / "recipes"
+    _, build_explicit, _ = _make_pkg_with_artifacts(recipe_dir, "pkg_explicit")
+
+    # Create an 'always'-tagged package with artifacts
+    always_root = _write_meta_with_tag(recipe_dir, "pkg_always", "always")
+    always_build = always_root / "build"
+    always_build.mkdir(parents=True, exist_ok=True)
+    (always_build / "artifact.txt").write_text("should survive", encoding="utf-8")
+
+    clean_recipes(recipe_dir, ["pkg_explicit"], build_dir=None, include_dist=False)
+
+    assert not build_explicit.exists(), "Explicitly targeted package should be cleaned"
+    assert always_build.exists(), (
+        "Package with 'always' tag should NOT be cleaned when not explicitly targeted"
+    )

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -2,13 +2,16 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from packaging.tags import Tag
 
 from pyodide_build.common import (
     IS_WIN,
+    _find_matching_wheels,
     check_wasm_magic_number,
     default_xbuildenv_path,
     environment_substitute_args,
     extract_wheel_metadata_file,
+    find_matching_wheel,
     find_missing_executables,
     make_zip_archive,
     parse_top_level_import_name,
@@ -285,3 +288,46 @@ def test_default_xbuildenv_path_env_var_non_writable(
     monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(non_writable_path))
 
     assert default_xbuildenv_path() == baseline_path
+
+
+# Bug 1: _find_matching_wheels should yield each wheel at most once even if its
+# compressed tag set matches multiple entries in supported_tags.
+def test_find_matching_wheels_no_duplicate_yield(tmp_path):
+    # A wheel with two platform tags in its filename (compressed tag set).
+    # packaging will expand "pyodide_2024_0_wasm32.pyemscripten_2024_0_wasm32"
+    # into two separate Tag objects, both of which appear in supported_tags.
+    wheel_name = (
+        "example-1.0-cp312-cp312-pyodide_2024_0_wasm32.pyemscripten_2024_0_wasm32.whl"
+    )
+    wheel_path = tmp_path / wheel_name
+    wheel_path.write_bytes(b"")
+
+    supported_tags = [
+        Tag("cp312", "cp312", "pyodide_2024_0_wasm32"),
+        Tag("cp312", "cp312", "pyemscripten_2024_0_wasm32"),
+    ]
+
+    matches = list(_find_matching_wheels([wheel_path], supported_tags))
+    assert matches == [wheel_path], (
+        f"Expected exactly one match but got {len(matches)}: {matches}"
+    )
+
+
+def test_find_matching_wheel_compressed_tags_no_runtime_error(tmp_path):
+    # Regression: when a single wheel matches two supported tags (compressed tag
+    # set), find_matching_wheel used to raise RuntimeError("Found multiple
+    # matching wheels") because the same path was yielded twice.
+    wheel_name = (
+        "example-1.0-cp312-cp312-pyodide_2024_0_wasm32.pyemscripten_2024_0_wasm32.whl"
+    )
+    wheel_path = tmp_path / wheel_name
+    wheel_path.write_bytes(b"")
+
+    supported_tags = [
+        Tag("cp312", "cp312", "pyodide_2024_0_wasm32"),
+        Tag("cp312", "cp312", "pyemscripten_2024_0_wasm32"),
+    ]
+
+    # Should return the single wheel, not raise RuntimeError.
+    result = find_matching_wheel([wheel_path], supported_tags)
+    assert result == wheel_path

--- a/pyodide_build/tests/test_config.py
+++ b/pyodide_build/tests/test_config.py
@@ -58,6 +58,29 @@ class TestConfigManager:
         assert config["xbuildenv_path"] == "my_custom/xbuildenv_path"
         assert config["ignored_build_requirements"] == "cmake foo bar"
 
+    # Bug 4: non-string scalars in [tool.pyodide.build] must not crash with
+    # TypeError when passed to _environment_substitute_str.
+    def test_load_config_from_file_non_string_values(
+        self, tmp_path, reset_env_vars, reset_cache
+    ):
+        pyproject_file = tmp_path / "pyproject.toml"
+        env: dict = {}
+
+        # TOML booleans (true/false) and integers are valid TOML spellings but
+        # would previously cause TypeError inside re.sub.
+        pyproject_file.write_text(
+            "[tool.pyodide.build]\n"
+            "skip_emscripten_version_check = true\n"
+            "use_legacy_platform = false\n"
+        )
+
+        config_manager = ConfigManager()
+        config = config_manager._load_config_file(pyproject_file, env)
+
+        # TOML true -> "1", false -> "0" (matches the env-var convention)
+        assert config["skip_emscripten_version_check"] == "1"
+        assert config["use_legacy_platform"] == "0"
+
 
 class TestCrossBuildEnvConfigManager_OutOfTree:
     def test_default_config(self, dummy_xbuildenv, reset_env_vars, reset_cache):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376

## Summary

This PR fixes four verified bugs that were each small in scope but each causing
real incorrect behaviour in production:

**Bug 1 — `continue` should be `break` in `_find_matching_wheels`
(`pyodide_build/common.py`)**

A wheel whose filename contains a compressed tag set (e.g.
`pyodide_2024_0_wasm32.pyemscripten_2024_0_wasm32`) is expanded by
`packaging` into multiple `Tag` objects. The inner loop iterated over all
`supported_tags` and used `continue` after a match, causing the same wheel
path to be yielded once per matching tag. `find_matching_wheel` then raised
`RuntimeError("Found multiple matching wheels")` listing the same file twice.
Fixed by changing `continue` to `break` so each wheel is yielded at most once.
Also corrected the implicit-Optional annotation `version: str = None` →
`version: str | None = None` on `find_matching_wheel`.

**Bug 2 — `pyodide clean recipes` silently cleans "always"-tagged packages
(`pyodide_build/recipe/cleanup.py`)**

`resolve_targets` called `loader.load_recipes` without `load_always_tag=False`,
so any explicit request (e.g. `pyodide clean recipes mypackage`) would also
clean every package tagged `always`. Fixed by passing `load_always_tag=False`.

**Bug 3 — Elapsed-time log drops the hours component for builds >= 1 h
(`pyodide_build/recipe/graph_builder.py`)**

`PackageStatus.finish` used `datetime.fromtimestamp(elapsed_time, tz=UTC)` to
format a duration. For a 3700 s build this displayed "1m 40s" instead of "1h
1m 40s". Replaced with straightforward integer `divmod` arithmetic. The unused
`import datetime` was removed.

**Bug 4 — Non-string values in `[tool.pyodide.build]` crash with an opaque
`TypeError` (`pyodide_build/config.py`)**

`_load_config_file` passed raw TOML values to `_environment_substitute_str`
which calls `re.sub(..., string)`. A natural TOML spelling such as
`skip_emscripten_version_check = true` produced `TypeError: expected string or
bytes-like object, got 'bool'` with no indication of the offending key. Fixed
by converting TOML booleans to `"1"` (true) or `"0"` (false) — matching the
env-var convention where `SKIP_EMSCRIPTEN_VERSION_CHECK` defaults to `"0"` —
and casting other non-string scalars with `str()`.

## Test plan

- New test `test_find_matching_wheels_no_duplicate_yield` verifies that a wheel
  with a compressed tag set matching two `supported_tags` entries is yielded
  exactly once by `_find_matching_wheels`.
- New test `test_find_matching_wheel_compressed_tags_no_runtime_error` verifies
  `find_matching_wheel` does not raise for such a wheel.
- New tests `test_resolve_targets_does_not_include_always_tagged_packages` and
  `test_clean_recipes_does_not_clean_always_tagged_packages` verify the
  always-tag exclusion.
- New parametrised test
  `test_package_status_elapsed_time_formatting` covers 0 s, sub-minute,
  sub-hour, and multi-hour cases.
- New test `test_load_config_from_file_non_string_values` exercises TOML
  `true`/`false` values in `[tool.pyodide.build]`.
- Full unit suite (`pytest pyodide_build -m "not integration"`): 337 passed,
  1 skipped, 1 xfailed, 4 pre-existing failures (unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)