### PR TITLE
Explicitly reject `oldest-supported-numpy` as a build-time dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `numpy-config` from NumPy) not being available on `PATH` during builds.
   [#21](https://github.com/pyodide/pyodide-build/pull/21)
 
+- `oldest-supported-numpy` is now explicitly rejected when encountered as a
+  build-time dependency. It is deprecated since NumPy 2.0, and packages that
+  still list it should migrate to a direct `numpy` dependency.
+  [#392](https://github.com/pyodide/pyodide-build/pull/392)
+
 ## [0.35.1] - 2026/06/13
 
 ### Fixed

--- a/pyodide_build/constants.py
+++ b/pyodide_build/constants.py
@@ -4,5 +4,4 @@
 BASE_IGNORED_REQUIREMENTS: list[str] = [
     # mesonpy installs patchelf in linux platform but we don't want it.
     "patchelf",
-    "oldest-supported-numpy",
 ]

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -146,6 +146,12 @@ def _replace_unisolated_packages(
         # is applicable in the current environment or not.
         if req.marker and not req.marker.evaluate():
             continue
+        if canonicalize_name(req.name) == "oldest-supported-numpy":
+            raise ValueError(
+                f"Build dependency '{reqstr}' is not supported. "
+                "oldest-supported-numpy is deprecated since NumPy 2.0. "
+                "Use a direct 'numpy' dependency instead."
+            )
         match = canonical_unisolated.get(canonicalize_name(req.name))
         if match is None:
             continue

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -73,6 +73,27 @@ def test_replace_unisolated_packages_version_mismatch():
     assert replaced == {"baz"}
 
 
+@pytest.mark.parametrize(
+    "reqstr",
+    [
+        "oldest-supported-numpy",
+        "oldest-supported-numpy>=2021.6.17",
+        "Oldest-Supported-NumPy",
+    ],
+)
+def test_replace_unisolated_packages_rejects_oldest_supported_numpy(reqstr):
+    with pytest.raises(ValueError, match="oldest-supported-numpy is deprecated"):
+        pypabuild._replace_unisolated_packages({reqstr}, {"numpy": "2.0.3"})
+
+
+def test_replace_unisolated_packages_oldest_supported_numpy_marker_not_applicable():
+    requires = {"oldest-supported-numpy; python_version<'3.0'"}
+
+    new_requires, replaced = pypabuild._replace_unisolated_packages(requires, {})
+    assert new_requires == requires
+    assert replaced == set()
+
+
 def test_install_reqs(tmp_path, dummy_xbuildenv, monkeypatch):
     monkeypatch.setattr(pypabuild, "_install_cross_build_files", lambda *a, **kw: None)
     env = MockIsolatedEnv(tmp_path)


### PR DESCRIPTION
Split off from #21. `oldest-supported-numpy` is no longer silently ignored when it appears as a build dependency, and instead raises an error. It has been deprecated since NumPy 2.0, so packages that still depend on it should move to a plain `numpy` dependency. If this causes trouble for a specific recipe, it can still be ignored by setting `ignored_build_requirements` to `"patchelf oldest-supported-numpy"` of course, but IMO we don't need to bother about it anymore. In https://github.com/pyodide/pyodide-recipes/pull/591, I tested the change via #21, only Fiona was using it. I updated its version to one that no longer uses it in https://github.com/pyodide/pyodide-recipes/pull/608 and all recipes are now fine.