### PR TITLE
Deploy unvendored tests in a zipfile format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.0] - 2026/07/24
+
+### Changed
+
+- Unvendored tests that are generated from the package recipes are now compressed as a
+  `.zip` file instead of a `.tar` file. This should not affect any user-facing
+  functionality.
+  [#401](https://github.com/pyodide/pyodide-build/pull/401)
+
 ## [0.36.0] - 2026/06/30
 
 ### Fixed

--- a/pyodide_build/recipe/unvendor.py
+++ b/pyodide_build/recipe/unvendor.py
@@ -17,7 +17,7 @@ def unvendor_tests_in_wheel(
     Unvendor tests from a wheel file.
 
     This function finds the tests in the wheel file, and extracts them to a separate
-    tar file. The tar file is placed in the same directory as the wheel file, with the -tests.tar suffix.
+    zip file. The zip file is placed in the same directory as the wheel file, with the -tests.zip suffix.
 
     Parameters
     ----------
@@ -29,12 +29,12 @@ def unvendor_tests_in_wheel(
 
     Returns
     -------
-    The path to the tar file containing the tests. If no tests were found, returns None.
+    The path to the zip file containing the tests. If no tests were found, returns None.
     """
     retain_patterns = retain_patterns or []
 
     name = parse_wheel_filename(wheel.name)[0]
-    file_format = "tar"
+    file_format = "zip"
     basename = f"{name}-tests"
     fullname = f"{basename}.{file_format}"
     destination = wheel.parent / fullname

--- a/pyodide_build/tests/recipe/test_unvendor.py
+++ b/pyodide_build/tests/recipe/test_unvendor.py
@@ -15,9 +15,9 @@ def test_unvendor_tests_in_wheel(tmp_path):
     test_tar_path = unvendor.unvendor_tests_in_wheel(test_wheel_path, [])
 
     assert test_tar_path.exists()
-    assert test_tar_path.name == "package-with-bunch-of-test-directories-tests.tar"
+    assert test_tar_path.name == "package-with-bunch-of-test-directories-tests.zip"
 
-    # Check the contents of the tar file
+    # Check the contents of the zip file
     shutil.unpack_archive(test_tar_path, extract_dir=tmp_path / "extracted_tests")
     files = [f.name for f in (tmp_path / "extracted_tests").rglob("*")]
 
@@ -52,9 +52,9 @@ def test_unvendor_tests_in_wheel_retain(tmp_path):
     )
 
     assert test_tar_path.exists()
-    assert test_tar_path.name == "package-with-bunch-of-test-directories-tests.tar"
+    assert test_tar_path.name == "package-with-bunch-of-test-directories-tests.zip"
 
-    # Check the contents of the tar file
+    # Check the contents of the zip file
     shutil.unpack_archive(test_tar_path, extract_dir=tmp_path / "extracted_tests")
     files = [f.name for f in (tmp_path / "extracted_tests").rglob("*")]
 


### PR DESCRIPTION
This makes https://github.com/pyodide/pyodide/pull/6354 easier, as we don't need to implement our own tar decompressor