### PR TITLE
Sanitize Content-Disposition filename to prevent path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to prevent path traversal: the extracted filename is now reduced to its final path
   component only (stripping any Unix or Windows directory separators), so a malicious
   mirror cannot write files outside the build directory.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376),
+  [#382](https://github.com/pyodide/pyodide-build/pull/382)
 
 ## [0.35.1] - 2026/06/13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Sanitize `Content-Disposition: filename=...` header values in `_extract_tarballname`
+  to prevent path traversal: the extracted filename is now reduced to its final path
+  component only (stripping any Unix or Windows directory separators), so a malicious
+  mirror cannot write files outside the build directory.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from email.message import Message
 from functools import cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, cast
 
 import requests
@@ -70,6 +70,26 @@ except shutil.RegistryError:
     pass
 
 
+def _sanitize_filename(filename: str) -> str | None:
+    """
+    Return the safe basename of *filename*, or None if it is unusable.
+
+    Strips Unix and Windows path separators so that a server-supplied
+    Content-Disposition value like ``../../evil.tar.gz`` or
+    ``..\\..\\evil.tar.gz`` cannot escape the build directory.
+    """
+    # Strip Windows-style separators so PurePosixPath sees only the leaf.
+    name = filename.replace("\\", "/")
+    # Take only the final component (handles both absolute and relative paths).
+    name = PurePosixPath(name).name
+    # Also guard against Windows absolute paths on the last component.
+    name = PureWindowsPath(name).name
+    # Reject empty, dot, or dot-dot.
+    if not name or name in (".", ".."):
+        return None
+    return name
+
+
 def _extract_tarballname(url: str, headers: dict) -> str:
     tarballname = url.rsplit("/", 1)[-1]
 
@@ -79,7 +99,16 @@ def _extract_tarballname(url: str, headers: dict) -> str:
 
         filename = msg.get_filename()
         if filename is not None:
-            tarballname = filename
+            safe = _sanitize_filename(filename)
+            if safe is not None:
+                tarballname = safe
+            else:
+                logger.warning(
+                    "Ignoring unsafe Content-Disposition filename %r; "
+                    "falling back to URL-derived name %r",
+                    filename,
+                    tarballname,
+                )
 
     return tarballname
 

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -342,3 +342,31 @@ def test_extract_tarballname():
 
     for header, tarballname in zip(headers, tarballnames, strict=True):
         assert _builder._extract_tarballname(url, header) == tarballname
+
+
+@pytest.mark.parametrize(
+    "disposition,expected",
+    [
+        # Path traversal with Unix separators: strip to basename only (safe)
+        ('attachment; filename="../../evil.tar.gz"', "evil.tar.gz"),
+        # Absolute Unix path: strip to basename only (safe)
+        ('attachment; filename="/abs/path.tar.gz"', "path.tar.gz"),
+        # Empty filename falls back to URL name
+        ('attachment; filename=""', "ball.tar.gz"),
+        # Windows-style path traversal: strip to basename only (safe)
+        ('attachment; filename="..\\\\..\\\\evil.tar.gz"', "evil.tar.gz"),
+        # Normal safe filename is kept unchanged
+        ('attachment; filename="safe-package-1.0.tar.gz"', "safe-package-1.0.tar.gz"),
+    ],
+)
+def test_extract_tarballname_sanitization(disposition, expected):
+    """
+    Content-Disposition filenames with path components must be reduced to a
+    safe basename that cannot escape the build directory.
+    """
+    url = "https://www.test.com/ball.tar.gz"
+    result = _builder._extract_tarballname(url, {"Content-Disposition": disposition})
+    assert result == expected
+    # Extra invariant: the result must never contain a path separator.
+    assert "/" not in result
+    assert "\\" not in result


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376

## Summary

- `_extract_tarballname` in `pyodide_build/recipe/builder.py` trusted the `Content-Disposition: filename=...` header verbatim. A malicious or compromised mirror could supply a value like `../../evil.tar.gz` or `/abs/path.tar.gz`, causing `self.build_dir / tarballname` to resolve outside the build directory.
- The fix introduces `_sanitize_filename()` which strips all Unix and Windows directory separators by taking only the final path component via `PurePosixPath.name` + `PureWindowsPath.name`, and rejects empty/`.`/`..` values with a fallback to the URL-derived filename.
- Member-level tar/zip extraction was already protected (tar `"data"` filter, `_unpack_zipfile`); this closes the remaining gap.

## Tests

Five parametrized cases covering Unix path traversal, absolute paths, empty filenames, Windows backslash traversal, and the normal happy path. Full unit suite passes (4 pre-existing failures on `main`, unrelated).