### PR TITLE
Fix bash runner hang on early shell exit and cached env mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a hang when a recipe `build/script` or `build/post` ends by exiting the
+  shell itself (e.g. `exit 0`). The build no longer blocks forever waiting for an
+  environment dump that never runs; the previous environment is kept instead.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
+- Fixed per-package build variables (`PKGDIR`, `PKG_VERSION`, `DISTDIR`, ...)
+  leaking into the cached build-environment dict, which caused later packages in
+  a sequential `build-recipes` run to see the previous package's values.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a hang when a recipe `build/script` or `build/post` ends by exiting the
   shell itself (e.g. `exit 0`). The build no longer blocks forever waiting for an
   environment dump that never runs; the previous environment is kept instead.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376),
+  [#383](https://github.com/pyodide/pyodide-build/pull/383)
 
 - Fixed per-package build variables (`PKGDIR`, `PKG_VERSION`, `DISTDIR`, ...)
   leaking into the cached build-environment dict, which caused later packages in
   a sequential `build-recipes` run to see the previous package's values.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376),
+  [#383](https://github.com/pyodide/pyodide-build/pull/383)
 
 ## [0.35.1] - 2026/06/13
 

--- a/pyodide_build/recipe/bash_runner.py
+++ b/pyodide_build/recipe/bash_runner.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from types import TracebackType
-from typing import Any, TextIO
+from typing import Any
 
 from pyodide_build.build_env import (
     get_build_environment_vars,
@@ -28,38 +28,58 @@ class BashRunnerWithSharedEnvironment:
         if env is None:
             env = dict(os.environ)
 
-        self._reader: TextIO | None
-        self._fd_write: int | None
         self.env: dict[str, str] = env
 
     def __enter__(self) -> "BashRunnerWithSharedEnvironment":
-        fd_read, self._fd_write = os.pipe()
-        self._reader = os.fdopen(fd_read, "r")
         return self
 
     def run_unchecked(self, cmd: str, **opts: Any) -> subprocess.CompletedProcess[str]:
-        assert self._fd_write is not None
-        assert self._reader is not None
-
-        write_env_pycode = ";".join(
-            [
-                "import os",
-                "import json",
-                f'os.write({self._fd_write}, json.dumps(dict(os.environ)).encode() + b"\\n")',
-            ]
-        )
-        write_env_shell_cmd = f"{sys.executable} -c '{write_env_pycode}'"
-        full_cmd = f"{cmd}\n{write_env_shell_cmd}"
-        result = subprocess.run(
-            ["bash", "-ce", full_cmd],
-            check=False,
-            pass_fds=[self._fd_write],
-            env=self.env,
-            encoding="utf8",
-            **opts,
-        )
-        if result.returncode == 0:
-            self.env = json.loads(self._reader.readline())
+        # Use a fresh pipe for every invocation. The child process inherits the
+        # write end and dumps the resulting environment to it. We close the
+        # parent's copy of the write end *before* reading so that ``readline``
+        # observes EOF if the script exited the shell early (e.g. ``exit 0``)
+        # without ever running the env-dump command. Otherwise the parent would
+        # block forever, since it would still hold the write end open and never
+        # see EOF. See https://github.com/pyodide/pyodide-build/issues/376.
+        fd_read, fd_write = os.pipe()
+        try:
+            write_env_pycode = ";".join(
+                [
+                    "import os",
+                    "import json",
+                    f'os.write({fd_write}, json.dumps(dict(os.environ)).encode() + b"\\n")',
+                ]
+            )
+            write_env_shell_cmd = f"{sys.executable} -c '{write_env_pycode}'"
+            full_cmd = f"{cmd}\n{write_env_shell_cmd}"
+            with os.fdopen(fd_read, "r") as reader:
+                result = subprocess.run(
+                    ["bash", "-ce", full_cmd],
+                    check=False,
+                    pass_fds=[fd_write],
+                    env=self.env,
+                    encoding="utf8",
+                    **opts,
+                )
+                # Close the parent's copy of the write end before reading so we
+                # can observe EOF when the child never wrote the env dump.
+                os.close(fd_write)
+                fd_write = None
+                if result.returncode == 0:
+                    env_dump = reader.readline()
+                    if env_dump:
+                        self.env = json.loads(env_dump)
+                    else:
+                        # The script exited the shell itself (e.g. ``exit 0``)
+                        # before the env-dump command ran, so there is no
+                        # updated environment to capture. Keep the current env.
+                        logger.debug(
+                            "Script exited the shell before dumping its "
+                            "environment; keeping the previous environment."
+                        )
+        finally:
+            if fd_write is not None:
+                os.close(fd_write)
         return result
 
     def run(
@@ -91,14 +111,9 @@ class BashRunnerWithSharedEnvironment:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Free the file descriptors."""
-
-        if self._fd_write:
-            os.close(self._fd_write)
-            self._fd_write = None
-        if self._reader:
-            self._reader.close()
-            self._reader = None
+        # Pipes are created and closed per ``run_unchecked`` call, so there is
+        # nothing to clean up here.
+        return None
 
 
 @contextmanager
@@ -106,7 +121,11 @@ def get_bash_runner(
     extra_envs: dict[str, str],
 ) -> Iterator[BashRunnerWithSharedEnvironment]:
     pyodide_root = get_pyodide_root()
-    env = get_build_environment_vars(pyodide_root)
+    # ``get_build_environment_vars`` is ``@functools.cache``d and returns the
+    # cached dict, so copy it before mutating to avoid leaking per-package
+    # variables (PKGDIR, PKG_VERSION, DISTDIR, ...) into the cached value, which
+    # would otherwise be seen by subsequent package builds in the same process.
+    env = dict(get_build_environment_vars(pyodide_root))
     env.update(extra_envs)
 
     with BashRunnerWithSharedEnvironment(env=env) as b:

--- a/pyodide_build/tests/recipe/test_bash_runner.py
+++ b/pyodide_build/tests/recipe/test_bash_runner.py
@@ -1,6 +1,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from pyodide_build.recipe import bash_runner
 
 
@@ -26,6 +28,71 @@ def test_subprocess_with_shared_env_1():
         res = p.run_unchecked("echo $A", stdout=subprocess.PIPE)
         assert res.stdout == "7\n"
         assert p.env["A"] == "7"
+
+
+def _run_with_watchdog(func, timeout=30):
+    """Run ``func`` in a thread, failing the test if it does not return in time.
+
+    Used to detect a regression where ``run_unchecked`` would block forever.
+    """
+    import threading
+
+    result: dict[str, object] = {}
+
+    def target():
+        result["value"] = func()
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        pytest.fail(f"run_unchecked did not return within {timeout}s (hung)")
+    return result.get("value")
+
+
+def test_run_unchecked_exit_zero_does_not_hang():
+    """A script that exits the shell early (e.g. ``exit 0``) must not hang.
+
+    The env-dump command appended after the user script never runs in this
+    case, so the parent must detect EOF on the pipe instead of blocking
+    forever waiting for an environment dump that never arrives.
+    See https://github.com/pyodide/pyodide-build/issues/376.
+    """
+
+    def body():
+        with bash_runner.BashRunnerWithSharedEnvironment() as p:
+            p.env["MARKER"] = "kept"
+
+            res = p.run_unchecked("echo hi; exit 0", stdout=subprocess.PIPE)
+            assert res.returncode == 0
+            assert res.stdout == "hi\n"
+            # The script exited the shell before dumping its env, so the
+            # previous environment is preserved and remains usable.
+            assert p.env["MARKER"] == "kept"
+
+            # A normal script afterwards still works and updates the env.
+            res = p.run_unchecked("export AFTER=1; echo $AFTER", stdout=subprocess.PIPE)
+            assert res.returncode == 0
+            assert res.stdout == "1\n"
+            assert p.env["AFTER"] == "1"
+            assert p.env["MARKER"] == "kept"
+
+    _run_with_watchdog(body)
+
+
+def test_run_unchecked_does_not_leak_fds():
+    """Repeated invocations must not leak file descriptors."""
+    import resource
+
+    with bash_runner.BashRunnerWithSharedEnvironment() as p:
+        for _ in range(200):
+            p.run_unchecked("echo hi; exit 0", stdout=subprocess.PIPE)
+            p.run_unchecked("export X=1", stdout=subprocess.PIPE)
+
+        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        # We should be nowhere near the open-file limit after 400 calls if fds
+        # are properly closed each time.
+        assert len(list(Path("/dev/fd").iterdir())) < soft_limit
 
 
 def test_subprocess_with_shared_env_cwd(tmp_path: Path) -> None:
@@ -78,3 +145,33 @@ def test_subprocess_with_shared_env_logging(capfd, tmp_path):
         assert "Running test2 script in" in cleaned_output
         assert str(dir) in cleaned_output
         assert "ERROR: test2 script failed" in cap.err
+
+
+def test_get_bash_runner_does_not_mutate_cached_env(dummy_xbuildenv):
+    """``get_build_environment_vars`` is cached and returns the cached dict.
+
+    ``get_bash_runner`` must copy it before injecting per-package variables,
+    otherwise those variables leak into the cached value and are seen by
+    subsequent package builds in the same process.
+    See https://github.com/pyodide/pyodide-build/issues/376.
+    """
+    from pyodide_build.build_env import (
+        get_build_environment_vars,
+        get_pyodide_root,
+    )
+
+    pyodide_root = get_pyodide_root()
+    cached_env = get_build_environment_vars(pyodide_root)
+    cached_keys_before = set(cached_env)
+
+    extra = {"PKGDIR": "/tmp/pkg1", "PKG_VERSION": "1.2.3", "LEAKED_MARKER": "1"}
+    with bash_runner.get_bash_runner(extra) as runner:
+        # The runner sees the injected variables ...
+        assert runner.env["PKGDIR"] == "/tmp/pkg1"
+        assert runner.env["LEAKED_MARKER"] == "1"
+
+    # ... but the cached dict is untouched.
+    assert "LEAKED_MARKER" not in cached_env
+    assert set(cached_env) == cached_keys_before
+    # And re-fetching returns the same pristine cached dict.
+    assert "LEAKED_MARKER" not in get_build_environment_vars(pyodide_root)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376

## Summary

Two fixes in `pyodide_build/recipe/bash_runner.py`:

- **Build hang on `exit 0`:** `run_unchecked` appends an env-dump command after the user script. If the script terminated the shell itself (`exit 0`, or `exec` of a program that exits 0), bash returned rc 0 without the env dump ever running, and the parent blocked forever on `readline()` — no EOF arrived because the parent still held the pipe's write end. Any recipe `build/script` or `build/post` ending in `exit 0` deadlocked the build. Now a fresh pipe is created per call and the parent closes its copy of the write end before reading, so an early shell exit yields EOF; in that case the previous environment is kept (with a debug log).
- **Cached env dict mutation:** `get_bash_runner` called `env.update(extra_envs)` directly on the dict returned by the `@functools.cache`d `get_build_environment_vars()`, permanently injecting per-package vars (`PKGDIR`, `PKG_VERSION`, `DISTDIR`, plus `os.environ`) into the cached value — later packages built in the same process saw the previous package's values. The dict is now copied first.

## Tests

- `test_run_unchecked_exit_zero_does_not_hang` (thread watchdog so a regression fails rather than hangs; verifies env stays usable and a later script still updates it)
- `test_run_unchecked_does_not_leak_fds`
- `test_get_bash_runner_does_not_mutate_cached_env`

Full unit suite passes (4 pre-existing failures on `main`, unrelated).