### PR TITLE
Drop all SciPy fixes from pyodide-build

### DIFF
--- a/pyodide_build/_f2c_fixes.py
+++ b/pyodide_build/_f2c_fixes.py
@@ -61,66 +61,6 @@ def fix_f2c_output(f2c_output: Path) -> None:
         return
 
 
-def scipy_fix_cfile(path: Path) -> None:
-    """
-    Replace void return types with int return types in various generated .c and
-    .h files. We can't achieve this with a simple patch because these files are
-    not in the sdist, they are generated as part of the build.
-    """
-    text = path.read_text()
-    text = text.replace("extern void F_WRAPPEDFUNC", "extern int F_WRAPPEDFUNC")
-    text = text.replace("extern void F_FUNC", "extern int F_FUNC")
-    text = text.replace("void (*f2py_func)", "int (*f2py_func)")
-    text = text.replace("static void cb_", "static int cb_")
-    text = text.replace("typedef void(*cb_", "typedef int(*cb_")
-    text = text.replace("void(*)", "int(*)")
-    text = text.replace("static void f2py_setup_", "static int f2py_setup_")
-
-    # Fix Cython-generated function pointer casts for __Pyx_IsSameCFunction
-    # for _matfuncs_sqrtm for builds of SciPy 1.16.0.
-    # TODO: I'm not sure if this is the best place to put this, but it works
-    text = re.sub(
-        r"(__Pyx_IsSameCFunction\([^,]+,\s*)\(int\(\*\)\(void\)\)",
-        r"\1(void(*)(void))",
-        text,
-    )
-
-    if path.name.endswith("_flapackmodule.c"):
-        text = text.replace(",size_t", "")
-        text = re.sub(r",slen\([a-z]*\)\)", ")", text)
-
-    path.write_text(text)
-
-    for lib in ["lapack", "blas"]:
-        if path.name.endswith(f"cython_{lib}.c"):
-            header_name = f"_{lib}_subroutines.h"
-            header_dir = path.parent
-            header_path = find_header(header_dir, header_name)
-
-            header_text = header_path.read_text()
-            header_text = header_text.replace("void F_FUNC", "int F_FUNC")
-            header_path.write_text(header_text)
-
-
-def find_header(source_dir: Path, header_name: str) -> Path:
-    """
-    Find the header file that corresponds to a source file.
-    """
-    while not (header_path := source_dir / header_name).exists():
-        # meson copies the source files into a subdirectory of the build
-        source_dir = source_dir.parent
-        if source_dir == Path("/"):
-            raise RuntimeError(f"Could not find header file {header_name}")
-
-    return header_path
-
-
-def scipy_fixes(args: list[str]) -> None:
-    for arg in args:
-        if arg.endswith(".c"):
-            scipy_fix_cfile(Path(arg))
-
-
 def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
     """Apply f2c to compilation arguments
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -649,11 +649,6 @@ def handle_command(
 
     new_args = handle_command_generate_args(line, build_args)
 
-    if build_args.pkgname == "scipy":
-        from _f2c_fixes import scipy_fixes
-
-        scipy_fixes(new_args)
-
     result = sp_run(new_args, check=False)
     return result.returncode
 


### PR DESCRIPTION
This PR removes all SciPy fixes from our code, so that we do not interfere with SciPy builds at all. 

This PR is not ready to be merged right now. However, I've been using a neutered rendition of this to aid my work on https://github.com/pyodide/pyodide-recipes/issues/604. I raised `RuntimeError`s in these places to ensure that these fixes and f2c hacks are not called when building SciPy. I am going to replace that with this PR, so that we have no code to call at all.

Note that f2c-related fixes are also used outside the SciPy recipe, so they are kept.

We should be able to merge this PR once I upstream my work (very soon! edit: done, see pyodide/pyodide-recipes#609).