### PR TITLE
Fix out-of-tree PyPI dependency resolution correctness bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--skip-dependency-check` to dependency sdist builds (including the sdist
   builds used to discover dependency metadata during resolution), instead of
   silently dropping them.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376), [#385](https://github.com/pyodide/pyodide-build/pull/385)
 - `PyPIProvider.find_matches` now unions the extras across all requirements for
   a package, so dependencies pulled in by extras are resolved even when the same
   package is required both with and without extras (e.g. `foo` and `foo[bar]`).
   Dependency markers are now evaluated once per requested extra so that a marker
   like `extra == "a"` matches when any requested extra satisfies it.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376), [#385](https://github.com/pyodide/pyodide-build/pull/385)
 - Building a non-gzip sdist (e.g. a `.zip` or `.tar.bz2`) from PyPI no longer
   raises `UnboundLocalError`; supported archive formats are now built and
   unsupported ones raise a clear error.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376), [#385](https://github.com/pyodide/pyodide-build/pull/385)
 - `pyodide build` now preserves the version specifier and all extras when
   building a PyPI package such as `pkg[a,b]==1.0`, instead of dropping the
   specifier and ignoring extras containing commas.
-  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+  [#376](https://github.com/pyodide/pyodide-build/issues/376), [#385](https://github.com/pyodide/pyodide-build/pull/385)
 
 ## [0.35.1] - 2026/06/13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Out-of-tree PyPI dependency resolution now forwards `--no-isolation` and
+  `--skip-dependency-check` to dependency sdist builds (including the sdist
+  builds used to discover dependency metadata during resolution), instead of
+  silently dropping them.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+- `PyPIProvider.find_matches` now unions the extras across all requirements for
+  a package, so dependencies pulled in by extras are resolved even when the same
+  package is required both with and without extras (e.g. `foo` and `foo[bar]`).
+  Dependency markers are now evaluated once per requested extra so that a marker
+  like `extra == "a"` matches when any requested extra satisfies it.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+- Building a non-gzip sdist (e.g. a `.zip` or `.tar.bz2`) from PyPI no longer
+  raises `UnboundLocalError`; supported archive formats are now built and
+  unsupported ones raise a clear error.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+- `pyodide build` now preserves the version specifier and all extras when
+  building a PyPI package such as `pkg[a,b]==1.0`, instead of dropping the
+  specifier and ignoring extras containing commas.
+  [#376](https://github.com/pyodide/pyodide-build/issues/376)
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -1,4 +1,3 @@
-import re
 import shutil
 import sys
 import tempfile
@@ -10,6 +9,7 @@ from urllib.parse import urlparse
 import click
 import requests
 from build import ConfigSettingsType
+from packaging.requirements import InvalidRequirement, Requirement
 
 from pyodide_build.build_env import (
     ensure_emscripten,
@@ -227,10 +227,21 @@ def _detect_source_type(source_location: str) -> str:
 
 
 def _extract_extras(source_location: str) -> tuple[str, list[str]]:
-    extras = re.findall(r"\[(\w+)\]", source_location)
-    if extras:
-        source_location = source_location[: source_location.find("[")]
-    return source_location, extras
+    """Split a pypi requirement into a name+specifier string and its extras.
+
+    For example ``"pkg[a,b]==1.0"`` returns ``("pkg==1.0", ["a", "b"])``. The
+    version specifier is preserved so the requested version is actually fetched.
+
+    URLs, directory paths and other non-requirement source locations are
+    returned unchanged with no extras.
+    """
+    try:
+        req = Requirement(source_location)
+    except InvalidRequirement:
+        return source_location, []
+
+    name = req.name + str(req.specifier)
+    return name, sorted(req.extras)
 
 
 DEFAULT_PATH = default_xbuildenv_path()

--- a/pyodide_build/out_of_tree/pypi.py
+++ b/pyodide_build/out_of_tree/pypi.py
@@ -114,14 +114,21 @@ def get_built_wheel(url, isolation=True, skip_dependency_check=False):
 @cache
 def _get_built_wheel_internal(url, isolation=True, skip_dependency_check=False):
     parsed_url = urlparse(url)
-    gz_name = Path(parsed_url.path).name
+    sdist_name = Path(parsed_url.path).name
+
+    # Preserve the archive's suffix so ``shutil.unpack_archive`` can infer the
+    # right format. PyPI serves ``.zip`` and ``.tar.bz2`` sdists in addition to
+    # ``.tar.gz``; hard-coding ``.tar.gz`` here would corrupt the others.
+    suffix = next(
+        (s for s in _SDIST_SUFFIXES if parsed_url.path.endswith(s)), ".tar.gz"
+    )
 
     cache_entry: dict[str, Any] = {}
     build_dir = tempfile.TemporaryDirectory()
     build_path = Path(build_dir.name)
 
     cache_entry["build_dir"] = build_dir
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
         data = requests.get(url).content
         f.write(data)
         f.close()
@@ -132,7 +139,7 @@ def _get_built_wheel_internal(url, isolation=True, skip_dependency_check=False):
             source_path = build_path / files[0]
         else:
             source_path = build_path
-    logger.info("Building wheel for %s...", gz_name)
+    logger.info("Building wheel for %s...", sdist_name)
     with (
         tempfile.NamedTemporaryFile(mode="w+") as logfile,
         stream_redirected(to=logfile, stream=sys.stdout),
@@ -234,6 +241,25 @@ def get_project_from_pypi(package_name, extras):
         yield Candidate(i.name, i.version, url=i.link.url, extras=extras)
 
 
+# Source distribution archive extensions that ``shutil.unpack_archive`` (and
+# therefore our build path) can handle. PyPI still serves ``.zip`` and
+# ``.tar.bz2`` sdists for some older packages, so we must not assume ``.tar.gz``.
+_SDIST_SUFFIXES = (
+    ".tar.gz",
+    ".tgz",
+    ".tar.bz2",
+    ".tbz2",
+    ".tar.xz",
+    ".txz",
+    ".tar",
+    ".zip",
+)
+
+
+def _is_buildable_sdist(path: str) -> bool:
+    return path.endswith(_SDIST_SUFFIXES)
+
+
 def download_or_build_wheel(
     url: str,
     target_directory: Path,
@@ -242,28 +268,38 @@ def download_or_build_wheel(
     skip_dependency_check: bool = False,
 ) -> None:
     parsed_url = urlparse(url)
-    if parsed_url.path.endswith("gz"):
-        wheel_file = get_built_wheel(url, isolation, skip_dependency_check)
-        shutil.copy(wheel_file, target_directory)
-        wheel_path = target_directory / wheel_file.name
-    elif parsed_url.path.endswith(".whl"):
+    if parsed_url.path.endswith(".whl"):
         wheel_path = target_directory / Path(parsed_url.path).name
         with open(wheel_path, "wb") as f:
             f.write(requests.get(url).content)
+    elif _is_buildable_sdist(parsed_url.path):
+        wheel_file = get_built_wheel(
+            url,
+            isolation=isolation,
+            skip_dependency_check=skip_dependency_check,
+        )
+        shutil.copy(wheel_file, target_directory)
+        wheel_path = target_directory / wheel_file.name
+    else:
+        raise RuntimeError(f"Distributions of this type are unsupported: {url}")
 
     repack_zip_archive(wheel_path, compression_level=compression_level)
 
 
 def get_metadata_for_wheel(url):
     parsed_url = urlparse(url)
-    if parsed_url.path.endswith("gz"):
-        wheel_file = get_built_wheel(url)
-        wheel_stream: BinaryIO = open(wheel_file, "rb")
-    elif parsed_url.path.endswith(".whl"):
+    if parsed_url.path.endswith(".whl"):
         data = requests.get(url).content
-        wheel_stream = BytesIO(data)
+        wheel_stream: BinaryIO = BytesIO(data)
+    elif _is_buildable_sdist(parsed_url.path):
+        wheel_file = get_built_wheel(
+            url,
+            isolation=PyPIProvider.BUILD_ISOLATION,
+            skip_dependency_check=PyPIProvider.BUILD_SKIP_DEPENDENCY_CHECK,
+        )
+        wheel_stream = open(wheel_file, "rb")
     else:
-        raise RuntimeError(f"Distributions of this type are unsupported:{url}")
+        raise RuntimeError(f"Distributions of this type are unsupported: {url}")
     with ZipFile(wheel_stream) as z:
         for n in z.namelist():
             if n.endswith(".dist-info/METADATA"):
@@ -278,6 +314,13 @@ class PyPIProvider(_AbstractProvider):
     BUILD_FLAGS: ConfigSettingsType = {}
     BUILD_SKIP: list[str] = []
     BUILD_EXPORTS: _BuildSpecExports = []
+    # Build isolation settings used when an sdist must be built (e.g. to
+    # discover dependency metadata during resolution). These mirror the flags
+    # passed to ``_resolve_and_build`` so that metadata resolution, which goes
+    # through ``Candidate`` -> ``get_metadata_for_wheel`` -> ``get_built_wheel``
+    # and has no direct access to those flags, still honors them.
+    BUILD_ISOLATION: bool = True
+    BUILD_SKIP_DEPENDENCY_CHECK: bool = False
 
     def __init__(self, build_dependencies: bool):
         self.build_dependencies = build_dependencies
@@ -301,24 +344,27 @@ class PyPIProvider(_AbstractProvider):
     def find_matches(self, identifier, requirements, incompatibilities):
         requirements = list(requirements[identifier])
 
-        extra_requirements = {}
+        # The same package may be required both with and without extras (e.g.
+        # ``foo`` and ``foo[bar]``). Union all requested extras so that the
+        # resulting candidate pulls in dependencies for every requested extra.
+        # ``Candidate._get_dependencies`` evaluates each ``extra == "..."``
+        # marker against every extra in this set, so a single candidate carrying
+        # the union is the semantically correct choice.
+        extras: set[str] = set()
         for r in requirements:
-            extra_requirements[tuple(r.extras)] = 1
+            extras |= set(r.extras)
 
         bad_versions = {c.version for c in incompatibilities[identifier]}
 
         # Need to pass the extras to the search, so they
         # are added to the candidate at creation - we
         # treat candidates as immutable once created.
-        for extra_tuple in extra_requirements.keys():
-            extras = set(extra_tuple)
-
-            candidates = (
-                candidate
-                for candidate in get_project_from_pypi(identifier, extras)
-                if candidate.version not in bad_versions
-                and all(candidate.version in r.specifier for r in requirements)
-            )
+        candidates = (
+            candidate
+            for candidate in get_project_from_pypi(identifier, extras)
+            if candidate.version not in bad_versions
+            and all(candidate.version in r.specifier for r in requirements)
+        )
 
         return sorted(candidates, key=attrgetter("version"), reverse=True)
 
@@ -380,18 +426,30 @@ def _resolve_and_build(
     BaseReporter, Resolver = _import_resolvelib()
     requirements = []
 
-    target_env = {
+    base_env = {
         "python_version": build_env.get_pyversion_major_minor(),
         "sys_platform": build_env.platform().split("_")[0],
-        "extra": ",".join(extras),
     }
+    # A marker like ``extra == "a"`` can only ever match a single extra value,
+    # so joining all extras into one string (``"a,b"``) never matches. Evaluate
+    # the marker once per requested extra (plus the empty extra) and include the
+    # requirement if it is satisfied for ANY of them.
+    extras_to_check = [*extras, ""] if extras else [""]
+
+    def _marker_matches(marker: Any) -> bool:
+        return any(marker.evaluate({**base_env, "extra": e}) for e in extras_to_check)
 
     for d in deps:
         r = Requirement(d)
         if (r.name not in PyPIProvider.BUILD_SKIP) and (
-            (not r.marker) or r.marker.evaluate(target_env)
+            (not r.marker) or _marker_matches(r.marker)
         ):
             requirements.append(r)
+
+    # Propagate build isolation settings to the resolver so that any sdist that
+    # must be built to discover its metadata honors these flags.
+    PyPIProvider.BUILD_ISOLATION = isolation
+    PyPIProvider.BUILD_SKIP_DEPENDENCY_CHECK = skip_dependency_check
 
     # Create the (reusable) resolver.
     provider = PyPIProvider(build_dependencies=build_dependencies)
@@ -405,7 +463,13 @@ def _resolve_and_build(
     if output_lockfile is not None and len(output_lockfile) > 0:
         version_file = open(output_lockfile, "w")
     for x in result.mapping.values():
-        download_or_build_wheel(x.url, target_folder, compression_level)
+        download_or_build_wheel(
+            x.url,
+            target_folder,
+            compression_level=compression_level,
+            isolation=isolation,
+            skip_dependency_check=skip_dependency_check,
+        )
         if len(x.extras) > 0:
             extratxt = "[" + ",".join(x.extras) + "]"
         else:

--- a/pyodide_build/tests/test_pypi.py
+++ b/pyodide_build/tests/test_pypi.py
@@ -364,3 +364,176 @@ def test_bad_requirements_text(dummy_xbuildenv, mock_emscripten):
             ["-r", "requirements.txt"],
         )
         assert result.exit_code != 0 and line.strip() in str(result)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pypi resolver correctness fixes (issue #376).
+# These do not require a network connection or a real build.
+# ---------------------------------------------------------------------------
+
+from email.message import EmailMessage  # noqa: E402
+
+from packaging.requirements import Requirement  # noqa: E402
+from packaging.version import Version  # noqa: E402
+
+from pyodide_build.cli.build import _extract_extras  # noqa: E402
+from pyodide_build.out_of_tree import pypi  # noqa: E402
+
+
+def _make_candidate(name, version, requires_dist, extras=None):
+    cand = pypi.Candidate(name, Version(version), url=None, extras=extras)
+    meta = EmailMessage()
+    for d in requires_dist:
+        meta["Requires-Dist"] = d
+    cand._metadata = meta
+    return cand
+
+
+def test_extract_extras_preserves_specifier_and_multiple_extras():
+    # Bug 4: name, extras and specifier must all be preserved.
+    name, extras = _extract_extras("pkg[a,b]==1.0")
+    assert name == "pkg==1.0"
+    assert extras == ["a", "b"]
+
+    # single extra with specifier
+    name, extras = _extract_extras("pkg[a]==1.0")
+    assert name == "pkg==1.0"
+    assert extras == ["a"]
+
+    # no extras, specifier preserved
+    name, extras = _extract_extras("pkg>=2.0")
+    assert name == "pkg>=2.0"
+    assert extras == []
+
+    # plain name
+    name, extras = _extract_extras("pkg")
+    assert name == "pkg"
+    assert extras == []
+
+    # non-requirement source locations (urls/paths) returned unchanged
+    name, extras = _extract_extras("https://example.com/pkg.tar.gz")
+    assert name == "https://example.com/pkg.tar.gz"
+    assert extras == []
+
+
+def test_resolve_and_build_forwards_flags(monkeypatch):
+    # Bug 1: isolation / skip_dependency_check must reach download_or_build_wheel.
+    captured = []
+
+    def fake_download_or_build_wheel(url, target_directory, **kwargs):
+        captured.append(kwargs)
+
+    class _FakeResult:
+        class _Entry:
+            url = "http://example.com/foo-1.0.tar.gz"
+            extras: list[str] = []
+            name = "foo"
+            version = Version("1.0")
+
+        mapping = {"foo": _Entry()}
+
+    class _FakeResolver:
+        def __init__(self, *a, **k):
+            pass
+
+        def resolve(self, requirements):
+            return _FakeResult()
+
+    monkeypatch.setattr(pypi, "download_or_build_wheel", fake_download_or_build_wheel)
+    monkeypatch.setattr(
+        pypi, "_import_resolvelib", lambda: (object, lambda *a, **k: _FakeResolver())
+    )
+    monkeypatch.setattr(pypi.build_env, "get_pyversion_major_minor", lambda: "3.12")
+    monkeypatch.setattr(pypi.build_env, "platform", lambda: "emscripten_3_1_0_wasm32")
+
+    pypi._resolve_and_build(
+        deps=[],
+        target_folder=Path(tempfile.mkdtemp()),
+        build_dependencies=False,
+        extras=[],
+        output_lockfile=None,
+        isolation=False,
+        skip_dependency_check=True,
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["isolation"] is False
+    assert captured[0]["skip_dependency_check"] is True
+    # Class-level attributes are set so metadata resolution also honors them.
+    assert pypi.PyPIProvider.BUILD_ISOLATION is False
+    assert pypi.PyPIProvider.BUILD_SKIP_DEPENDENCY_CHECK is True
+
+
+def test_find_matches_unions_extras(monkeypatch):
+    # Bug 2: when foo and foo[bar] are both required, the candidate must carry
+    # the union of all requested extras.
+    seen_extras = []
+
+    def fake_get_project_from_pypi(identifier, extras):
+        seen_extras.append(set(extras))
+        yield pypi.Candidate("foo", Version("1.0"), url=None, extras=extras)
+
+    monkeypatch.setattr(pypi, "get_project_from_pypi", fake_get_project_from_pypi)
+
+    provider = pypi.PyPIProvider(build_dependencies=True)
+    requirements = {"foo": [Requirement("foo"), Requirement("foo[bar]")]}
+    incompatibilities: dict[str, list] = {"foo": []}
+
+    matches = provider.find_matches("foo", requirements, incompatibilities)
+
+    assert len(seen_extras) == 1
+    assert seen_extras[0] == {"bar"}
+    assert len(matches) == 1
+    assert matches[0].extras == {"bar"}
+
+
+def test_candidate_dependencies_match_any_extra():
+    # Bug 2 (related): a Requires-Dist marker must match if ANY requested extra
+    # satisfies it, even when several extras are requested at once.
+    cand = _make_candidate(
+        "foo",
+        "1.0",
+        [
+            'dep-a; extra == "a"',
+            'dep-b; extra == "b"',
+            "dep-base",
+        ],
+        extras={"a", "b"},
+    )
+    dep_names = {d.name for d in cand.dependencies}
+    assert dep_names == {"dep-a", "dep-b", "dep-base"}
+
+
+def test_download_or_build_wheel_unsupported_type_raises(tmp_path):
+    # Bug 3: a non-gz, non-whl URL must raise a clear error, not UnboundLocalError.
+    with pytest.raises(RuntimeError, match="unsupported"):
+        pypi.download_or_build_wheel("http://example.com/pkg-1.0.rar", tmp_path)
+
+
+def test_download_or_build_wheel_routes_zip_sdist_to_builder(monkeypatch, tmp_path):
+    # Bug 3: a .zip sdist must be routed to the builder (not UnboundLocalError).
+    built = tmp_path / "foo-1.0-py3-none-any.whl"
+    built.write_bytes(b"PK\x03\x04dummy")
+    captured = {}
+
+    def fake_get_built_wheel(url, isolation=True, skip_dependency_check=False):
+        captured["url"] = url
+        captured["isolation"] = isolation
+        captured["skip_dependency_check"] = skip_dependency_check
+        return built
+
+    monkeypatch.setattr(pypi, "get_built_wheel", fake_get_built_wheel)
+    monkeypatch.setattr(pypi, "repack_zip_archive", lambda *a, **k: None)
+
+    target = tmp_path / "out"
+    target.mkdir()
+    pypi.download_or_build_wheel(
+        "http://example.com/foo-1.0.zip",
+        target,
+        isolation=False,
+        skip_dependency_check=True,
+    )
+    assert captured["url"] == "http://example.com/foo-1.0.zip"
+    assert captured["isolation"] is False
+    assert captured["skip_dependency_check"] is True
+    assert (target / built.name).exists()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #376.

This fixes four verified correctness bugs in the out-of-tree PyPI dependency resolution (`pyodide_build/out_of_tree/pypi.py` and `pyodide_build/cli/build.py`).

### Bug 1: `isolation` / `skip_dependency_check` silently dropped for dependency builds
`_resolve_and_build` called `download_or_build_wheel(x.url, target_folder, compression_level)`, where the third positional argument landed in `compression_level` and the `isolation` / `skip_dependency_check` flags were never forwarded. The same happened during metadata resolution, where `get_built_wheel(url)` was called with no flags. As a result `pyodide build -r reqs.txt --no-isolation -x` still built dependency sdists with default isolation.

**Fix:** forward the flags using keyword arguments throughout the call chain. Because metadata resolution flows through `Candidate` -> `get_metadata_for_wheel` -> `get_built_wheel` (which has no direct access to the flags), the flags are also stored on new `PyPIProvider.BUILD_ISOLATION` / `BUILD_SKIP_DEPENDENCY_CHECK` class attributes (mirroring the existing `BUILD_FLAGS` / `BUILD_EXPORTS` pattern) and honored there.

### Bug 2: `PyPIProvider.find_matches` only honored the last extras set
The loop over `extra_requirements` rebound the `candidates` generator each iteration, so only the last extras set was consumed. When a package was required both with and without extras (`foo` and `foo[bar]`), dependencies pulled in by the lost extras were never resolved.

**Fix:** union the extras across all requirements and create the candidates once. `Candidate._get_dependencies` evaluates each `extra == "..."` marker against every extra in the set, so a single candidate carrying the union is the correct choice.

Related: marker evaluation in `_resolve_and_build` used `{"extra": ",".join(extras)}`, which can never match a marker like `extra == "a"` when there are multiple extras. Now the marker is evaluated once per requested extra (plus the empty extra) and the requirement is included if it matches **any** of them.

### Bug 3: `UnboundLocalError` for non-gz, non-whl sdist URLs
`download_or_build_wheel` only handled URLs ending in `gz` or `.whl`. For a `.zip` or `.tar.bz2` sdist (still present on PyPI for older packages), `wheel_path` was never assigned and the later `repack_zip_archive(wheel_path, ...)` raised `UnboundLocalError`.

**Fix:** route any supported sdist archive format (`.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, `.tar.xz`, `.txz`, `.tar`, `.zip`) to the builder (the build path is format-agnostic via `shutil.unpack_archive`), and raise a clear error for unsupported types. The temp file used during the build now preserves the archive suffix so the format is inferred correctly. `get_metadata_for_wheel` was made consistent.

### Bug 4: `_extract_extras` dropped version specifiers and mishandled multiple extras
For `"pkg[extra]==1.0"` the hand-rolled regex discarded `==1.0` (so the latest version was fetched), and for `"pkg[a,b]"` the regex `\[(\w+)\]` did not match commas, so no extras were extracted.

**Fix:** parse with `packaging.requirements.Requirement` so name, extras (including comma-separated) and the version specifier are all preserved. The specifier is folded back into the source-location string that flows to `fetch_pypi_package`. Non-requirement source locations (URLs, paths) are returned unchanged.

### Tests
Added unit tests in `pyodide_build/tests/test_pypi.py`:
- flags propagate from `_resolve_and_build` into `download_or_build_wheel` (monkeypatched) and onto the `PyPIProvider` class attributes;
- `find_matches` with `foo` + `foo[bar]` honors the extras union; a candidate with multiple extras resolves dependencies whose markers match any single extra;
- a non-gz/non-whl URL raises a clear error (not `UnboundLocalError`), and a `.zip` sdist is routed to the builder with flags forwarded;
- `_extract_extras("pkg[a,b]==1.0")` yields name `pkg==1.0` and extras `["a", "b"]`, with specifiers preserved and URLs passed through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
