### PR TITLE
Test the stable-debug xbuildenv variants in our CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,7 @@ jobs:
         # for the pip installer and on Linux
           - task: {name: test-src-no-isolation, installer: pip} # installer doesn't matter
             os: ubuntu-latest
+            pyodide-version: stable
           - task: { name: test-recipe, installer: pip }
             os: ubuntu-latest
             pyodide-version: minimum

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,10 @@ jobs:
           - task: { name: test-src, installer: pip }
             os: ubuntu-latest
             pyodide-version: minimum
+          - task: { name: test-src, installer: pip }
+            os: ubuntu-latest
+            pyodide-version: stable-debug
+            python-version: "3.14"
 
     if: needs.check-integration-test-trigger.outputs.run-integration-test
     steps:
@@ -179,7 +183,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version || '3.13' }}
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -197,6 +201,8 @@ jobs:
             MIN_VERSION=$(pyodide xbuildenv search --json | jq -r '.environments | sort_by(.version) | .[0].version')
             echo "Installing Pyodide xbuildenv version: $MIN_VERSION"
             pyodide xbuildenv install $MIN_VERSION
+          elif [[ "${{ matrix.pyodide-version }}" == "stable-debug" ]]; then
+            pyodide xbuildenv install --debug
           else
             pyodide xbuildenv install
           fi


### PR DESCRIPTION
We added functionality to install these easily via #350 and #371, but haven't been testing them properly, which is what led me to open https://github.com/pyodide/pyodide/issues/6379. This PR adds an entry to our integration tests matrix so that we can have at least one job that tests the stable-debug xbuildenvs.