### PR TITLE
perf: stream downloads, lazy xbuildenv path, skip pure-wheel repack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Archive downloads (xbuildenv, emsdk) now stream directly to a temporary file
+  instead of buffering the entire archive in RAM, reducing peak memory usage for
+  large downloads. Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
+
+- The default xbuildenv path is now resolved lazily — only when a CLI command
+  body actually needs it — instead of at module import time. This avoids
+  triggering a `ConfigManager` build, filesystem probes, and a potential
+  `RuntimeError` on every `pyodide` invocation, regardless of the subcommand
+  used. Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
+
+- Out-of-tree builds now skip the wheel unpack/repack step when the built wheel
+  contains no native `.so` extension files (i.e., pure-Python wheels). This
+  eliminates two `python -m wheel` subprocess round-trips that were always a
+  no-op for pure-Python packages. Part of
+  [#376](https://github.com/pyodide/pyodide-build/issues/376).
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Archive downloads (xbuildenv, emsdk) now stream directly to a temporary file
   instead of buffering the entire archive in RAM, reducing peak memory usage for
-  large downloads. Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
+  large downloads.
+  [#386](https://github.com/pyodide/pyodide-build/pull/386),
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
 
 - The default xbuildenv path is now resolved lazily — only when a CLI command
   body actually needs it — instead of at module import time. This avoids
   triggering a `ConfigManager` build, filesystem probes, and a potential
   `RuntimeError` on every `pyodide` invocation, regardless of the subcommand
-  used. Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
+  used.
+  [#386](https://github.com/pyodide/pyodide-build/pull/386),
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
 
 - Out-of-tree builds now skip the wheel unpack/repack step when the built wheel
   contains no native `.so` extension files (i.e., pure-Python wheels). This
   eliminates two `python -m wheel` subprocess round-trips that were always a
-  no-op for pure-Python packages. Part of
-  [#376](https://github.com/pyodide/pyodide-build/issues/376).
+  no-op for pure-Python packages.
+  [#386](https://github.com/pyodide/pyodide-build/pull/386),
+  Part of [#376](https://github.com/pyodide/pyodide-build/issues/376).
 
 ## [0.35.1] - 2026/06/13
 

--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -233,9 +233,6 @@ def _extract_extras(source_location: str) -> tuple[str, list[str]]:
     return source_location, extras
 
 
-DEFAULT_PATH = default_xbuildenv_path()
-
-
 @click.command(
     context_settings={
         "ignore_unknown_options": True,
@@ -334,10 +331,10 @@ DEFAULT_PATH = default_xbuildenv_path()
 @click.option(
     "--xbuildenv-path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     envvar="PYODIDE_XBUILDENV_PATH",
     show_envvar=True,
-    help="Path to the cross-build environment directory.",
+    help="Path to the cross-build environment directory (default: resolved from config or platformdirs cache).",
 )
 @click.option(
     "--skip-emscripten-install",
@@ -369,7 +366,7 @@ def main(
     no_isolation: bool,
     skip_dependency_check: bool,
     config_setting: tuple[str, ...],
-    xbuildenv_path: Path,
+    xbuildenv_path: Path | None,
     skip_emscripten_install: bool,
     verbosity: int,
 ) -> None:
@@ -381,6 +378,8 @@ def main(
             or url to a source dist archive or wheel file. If this is blank, it
             will build the current directory.
     """
+    if xbuildenv_path is None:
+        xbuildenv_path = default_xbuildenv_path()
     init_environment(xbuildenv_path=xbuildenv_path)
     try:
         ensure_emscripten(skip_install=skip_emscripten_install)

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -14,8 +14,6 @@ from pyodide_build.xbuildenv_releases import (
     load_cross_build_env_metadata,
 )
 
-DEFAULT_PATH = default_xbuildenv_path()
-
 
 @click.group(invoke_without_command=True)
 @click.pass_context
@@ -36,10 +34,10 @@ def check_xbuildenv_root(path: Path) -> None:
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     envvar="PYODIDE_XBUILDENV_PATH",
     show_envvar=True,
-    help="destination to download cross-build environment directory to.",
+    help="destination to download cross-build environment directory to (default: resolved from config or platformdirs cache).",
 )
 @click.option(
     "--url",
@@ -77,7 +75,7 @@ def check_xbuildenv_root(path: Path) -> None:
 )
 def _install(
     version: str | None,
-    path: Path,
+    path: Path | None,
     url: str | None,
     force_install: bool,
     nightly: bool,
@@ -95,6 +93,8 @@ def _install(
     Arguments:
         VERSION: version of cross-build environment to install (optional)
     """
+    if path is None:
+        path = default_xbuildenv_path()
     if nightly and debug:
         metadata_url = NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL
     elif nightly:
@@ -118,11 +118,13 @@ def _install(
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     help="path to cross-build environment directory.",
 )
-def _version(path: Path) -> None:
+def _version(path: Path | None) -> None:
     """Print current version of cross-build environment."""
+    if path is None:
+        path = default_xbuildenv_path()
     check_xbuildenv_root(path)
     manager = CrossBuildEnvManager(path)
     version = manager.current_version
@@ -137,11 +139,13 @@ def _version(path: Path) -> None:
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     help="path to cross-build environment directory.",
 )
-def _versions(path: Path) -> None:
+def _versions(path: Path | None) -> None:
     """Print all installed versions of cross-build environment."""
+    if path is None:
+        path = default_xbuildenv_path()
     check_xbuildenv_root(path)
     manager = CrossBuildEnvManager(path)
     versions = manager.list_versions()
@@ -159,16 +163,18 @@ def _versions(path: Path) -> None:
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     help="path to cross-build environment directory.",
 )
-def _uninstall(version: str | None, path: Path) -> None:
+def _uninstall(version: str | None, path: Path | None) -> None:
     """Uninstall cross-build environment.
 
     \b
     Arguments:
         VERSION: version of cross-build environment to uninstall (optional)
     """
+    if path is None:
+        path = default_xbuildenv_path()
     check_xbuildenv_root(path)
     manager = CrossBuildEnvManager(path)
     v = manager.uninstall_version(version)
@@ -180,16 +186,18 @@ def _uninstall(version: str | None, path: Path) -> None:
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     help="path to cross-build environment directory.",
 )
-def _use(version: str, path: Path) -> None:
+def _use(version: str, path: Path | None) -> None:
     """Select a version of cross-build environment to use.
 
     \b
     Arguments:
         VERSION: version of cross-build environment to use (required)
     """
+    if path is None:
+        path = default_xbuildenv_path()
     check_xbuildenv_root(path)
     manager = CrossBuildEnvManager(path)
     manager.use_version(version)
@@ -328,7 +336,7 @@ def _search(
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
-    default=DEFAULT_PATH,
+    default=None,
     help="Pyodide cross-env path",
 )
 @click.option(
@@ -340,7 +348,7 @@ def _search(
 )
 def _install_emscripten(
     version: str | None,
-    path: Path,
+    path: Path | None,
     force: bool,
 ) -> None:
     """Install Emscripten SDK into the cross-build environment.
@@ -351,6 +359,8 @@ def _install_emscripten(
     If the requested version is already installed, the command is a no-op unless
     --force is passed.
     """
+    if path is None:
+        path = default_xbuildenv_path()
     check_xbuildenv_root(path)
     manager = CrossBuildEnvManager(path)
 

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -630,7 +630,6 @@ def download_and_unpack_archive(
 
     try:
         resp = urlopen(url)
-        data = resp.read()
     except Exception as e:
         raise ValueError(f"Failed to download {descr} from {url}") from e
 
@@ -644,7 +643,11 @@ def download_and_unpack_archive(
 
     with TemporaryDirectory() as temp_dir:
         f_path = Path(temp_dir) / "temp.tar"
-        f_path.write_bytes(data)
+        try:
+            with f_path.open("wb") as f:
+                shutil.copyfileobj(resp, f)
+        except Exception as e:
+            raise ValueError(f"Failed to download {descr} from {url}") from e
         with warnings.catch_warnings():
             # Python 3.12-3.13 emits a DeprecationWarning when using shutil.unpack_archive without a filter,
             # but filter doesn't work well for zip files, so we suppress the warning until we find a better solution.

--- a/pyodide_build/out_of_tree/build.py
+++ b/pyodide_build/out_of_tree/build.py
@@ -1,4 +1,5 @@
 import os
+import zipfile
 from pathlib import Path
 from textwrap import dedent
 
@@ -6,6 +7,7 @@ from build import ConfigSettingsType
 
 from pyodide_build import build_env, common, pypabuild
 from pyodide_build.build_env import get_pyodide_root, wheel_platform
+from pyodide_build.logger import logger
 from pyodide_build.spec import _BuildSpecExports
 
 
@@ -88,7 +90,30 @@ def run(
     if "emscripten" in wheel_path.name:
         # Retag platformed wheels to pyodide
         wheel_path = common.retag_wheel(wheel_path, wheel_platform())
-    with common.modify_wheel(wheel_path) as wheel_dir:
-        build_env.replace_so_abi_tags(wheel_dir)
+
+    _check_and_maybe_modify_wheel(wheel_path)
 
     return wheel_path
+
+
+def _check_and_maybe_modify_wheel(wheel_path: Path) -> None:
+    """Rewrite .so ABI tags inside *wheel_path*, but only when necessary.
+
+    For pure-Python wheels there are no native extensions, so the unpack/repack
+    round-trip performed by :func:`common.modify_wheel` would be a no-op.
+    We detect that case up-front and skip the two ``python -m wheel`` subprocess
+    calls entirely.
+    """
+    # Only unpack/repack the wheel if it contains native extension files that
+    # need their ABI tags rewritten.  For pure-Python wheels this is always a
+    # no-op, so we skip the two subprocess round-trips entirely.
+    with zipfile.ZipFile(wheel_path) as zf:
+        has_so = any(name.endswith(".so") for name in zf.namelist())
+
+    if has_so:
+        with common.modify_wheel(wheel_path) as wheel_dir:
+            build_env.replace_so_abi_tags(wheel_dir)
+    else:
+        logger.debug(
+            "Skipping ABI-tag rewrite for pure-Python wheel %s", wheel_path.name
+        )

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -33,6 +33,33 @@ def assert_runner_succeeded(result):
     assert result.exit_code == 0
 
 
+def test_cli_import_does_not_resolve_xbuildenv_path(monkeypatch):
+    """Importing the build/xbuildenv CLI modules must NOT call default_xbuildenv_path.
+
+    Resolving the default path does a ConfigManager build, filesystem probes,
+    and can even raise RuntimeError when no writable directory exists.  All of
+    that should be deferred until the command body runs, not happen at import
+    time on every ``pyodide`` invocation.
+    """
+    called = []
+    monkeypatch.setattr(
+        common, "default_xbuildenv_path", lambda: called.append(1) or None
+    )
+
+    # Re-import the modules so module-level code runs again under the monkeypatch.
+    import importlib
+
+    import pyodide_build.cli.build as _build_mod
+    import pyodide_build.cli.xbuildenv as _xbuildenv_mod
+
+    importlib.reload(_build_mod)
+    importlib.reload(_xbuildenv_mod)
+
+    assert not called, (
+        "default_xbuildenv_path must not be called at CLI module import time"
+    )
+
+
 def test_skeleton_pypi(tmp_path):
     test_pkg = "pytest-pyodide"
     old_version = "0.21.0"
@@ -446,6 +473,9 @@ def test_build1(tmp_path, monkeypatch, dummy_xbuildenv, mock_emscripten):
         results["outdir"] = outdir
         results["backend_flags"] = backend_flags
         dummy_wheel = outdir / "package-1.0.0-py3-none-any.whl"
+        # Create a real (empty) zip so that the .so-detection step can read it.
+        with zipfile.ZipFile(dummy_wheel, "w"):
+            pass
         return str(dummy_wheel)
 
     from contextlib import nullcontext
@@ -770,6 +800,9 @@ def test_build_isolation_flags(
             }
         )
         dummy_wheel = outdir / "package-1.0.0-py3-none-any.whl"
+        # Create a real (empty) zip so that the .so-detection step can read it.
+        with zipfile.ZipFile(dummy_wheel, "w"):
+            pass
         return str(dummy_wheel)
 
     monkeypatch.setattr(pypabuild, "build", mocked_build)
@@ -833,6 +866,9 @@ def test_build_skip_dependency_check(
             }
         )
         dummy_wheel = outdir / "package-1.0.0-py3-none-any.whl"
+        # Create a real (empty) zip so that the .so-detection step can read it.
+        with zipfile.ZipFile(dummy_wheel, "w"):
+            pass
         return str(dummy_wheel)
 
     monkeypatch.setattr(pypabuild, "build", mocked_build)
@@ -897,6 +933,9 @@ def test_build_combined_flags(
             }
         )
         dummy_wheel = outdir / "package-1.0.0-py3-none-any.whl"
+        # Create a real (empty) zip so that the .so-detection step can read it.
+        with zipfile.ZipFile(dummy_wheel, "w"):
+            pass
         return str(dummy_wheel)
 
     monkeypatch.setattr(pypabuild, "build", mocked_build)
@@ -962,6 +1001,9 @@ def test_build_verbosity_flag(
     ):
         build_calls.append({"verbosity": verbosity})
         dummy_wheel = outdir / "package-1.0.0-py3-none-any.whl"
+        # Create a real (empty) zip so that the .so-detection step can read it.
+        with zipfile.ZipFile(dummy_wheel, "w"):
+            pass
         return str(dummy_wheel)
 
     monkeypatch.setattr(pypabuild, "build", mocked_build)

--- a/pyodide_build/tests/test_oot_build.py
+++ b/pyodide_build/tests/test_oot_build.py
@@ -1,7 +1,11 @@
+import zipfile
+from contextlib import nullcontext
+from pathlib import Path
 from typing import Literal
 
 import pytest
 
+from pyodide_build import build_env, common
 from pyodide_build.out_of_tree import build
 
 FAKE_PYPROJECT_TOML = """\
@@ -118,3 +122,64 @@ def test_get_requires_for_build_not_retried_on_empty_result(
     assert call_count[0] == 1, (
         f"get_requires_for_build called {call_count[0]} times but expected 1"
     )
+
+
+class TestSoDetectionSkip:
+    """Tests for the .so-detection optimisation in out_of_tree.build.run."""
+
+    def _make_wheel(self, tmp_path: Path, name: str, so_files: list[str]) -> Path:
+        """Create a minimal wheel zip for testing purposes."""
+        whl = tmp_path / name
+        with zipfile.ZipFile(whl, "w") as zf:
+            zf.writestr("pkg/__init__.py", "")
+            for so in so_files:
+                zf.writestr(so, "")
+        return whl
+
+    def test_pure_wheel_skips_modify(self, tmp_path, monkeypatch):
+        """A wheel with no .so files must not call modify_wheel or replace_so_abi_tags."""
+        whl = self._make_wheel(tmp_path, "pkg-1.0-py3-none-any.whl", [])
+
+        replace_called = []
+
+        def _record_replace(wheel_dir):
+            replace_called.append(wheel_dir)
+
+        monkeypatch.setattr(common, "modify_wheel", lambda *a, **kw: nullcontext())
+        monkeypatch.setattr(build_env, "replace_so_abi_tags", _record_replace)
+
+        from pyodide_build.out_of_tree.build import _check_and_maybe_modify_wheel
+
+        _check_and_maybe_modify_wheel(whl)
+
+        assert not replace_called, (
+            "replace_so_abi_tags must not be called for a pure wheel"
+        )
+
+    def test_so_wheel_calls_modify(self, tmp_path, monkeypatch):
+        """A wheel containing a .so file must call modify_wheel and replace_so_abi_tags."""
+        whl = self._make_wheel(
+            tmp_path,
+            "pkg-1.0-cp312-cp312-emscripten_3_1_58_wasm32.whl",
+            ["pkg/ext.cpython-312-x86_64-linux-gnu.so"],
+        )
+
+        replace_called = []
+
+        def _record_replace(wheel_dir):
+            replace_called.append(wheel_dir)
+
+        monkeypatch.setattr(
+            common,
+            "modify_wheel",
+            lambda wheel_path: nullcontext(tmp_path),
+        )
+        monkeypatch.setattr(build_env, "replace_so_abi_tags", _record_replace)
+
+        from pyodide_build.out_of_tree.build import _check_and_maybe_modify_wheel
+
+        _check_and_maybe_modify_wheel(whl)
+
+        assert replace_called, (
+            "replace_so_abi_tags must be called for a wheel with .so files"
+        )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Three small performance improvements to the pyodide-build toolchain. Part of #376.

- **Stream archive downloads**: `download_and_unpack_archive` in `common.py` previously called `resp.read()` which buffers the entire archive (potentially hundreds of MB for xbuildenv/emsdk tarballs) in RAM before writing to disk. Changed to stream directly with `shutil.copyfileobj(resp, f)`, reducing peak memory usage proportionally to archive size.

- **Lazy xbuildenv default path resolution**: `DEFAULT_PATH = default_xbuildenv_path()` in `cli/build.py` and `cli/xbuildenv.py` ran at module import time — triggering a `ConfigManager` build, a parent-directory `pyproject.toml` walk, write-access probes, and a potential `RuntimeError` — on *every* `pyodide` invocation for *every* subcommand. Changed both modules to `default=None` on all `--path`/`--xbuildenv-path` options and added an `if path is None: path = default_xbuildenv_path()` guard inside each command body so the cost is deferred until it is actually needed.

- **Skip wheel unpack/repack for pure-Python wheels**: `out_of_tree/build.py` previously called `modify_wheel` (two `python -m wheel` subprocess round-trips + full unzip/rezip) unconditionally, even for pure-Python wheels where `replace_so_abi_tags` does nothing. Now checks the wheel's zipfile namelist for any `.so` entries before deciding whether to unpack. The logic is extracted into a helper `_check_and_maybe_modify_wheel` for testability.

## Test plan

- [x] `pyodide_build/tests/test_xbuildenv.py::TestCrossBuildEnvManager::test_download` — exercises `download_and_unpack_archive` against `pytest-httpserver`; still passes with streaming.
- [x] `pyodide_build/tests/test_cli.py::test_cli_import_does_not_resolve_xbuildenv_path` — new test that reloads `cli.build` and `cli.xbuildenv` under a monkeypatched `default_xbuildenv_path` and asserts it was never called.
- [x] `pyodide_build/tests/test_oot_build.py::TestSoDetectionSkip` — new tests: pure wheel → `replace_so_abi_tags` not called; wheel with `.so` → called.
- [x] Full unit suite (`pytest pyodide_build -m "not integration"`) passes (320 passed, 1 skipped, 1 xfailed; pre-existing failures unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)