### PR TITLE
Install python.exe into Windows venvs for console scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,10 +335,15 @@ jobs:
           pyodide venv .venv-pyodide
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-          .\.venv-pyodide\Scripts\pip.bat install six
+          .\.venv-pyodide\Scripts\pip.bat install pygments
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-          .\.venv-pyodide\Scripts\python.bat -c "import six; print(six.__version__)"
+          Get-ChildItem .\.venv-pyodide\Scripts
+          $script = Get-ChildItem .\.venv-pyodide\Scripts -Filter "pygmentize*" |
+            Select-Object -First 1
+          if (-not $script) { throw "pygmentize console script was not created" }
+
+          & $script.FullName -V
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   coverage:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -342,16 +342,18 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $dest = "C:\Program Files\pyodide venv test\.venv-pyodide"
-          New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+          $root = "C:\Program Files\pyodide venv test"
+          New-Item -ItemType Directory -Force -Path $root | Out-Null
 
-          pyodide venv $dest
+          Set-Location $root
+
+          pyodide venv .venv-pyodide
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-          & "$dest\Scripts\pip.bat" install six
+          .\.venv-pyodide\Scripts\pip.bat install six
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-          & "$dest\Scripts\python.bat" -c "import six; print(six.__version__)"
+          .\.venv-pyodide\Scripts\python.bat -c "import six; print(six.__version__)"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   coverage:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,30 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+  windows-test:
+    name: windows-test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # include tags so that hatch-vcs can infer the version
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --group test
+
+      # The rest of the suite has never been run on Windows, so for now this
+      # is scoped to the tests that are specifically about Windows behaviour.
+      - name: Run tests marked with windows
+        run: pytest pyodide_build/tests/test_venv.py -m windows
+
   windows-integration-test:
     runs-on: windows-latest
     needs: [check-integration-test-trigger]
@@ -312,6 +336,8 @@ jobs:
             ./scripts/pyodide_venv_test.sh
           fi
 
+      # The runner has administrator rights, so this can use the real Program
+      # Files rather than a workspace directory that merely contains a space.
       - name: Create a venv under Program Files
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,13 +321,15 @@ jobs:
             ./scripts/pyodide_venv_test.sh
           fi
 
-      # The runner has administrator rights, so this can use the real Program
-      # Files rather than a workspace directory that merely contains a space.
-      - name: Create a venv under Program Files
+      # Pyodide's python.exe launcher mangles the path to python.bat when it
+      # holds a space, so for now this runs somewhere without one.
+      # TODO: move this back to "C:\Program Files\pyodide venv test" when
+      # https://github.com/pyodide/pyodide/pull/6381 is released.
+      - name: Create a venv outside the workspace
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $root = "C:\Program Files\pyodide venv test"
+          $root = "C:\pyodide-venv-test"
           New-Item -ItemType Directory -Force -Path $root | Out-Null
 
           Set-Location $root

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,13 +245,14 @@ jobs:
           include-hidden-files: true
 
   test-venv:
-    name: test-venv (${{ matrix.os }})
+    name: test-venv (${{ matrix.os }}, ${{ matrix.python-source }})
     runs-on: ${{ matrix.os }}
     needs: [check-integration-test-trigger]
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-source: [gha-python, uv-managed]
 
     if: needs.check-integration-test-trigger.outputs.run-integration-test
     steps:
@@ -260,9 +261,33 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
+        if: matrix.python-source == 'gha-python'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+
+      - name: Set up uv
+        if: matrix.python-source == 'uv-managed'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Set up a uv-managed Python
+        if: matrix.python-source == 'uv-managed'
+        shell: bash
+        env:
+          # never fall back to a system Python
+          UV_PYTHON_PREFERENCE: only-managed
+        run: |
+          set -ex
+          uv python install 3.13
+          # log the interpreter path so it is obvious whether it has a space in it
+          uv python find 3.13
+          # --seed gives us pip, which the steps below and the venv test need
+          uv venv --seed --python 3.13 .venv-uv-host
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "$GITHUB_WORKSPACE/.venv-uv-host/Scripts" >> "$GITHUB_PATH"
+          else
+            echo "$GITHUB_WORKSPACE/.venv-uv-host/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,6 +49,7 @@ jobs:
           pip install -e ".[resolve]" --group test
 
       - name: Run tests
+        if: runner.os != 'Windows'
         run: |
           pytest \
             --junitxml=test-results/junit.xml \
@@ -56,37 +57,21 @@ jobs:
             pyodide_build \
             -m "not integration"
 
+      # The rest of the suite has never been run on Windows, so for now this
+      # is scoped to the tests that are specifically about Windows behaviour.
+      - name: Run tests marked with windows
+        if: runner.os == 'Windows'
+        run: pytest pyodide_build/tests/test_venv.py -m windows
+
       - name: Upload coverage
+        # the Windows leg runs too little of the suite to be worth measuring
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-no-integration-${{ matrix.os }}
           path: .coverage
           if-no-files-found: error
           include-hidden-files: true
-
-  windows-test:
-    name: windows-test
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # include tags so that hatch-vcs can infer the version
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e . --group test
-
-      # The rest of the suite has never been run on Windows, so for now this
-      # is scoped to the tests that are specifically about Windows behaviour.
-      - name: Run tests marked with windows
-        run: pytest pyodide_build/tests/test_venv.py -m windows
 
   windows-integration-test:
     runs-on: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,7 +279,7 @@ jobs:
         run: |
           set -ex
           uv python install 3.13
-          # log the interpreter path so it is obvious whether it has a space in it
+          # log the interpreter path, which on macOS is under Application Support
           uv python find 3.13
           # --seed gives us pip, which the steps below and the venv test need
           uv venv --seed --python 3.13 .venv-uv-host

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,32 +321,6 @@ jobs:
             ./scripts/pyodide_venv_test.sh
           fi
 
-      # Pyodide's python.exe launcher mangles the path to python.bat when it
-      # holds a space, so for now this runs somewhere without one.
-      # TODO: move this back to "C:\Program Files\pyodide venv test" when
-      # https://github.com/pyodide/pyodide/pull/6381 is released.
-      - name: Create a venv outside the workspace
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $root = "C:\pyodide-venv-test"
-          New-Item -ItemType Directory -Force -Path $root | Out-Null
-
-          Set-Location $root
-
-          pyodide venv .venv-pyodide
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-          .\.venv-pyodide\Scripts\pip.bat install pygments
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-          Get-ChildItem .\.venv-pyodide\Scripts
-          $script = Get-ChildItem .\.venv-pyodide\Scripts -Filter "pygmentize*" |
-            Select-Object -First 1
-          if (-not $script) { throw "pygmentize console script was not created" }
-
-          & $script.FullName -V
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   coverage:
     name: Collect and upload coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,6 +321,32 @@ jobs:
             ./scripts/pyodide_venv_test.sh
           fi
 
+      # Pyodide's python.exe launcher mangles the path to python.bat when it
+      # holds a space, so for now this runs somewhere without one.
+      # TODO: move this back to "C:\Program Files\pyodide venv test" when
+      # https://github.com/pyodide/pyodide/pull/6381 is released.
+      - name: Create a venv outside the workspace
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $root = "C:\pyodide-venv-test"
+          New-Item -ItemType Directory -Force -Path $root | Out-Null
+
+          Set-Location $root
+
+          pyodide venv .venv-pyodide
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          .\.venv-pyodide\Scripts\pip.bat install pygments
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          Get-ChildItem .\.venv-pyodide\Scripts
+          $script = Get-ChildItem .\.venv-pyodide\Scripts -Filter "pygmentize*" |
+            Select-Object -First 1
+          if (-not $script) { throw "pygmentize console script was not created" }
+
+          & $script.FullName -V
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   coverage:
     name: Collect and upload coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,6 +312,22 @@ jobs:
             ./scripts/pyodide_venv_test.sh
           fi
 
+      - name: Create a venv under Program Files
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dest = "C:\Program Files\pyodide venv test\.venv-pyodide"
+          New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+
+          pyodide venv $dest
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          & "$dest\Scripts\pip.bat" install six
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          & "$dest\Scripts\python.bat" -c "import six; print(six.__version__)"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   coverage:
     name: Collect and upload coverage
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uv`-managed Pythons on macOS, which live under `Library/Application Support`.
   [#409](https://github.com/pyodide/pyodide-build/pull/409)
 
-- Pyodide virtual environments on Windows now include the `python.exe` shim that
-  Pyodide ships, and console scripts installed into them point at it. The venv
-  previously had no `.exe` interpreter at all, and the launcher that pip puts in
-  front of a console script refuses to invoke anything else, so no installed
-  script could be run. This needs a cross-build environment from Pyodide 0.29.3
-  or later, which is when the shim was first shipped.
-  [#409](https://github.com/pyodide/pyodide-build/pull/409)
-
 ### Changed
 
 - Replaced the `pydantic` dependency with `attrs` + `cattrs` for recipe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uv`-managed Pythons on macOS, which live under `Library/Application Support`.
   [#409](https://github.com/pyodide/pyodide-build/pull/409)
 
+- Pyodide virtual environments on Windows now include the `python.exe` shim that
+  Pyodide ships, and console scripts installed into them point at it. The venv
+  previously had no `.exe` interpreter at all, and the launcher that pip puts in
+  front of a console script refuses to invoke anything else, so no installed
+  script could be run. This needs a cross-build environment from Pyodide 0.29.3
+  or later, which is when the shim was first shipped.
+  [#409](https://github.com/pyodide/pyodide-build/pull/409)
+
 ### Changed
 
 - Replaced the `pydantic` dependency with `attrs` + `cattrs` for recipe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PYO3_USE_ABI3_FORWARD_COMPATIBILITY` environment variable is now set for all
   builds so that PyO3 packages will build against the unstable CPython version.
 
+### Fixed
+
+- The wrapper scripts written into a Pyodide virtual environment now quote every
+  interpolated path, so `pyodide venv` works when the host Python, the
+  cross-build environment, or `PATH` contains a space. This previously broke
+  `uv`-managed Pythons on macOS, which live under `Library/Application Support`.
+  [#409](https://github.com/pyodide/pyodide-build/pull/409)
+
 ### Changed
 
 - Replaced the `pydantic` dependency with `attrs` + `cattrs` for recipe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uv`-managed Pythons on macOS, which live under `Library/Application Support`.
   [#409](https://github.com/pyodide/pyodide-build/pull/409)
 
-- Console scripts installed into a Pyodide virtual environment on Windows now
-  point at the Pyodide interpreter. Their generated launcher previously referred
-  to `Scripts\python`, which does not exist there because the interpreter is
-  `Scripts\python.bat`, so running any installed script failed.
+- Pyodide virtual environments on Windows now include the `python.exe` shim that
+  Pyodide ships, and console scripts installed into them point at it. The venv
+  previously had no `.exe` interpreter at all, and the launcher that pip puts in
+  front of a console script refuses to invoke anything else, so no installed
+  script could be run. This needs a cross-build environment from Pyodide 0.29.3
+  or later, which is when the shim was first shipped.
   [#409](https://github.com/pyodide/pyodide-build/pull/409)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uv`-managed Pythons on macOS, which live under `Library/Application Support`.
   [#409](https://github.com/pyodide/pyodide-build/pull/409)
 
+- Console scripts installed into a Pyodide virtual environment on Windows now
+  point at the Pyodide interpreter. Their generated launcher previously referred
+  to `Scripts\python`, which does not exist there because the interpreter is
+  `Scripts\python.bat`, so running any installed script failed.
+  [#409](https://github.com/pyodide/pyodide-build/pull/409)
+
 ### Changed
 
 - Replaced the `pydantic` dependency with `attrs` + `cattrs` for recipe

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -82,7 +82,7 @@ clean:
 	rm -rf .pyodide-xbuildenv*
 	rm -rf recipes/*/build
 	rm -rf test_venv
-	rm -rf test-cmdline-runner
+	rm -rf "test cmdline runner"
 	rm -rf src/numpy-*
 	rm -rf src/numpy-*.tar.gz
 	rm -rf numpy-*

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -83,6 +83,9 @@ clean:
 	rm -rf recipes/*/build
 	rm -rf test_venv
 	rm -rf "test cmdline runner"
+# TODO: drop the line below, the Windows script uses the name above again, when
+# https://github.com/pyodide/pyodide/pull/6381 is released
+	rm -rf test-cmdline-runner
 	rm -rf src/numpy-*
 	rm -rf src/numpy-*.tar.gz
 	rm -rf numpy-*

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -83,9 +83,6 @@ clean:
 	rm -rf recipes/*/build
 	rm -rf test_venv
 	rm -rf "test cmdline runner"
-# TODO: drop the line below, the Windows script uses the name above again, when
-# https://github.com/pyodide/pyodide/pull/6381 is released
-	rm -rf test-cmdline-runner
 	rm -rf src/numpy-*
 	rm -rf src/numpy-*.tar.gz
 	rm -rf numpy-*

--- a/integration_tests/scripts/pyodide_venv_test.bat
+++ b/integration_tests/scripts/pyodide_venv_test.bat
@@ -1,11 +1,14 @@
 @echo on
 setlocal enabledelayedexpansion
 
-REM Clean up and create test directory. The space in the name is
-REM deliberate, as it lets us test venv paths that need quoting.
-if exist "test cmdline runner" rmdir /s /q "test cmdline runner"
-mkdir "test cmdline runner"
-cd "test cmdline runner"
+REM Clean up and create test directory. This has no space in it, unlike the
+REM POSIX script, because Pyodide's python.exe launcher mangles the path to
+REM python.bat when it contains one.
+REM TODO: rename this back to "test cmdline runner", matching the POSIX script,
+REM when https://github.com/pyodide/pyodide/pull/6381 is released.
+if exist test-cmdline-runner rmdir /s /q test-cmdline-runner
+mkdir test-cmdline-runner
+cd test-cmdline-runner
 if errorlevel 1 exit /b 1
 
 REM Create host virtual environment

--- a/integration_tests/scripts/pyodide_venv_test.bat
+++ b/integration_tests/scripts/pyodide_venv_test.bat
@@ -1,10 +1,11 @@
 @echo on
 setlocal enabledelayedexpansion
 
-REM Clean up and create test directory
-if exist test-cmdline-runner rmdir /s /q test-cmdline-runner
-mkdir test-cmdline-runner
-cd test-cmdline-runner
+REM Clean up and create test directory. The space in the name is
+REM deliberate, as it lets us test venv paths that need quoting.
+if exist "test cmdline runner" rmdir /s /q "test cmdline runner"
+mkdir "test cmdline runner"
+cd "test cmdline runner"
 if errorlevel 1 exit /b 1
 
 REM Create host virtual environment

--- a/integration_tests/scripts/pyodide_venv_test.bat
+++ b/integration_tests/scripts/pyodide_venv_test.bat
@@ -1,14 +1,11 @@
 @echo on
 setlocal enabledelayedexpansion
 
-REM Clean up and create test directory. This has no space in it, unlike the
-REM POSIX script, because Pyodide's python.exe launcher mangles the path to
-REM python.bat when it contains one.
-REM TODO: rename this back to "test cmdline runner", matching the POSIX script,
-REM when https://github.com/pyodide/pyodide/pull/6381 is released.
-if exist test-cmdline-runner rmdir /s /q test-cmdline-runner
-mkdir test-cmdline-runner
-cd test-cmdline-runner
+REM Clean up and create test directory. The space in the name is
+REM deliberate, as it lets us test venv paths that need quoting.
+if exist "test cmdline runner" rmdir /s /q "test cmdline runner"
+mkdir "test cmdline runner"
+cd "test cmdline runner"
 if errorlevel 1 exit /b 1
 
 REM Create host virtual environment

--- a/integration_tests/scripts/pyodide_venv_test.sh
+++ b/integration_tests/scripts/pyodide_venv_test.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -ex
 
-rm -rf test-cmdline-runner
-mkdir test-cmdline-runner
-cd test-cmdline-runner || exit
+# Clean up and create test directory. The space in the name is
+# deliberate, as it lets us test venv paths that need quoting.
+rm -rf "test cmdline runner"
+mkdir "test cmdline runner"
+cd "test cmdline runner" || exit
 
 python -m venv .venv-host
 # shellcheck source=/dev/null

--- a/pyodide_build/out_of_tree/pip_wrapper.py
+++ b/pyodide_build/out_of_tree/pip_wrapper.py
@@ -37,7 +37,10 @@ def get_executable():
         raise RuntimeError(
             f'Internal Pyodide error: expected sys.executable="{sys.executable}" to end with "{CONFIG.executable_symlink_suffix}"'
         )
-    return sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
+    return (
+        sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
+        + CONFIG.exe_suffix
+    )
 
 
 scripts.get_executable = get_executable  # type: ignore[attr-defined]

--- a/pyodide_build/out_of_tree/pip_wrapper.py
+++ b/pyodide_build/out_of_tree/pip_wrapper.py
@@ -16,7 +16,6 @@ class Config:
     pip_wrapper_name: str
     platform_data: tuple[str, str, str, str, str]
     pyodide_platform: str
-    script_interpreter_suffix: str
     sysconfigdata_dir: str
 
 
@@ -38,10 +37,7 @@ def get_executable():
         raise RuntimeError(
             f'Internal Pyodide error: expected sys.executable="{sys.executable}" to end with "{CONFIG.executable_symlink_suffix}"'
         )
-    return (
-        sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
-        + CONFIG.script_interpreter_suffix
-    )
+    return sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
 
 
 scripts.get_executable = get_executable  # type: ignore[attr-defined]

--- a/pyodide_build/out_of_tree/pip_wrapper.py
+++ b/pyodide_build/out_of_tree/pip_wrapper.py
@@ -16,6 +16,7 @@ class Config:
     pip_wrapper_name: str
     platform_data: tuple[str, str, str, str, str]
     pyodide_platform: str
+    script_interpreter_suffix: str
     sysconfigdata_dir: str
 
 
@@ -39,7 +40,7 @@ def get_executable():
         )
     return (
         sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
-        + CONFIG.exe_suffix
+        + CONFIG.script_interpreter_suffix
     )
 
 

--- a/pyodide_build/out_of_tree/pip_wrapper.py
+++ b/pyodide_build/out_of_tree/pip_wrapper.py
@@ -16,6 +16,7 @@ class Config:
     pip_wrapper_name: str
     platform_data: tuple[str, str, str, str, str]
     pyodide_platform: str
+    script_interpreter_suffix: str
     sysconfigdata_dir: str
 
 
@@ -37,7 +38,10 @@ def get_executable():
         raise RuntimeError(
             f'Internal Pyodide error: expected sys.executable="{sys.executable}" to end with "{CONFIG.executable_symlink_suffix}"'
         )
-    return sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
+    return (
+        sys.executable.removesuffix(CONFIG.executable_symlink_suffix)
+        + CONFIG.script_interpreter_suffix
+    )
 
 
 scripts.get_executable = get_executable  # type: ignore[attr-defined]

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -1,6 +1,7 @@
 import ast
 import json
 import os
+import shlex
 import shutil
 import sys
 import textwrap
@@ -504,10 +505,13 @@ class UnixPyodideVenv(PyodideVenv):
         """
         base_executable = getattr(sys, "_base_executable", sys.executable)
         pythonhome = Path(base_executable).parents[1]
+        # These paths can contain spaces, such as noticed via uv-managed
+        # Python on macOS which lives under "Application Support". See:
+        # https://github.com/pyodide/pyodide-build/issues/399
         return dedent(
             f"""\
             #!/bin/sh
-            exec env PYTHONHOME={pythonhome} {self.host_python_symlink_path} "$@"
+            exec env PYTHONHOME={shlex.quote(str(pythonhome))} {shlex.quote(str(self.host_python_symlink_path))} "$@"
             """
         )
 
@@ -518,7 +522,7 @@ class UnixPyodideVenv(PyodideVenv):
         return dedent(
             f"""
             #!/usr/bin/env bash
-            {self.host_python_path} -s {self.pip_wrapper_path} "$@"
+            {shlex.quote(str(self.host_python_path))} -s {shlex.quote(str(self.pip_wrapper_path))} "$@"
             """
         )
 
@@ -556,7 +560,7 @@ class UnixPyodideVenv(PyodideVenv):
             dedent(
                 f"""
                 #!/usr/bin/env bash
-                PATH="{PATH}:$PATH" PYODIDE_ROOT='{PYODIDE_ROOT}' exec {original_pyodide_cli} "$@"
+                PATH={shlex.quote(PATH)}:"$PATH" PYODIDE_ROOT={shlex.quote(PYODIDE_ROOT)} exec {shlex.quote(original_pyodide_cli)} "$@"
                 """
             )
         )
@@ -654,8 +658,8 @@ class WindowsPyodideVenv(PyodideVenv):
             dedent(
                 f"""
                 @echo off
-                set PATH={PATH};%PATH%
-                set PYODIDE_ROOT={PYODIDE_ROOT}
+                set "PATH={PATH};%PATH%"
+                set "PYODIDE_ROOT={PYODIDE_ROOT}"
                 "{original_pyodide_cli}" %*
                 """
             )

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -188,6 +188,21 @@ class PyodideVenv(ABC):
         return self.venv_bin / self.python_exe_name
 
     @property
+    def script_interpreter_suffix(self) -> str:
+        """Get the extension of the interpreter that console scripts invoke.
+
+        This is the ``+ suffix`` half of the calculation that ``pip_wrapper``
+        does to turn ``sys.executable`` into the Pyodide interpreter, the other
+        half being ``host_python_symlink_suffix``.
+        """
+        return ""
+
+    @property
+    def script_interpreter_path(self) -> Path:
+        """Get the path to the interpreter that installed console scripts invoke."""
+        return self.venv_bin / f"python{self.script_interpreter_suffix}"
+
+    @property
     def pyodide_cli_path(self) -> Path:
         """Get the path to the pyodide CLI script in the virtualenv."""
         return self.venv_bin / self.pyodide_exe_name
@@ -348,6 +363,7 @@ class PyodideVenv(ABC):
         return dict(
             executable_symlink_suffix=self.host_python_symlink_suffix,
             exe_suffix=self.exe_suffix,
+            script_interpreter_suffix=self.script_interpreter_suffix,
             pip_patched_name=self.pip_patched_path.name,
             pip_wrapper_name=self.pip_wrapper_path.name,
             platform_data=ast.literal_eval(result.stdout),
@@ -586,6 +602,21 @@ class WindowsPyodideVenv(PyodideVenv):
         return "-host-link.exe"
 
     @property
+    def script_interpreter_suffix(self) -> str:
+        """Get the extension of the interpreter that console scripts invoke.
+
+        The launcher that pip puts in front of a console script can only
+        invoke an ``.exe``, so these point at the ``python.exe`` shim rather
+        than at ``python.bat``.
+        """
+        return ".exe"
+
+    @property
+    def interpreter_launcher_path(self) -> Path:
+        """Get the path to the python.exe shim in the Pyodide dist directory."""
+        return pyodide_dist_dir() / "python.exe"
+
+    @property
     def host_python_wrapper(self) -> str:
         """Get the content of the host python wrapper script.
 
@@ -644,6 +675,31 @@ class WindowsPyodideVenv(PyodideVenv):
             if python_bat != self.interpreter_symlink_path:
                 python_bat.unlink(missing_ok=True)
                 python_bat.symlink_to(self.interpreter_path)
+
+        self._install_interpreter_launcher()
+
+    def _install_interpreter_launcher(self) -> None:
+        """Put the python.exe shim from the Pyodide dist next to python.bat.
+
+        Pyodide ships a small launcher that forwards to python.bat, so that the
+        venv has an ``.exe`` interpreter like an ordinary one does. Without it
+        the launchers pip generates for console scripts have nothing they can
+        invoke, since they refuse any interpreter that is not an ``.exe``.
+        """
+        if not self.interpreter_launcher_path.exists():
+            # Pyodide only started shipping the shim in 0.29.3
+            logger.warning(
+                "%s not found in the cross-build environment. Console scripts "
+                "installed into this virtualenv will not be runnable.",
+                self.interpreter_launcher_path.name,
+            )
+            return
+
+        # Copy rather than symlink. The shim resolves its own path before
+        # looking for python.bat beside it, so a symlink would send it to the
+        # dist directory and it would lose track of the virtualenv.
+        self.script_interpreter_path.unlink(missing_ok=True)
+        shutil.copy(self.interpreter_launcher_path, self.script_interpreter_path)
 
     def _create_pyodide_script(self) -> None:
         """Write pyodide cli script into the virtualenv bin folder."""

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -188,21 +188,6 @@ class PyodideVenv(ABC):
         return self.venv_bin / self.python_exe_name
 
     @property
-    def script_interpreter_suffix(self) -> str:
-        """Get the extension of the interpreter that console scripts invoke.
-
-        This is the ``+ suffix`` half of the calculation that ``pip_wrapper``
-        does to turn ``sys.executable`` into the Pyodide interpreter, the other
-        half being ``host_python_symlink_suffix``.
-        """
-        return ""
-
-    @property
-    def script_interpreter_path(self) -> Path:
-        """Get the path to the interpreter that installed console scripts invoke."""
-        return self.venv_bin / f"python{self.script_interpreter_suffix}"
-
-    @property
     def pyodide_cli_path(self) -> Path:
         """Get the path to the pyodide CLI script in the virtualenv."""
         return self.venv_bin / self.pyodide_exe_name
@@ -363,7 +348,6 @@ class PyodideVenv(ABC):
         return dict(
             executable_symlink_suffix=self.host_python_symlink_suffix,
             exe_suffix=self.exe_suffix,
-            script_interpreter_suffix=self.script_interpreter_suffix,
             pip_patched_name=self.pip_patched_path.name,
             pip_wrapper_name=self.pip_wrapper_path.name,
             platform_data=ast.literal_eval(result.stdout),
@@ -602,21 +586,6 @@ class WindowsPyodideVenv(PyodideVenv):
         return "-host-link.exe"
 
     @property
-    def script_interpreter_suffix(self) -> str:
-        """Get the extension of the interpreter that console scripts invoke.
-
-        The launcher that pip puts in front of a console script can only
-        invoke an ``.exe``, so these point at the ``python.exe`` shim rather
-        than at ``python.bat``.
-        """
-        return ".exe"
-
-    @property
-    def interpreter_launcher_path(self) -> Path:
-        """Get the path to the python.exe shim in the Pyodide dist directory."""
-        return pyodide_dist_dir() / "python.exe"
-
-    @property
     def host_python_wrapper(self) -> str:
         """Get the content of the host python wrapper script.
 
@@ -675,31 +644,6 @@ class WindowsPyodideVenv(PyodideVenv):
             if python_bat != self.interpreter_symlink_path:
                 python_bat.unlink(missing_ok=True)
                 python_bat.symlink_to(self.interpreter_path)
-
-        self._install_interpreter_launcher()
-
-    def _install_interpreter_launcher(self) -> None:
-        """Put the python.exe shim from the Pyodide dist next to python.bat.
-
-        Pyodide ships a small launcher that forwards to python.bat, so that the
-        venv has an ``.exe`` interpreter like an ordinary one does. Without it
-        the launchers pip generates for console scripts have nothing they can
-        invoke, since they refuse any interpreter that is not an ``.exe``.
-        """
-        if not self.interpreter_launcher_path.exists():
-            # Pyodide only started shipping the shim in 0.29.3
-            logger.warning(
-                "%s not found in the cross-build environment. Console scripts "
-                "installed into this virtualenv will not be runnable.",
-                self.interpreter_launcher_path.name,
-            )
-            return
-
-        # Copy rather than symlink. The shim resolves its own path before
-        # looking for python.bat beside it, so a symlink would send it to the
-        # dist directory and it would lose track of the virtualenv.
-        self.script_interpreter_path.unlink(missing_ok=True)
-        shutil.copy(self.interpreter_launcher_path, self.script_interpreter_path)
 
     def _create_pyodide_script(self) -> None:
         """Write pyodide cli script into the virtualenv bin folder."""

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -33,7 +33,7 @@ def base_test_dir(tmp_path_factory):
 
     manager = CrossBuildEnvManager(xbuildenv_test_name)
     manager.install(
-        url="https://github.com/pyodide/pyodide/releases/download/0.27.3/xbuildenv-0.27.3.tar.bz2"
+        url="https://github.com/pyodide/pyodide/releases/download/0.29.4/xbuildenv-0.29.4.tar.bz2"
     )
 
     os.chdir(cwd)

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -562,6 +562,74 @@ def test_host_python_wrapper_runs_with_spaces_in_paths(tmp_path, monkeypatch):
     ]
 
 
+def _windows_venv_with_spaces(tmp_path):
+    """Build a ``WindowsPyodideVenv`` rooted somewhere like ``C:\\Program Files``"""
+    dest = tmp_path / "Program Files" / "my venv"
+    scripts_dir = dest / "Scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    pyodide_venv = venv.WindowsPyodideVenv(dest)
+    pyodide_venv._venv_root = dest
+    pyodide_venv._venv_bin = scripts_dir
+    return pyodide_venv
+
+
+@pytest.mark.windows
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only batch wrappers")
+def test_windows_host_pip_wrapper_runs_with_spaces_in_paths(tmp_path):
+    """``pip_patched`` must reach the host Python across a path with spaces."""
+    pyodide_venv = _windows_venv_with_spaces(tmp_path)
+
+    # Stand in for the real interpreter. Echo back the arguments.
+    pyodide_venv.host_python_path.write_text("@echo off\r\necho %*\r\n")
+    # In a real venv ``pip.bat`` is a symlink to ``pip_patched``. Here the
+    # ``.bat`` extension is what makes the file executable by cmd.
+    pip = pyodide_venv.venv_bin / "pip.bat"
+    pip.write_text(pyodide_venv.host_pip_wrapper)
+
+    result = subprocess.run(
+        [str(pip), "install", "six"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f'-s "{pyodide_venv.pip_wrapper_path}" install six'
+
+
+@pytest.mark.windows
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only batch wrappers")
+def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypatch):
+    """PATH/PYODIDE_ROOT with spaces must round-trip through ``pyodide.bat``.
+
+    ``set`` needs its quoted form here. Without the quotes cmd takes the rest
+    of the line verbatim, so a trailing space ends up in the value and an
+    ``&`` in a directory name is read as a command separator.
+    """
+    pyodide_root = tmp_path / "Program Files" / "pyodide-build"
+    pyodide_root.mkdir(parents=True)
+    cli = tmp_path / "Program Files (x86)" / "pyodide.bat"
+    cli.parent.mkdir(parents=True)
+    # Stand in for the real CLI. Echo back PYODIDE_ROOT and the arguments.
+    cli.write_text("@echo off\r\necho %PYODIDE_ROOT%\r\necho %*\r\n")
+
+    monkeypatch.setenv("PATH", f"{cli.parent}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("PYODIDE_ROOT", str(pyodide_root))
+    monkeypatch.setattr(shutil, "which", lambda name: str(cli))
+
+    pyodide_venv = _windows_venv_with_spaces(tmp_path)
+    pyodide_venv._create_pyodide_script()
+
+    result = subprocess.run(
+        [str(pyodide_venv.pyodide_cli_path), "build", "."],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [str(pyodide_root), "build ."]
+
+
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):
     """A failed venv creation must not delete a pre-existing destination."""
     dest = tmp_path / "existing-venv"

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -33,7 +33,7 @@ def base_test_dir(tmp_path_factory):
 
     manager = CrossBuildEnvManager(xbuildenv_test_name)
     manager.install(
-        url="https://github.com/pyodide/pyodide/releases/download/0.27.3/xbuildenv-0.27.3.tar.bz2"
+        url="https://github.com/pyodide/pyodide/releases/download/0.29.4/xbuildenv-0.29.4.tar.bz2"
     )
 
     os.chdir(cwd)
@@ -628,6 +628,66 @@ def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypa
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == [str(pyodide_root), "build ."]
+
+
+def test_windows_interpreter_launcher_is_copied(tmp_path, monkeypatch):
+    """``python.exe`` has to be a copy of the shim, not a symlink to it.
+
+    The shim resolves its own path before looking for ``python.bat`` beside it,
+    so a symlink would resolve into the dist directory and run the interpreter
+    outside the virtualenv.
+    """
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "python.exe").write_bytes(b"pyodide launcher shim")
+    monkeypatch.setattr(venv, "pyodide_dist_dir", lambda: dist_dir)
+
+    pyodide_venv = _windows_venv_with_spaces(tmp_path)
+    pyodide_venv._install_interpreter_launcher()
+
+    launcher = pyodide_venv.script_interpreter_path
+    assert launcher.name == "python.exe"
+    assert not launcher.is_symlink()
+    assert launcher.read_bytes() == b"pyodide launcher shim"
+
+
+def test_windows_interpreter_launcher_may_be_absent(tmp_path, monkeypatch):
+    """Cross-build environments older than Pyodide 0.29.3 ship no python.exe."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    monkeypatch.setattr(venv, "pyodide_dist_dir", lambda: dist_dir)
+
+    pyodide_venv = _windows_venv_with_spaces(tmp_path)
+    pyodide_venv._install_interpreter_launcher()
+
+    assert not pyodide_venv.script_interpreter_path.exists()
+
+
+@pytest.mark.parametrize(
+    "make_venv",
+    [_unix_venv_with_spaces, _windows_venv_with_spaces],
+    ids=["unix", "windows"],
+)
+def test_pip_wrapper_executable_is_the_interpreter(tmp_path, make_venv):
+    """The path pip bakes into console scripts must be the venv interpreter.
+
+    ``pip_wrapper.get_executable`` rewrites ``sys.executable`` (the host python
+    symlink) into the interpreter a console script should invoke. The two names
+    differ by more than the symlink suffix on Windows, where the host symlink is
+    ``python-host-link.exe`` and the target is ``python.exe``, so dropping the
+    suffix alone used to leave a path that does not exist.
+    """
+    pyodide_venv = make_venv(tmp_path)
+
+    # What pip_wrapper.get_executable() computes. It cannot import from
+    # pyodide-build, so the calculation is repeated rather than shared.
+    sys_executable = str(pyodide_venv.host_python_symlink_path)
+    executable = (
+        sys_executable.removesuffix(pyodide_venv.host_python_symlink_suffix)
+        + pyodide_venv.script_interpreter_suffix
+    )
+
+    assert executable == str(pyodide_venv.script_interpreter_path)
 
 
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shlex
 import shutil
 import subprocess
 import sys
@@ -458,6 +459,107 @@ def test_pip_script_name_helper(tmp_path, script_name, exe_suffix, expected_name
     """``_pip_script_name`` must preserve versioned pip names like ``pip3.12``."""
     result = _pip_script_name(tmp_path / script_name, exe_suffix)
     assert result.name == expected_name
+
+
+def _unix_venv_with_spaces(tmp_path):
+    """Build a ``UnixPyodideVenv`` whose paths all contain spaces"""
+    dest = tmp_path / "my venv"
+    bin_dir = dest / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    pyodide_venv = venv.UnixPyodideVenv(dest)
+    pyodide_venv._venv_root = dest
+    pyodide_venv._venv_bin = bin_dir
+    return pyodide_venv
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only shell wrappers")
+def test_host_python_wrapper_quotes_paths(tmp_path, monkeypatch):
+    """A host Python under a path with spaces must not be split by the shell.
+
+    Regression test for https://github.com/pyodide/pyodide-build/issues/399:
+    a uv-managed Python on macOS lives under ``Library/Application Support``,
+    and the unquoted ``PYTHONHOME=`` assignment made ``env`` treat everything
+    after the space as a command name.
+    """
+    fake_python = tmp_path / "Application Support" / "uv" / "bin" / "python3"
+    fake_python.parent.mkdir(parents=True)
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+    monkeypatch.setattr(sys, "_base_executable", str(fake_python), raising=False)
+
+    pyodide_venv = _unix_venv_with_spaces(tmp_path)
+    wrapper = pyodide_venv.host_python_wrapper
+
+    tokens = shlex.split(wrapper.splitlines()[-1])
+    assert tokens[0] == "exec"
+    assert tokens[1] == "env"
+    assert tokens[2] == f"PYTHONHOME={tmp_path / 'Application Support' / 'uv'}"
+    assert tokens[3] == str(pyodide_venv.host_python_symlink_path)
+    assert tokens[4] == "$@"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only shell wrappers")
+def test_host_pip_wrapper_quotes_paths(tmp_path):
+    """The pip wrapper must survive a venv path containing spaces."""
+    pyodide_venv = _unix_venv_with_spaces(tmp_path)
+
+    tokens = shlex.split(pyodide_venv.host_pip_wrapper.splitlines()[-1])
+    assert tokens[0] == str(pyodide_venv.host_python_path)
+    assert tokens[1] == "-s"
+    assert tokens[2] == str(pyodide_venv.pip_wrapper_path)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only shell wrappers")
+def test_pyodide_cli_script_quotes_paths(tmp_path, monkeypatch):
+    """PATH/PYODIDE_ROOT entries with spaces must not break the pyodide shim."""
+    pyodide_root = tmp_path / "Application Support" / "pyodide-build"
+    pyodide_root.mkdir(parents=True)
+    cli = tmp_path / "some dir" / "pyodide"
+    cli.parent.mkdir()
+
+    monkeypatch.setenv("PATH", f"{tmp_path / 'some dir'}:/usr/bin")
+    monkeypatch.setenv("PYODIDE_ROOT", str(pyodide_root))
+    monkeypatch.setattr(shutil, "which", lambda name: str(cli))
+
+    pyodide_venv = _unix_venv_with_spaces(tmp_path)
+    pyodide_venv._create_pyodide_script()
+
+    tokens = shlex.split(pyodide_venv.pyodide_cli_path.read_text().splitlines()[-1])
+    assert tokens[0] == f"PATH={tmp_path / 'some dir'}:/usr/bin:$PATH"
+    assert tokens[1] == f"PYODIDE_ROOT={pyodide_root}"
+    assert tokens[2] == "exec"
+    assert tokens[3] == str(cli)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only shell wrappers")
+def test_host_python_wrapper_runs_with_spaces_in_paths(tmp_path, monkeypatch):
+    """Actually execute the wrapper to prove the quoting holds up end to end."""
+    fake_python = tmp_path / "Application Support" / "uv" / "bin" / "python3"
+    fake_python.parent.mkdir(parents=True)
+    monkeypatch.setattr(sys, "executable", str(fake_python), raising=False)
+    monkeypatch.setattr(sys, "_base_executable", str(fake_python), raising=False)
+
+    pyodide_venv = _unix_venv_with_spaces(tmp_path)
+    # Stand in for the real interpreter. Echo back PYTHONHOME and the arguments.
+    pyodide_venv.host_python_symlink_path.write_text(
+        '#!/bin/sh\necho "$PYTHONHOME"\necho "$@"\n'
+    )
+    pyodide_venv.host_python_symlink_path.chmod(0o755)
+
+    pyodide_venv.host_python_path.write_text(pyodide_venv.host_python_wrapper)
+    pyodide_venv.host_python_path.chmod(0o755)
+
+    result = subprocess.run(
+        [str(pyodide_venv.host_python_path), "-c", "pass"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        str(tmp_path / "Application Support" / "uv"),
+        "-c pass",
+    ]
 
 
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -630,6 +630,39 @@ def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypa
     assert result.stdout.splitlines() == [str(pyodide_root), "build ."]
 
 
+def test_windows_interpreter_launcher_is_copied(tmp_path, monkeypatch):
+    """``python.exe`` has to be a copy of the shim, not a symlink to it.
+
+    The shim resolves its own path before looking for ``python.bat`` beside it,
+    so a symlink would resolve into the dist directory and run the interpreter
+    outside the virtualenv.
+    """
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "python.exe").write_bytes(b"pyodide launcher shim")
+    monkeypatch.setattr(venv, "pyodide_dist_dir", lambda: dist_dir)
+
+    pyodide_venv = _windows_venv_with_spaces(tmp_path)
+    pyodide_venv._install_interpreter_launcher()
+
+    launcher = pyodide_venv.script_interpreter_path
+    assert launcher.name == "python.exe"
+    assert not launcher.is_symlink()
+    assert launcher.read_bytes() == b"pyodide launcher shim"
+
+
+def test_windows_interpreter_launcher_may_be_absent(tmp_path, monkeypatch):
+    """Cross-build environments older than Pyodide 0.29.3 ship no python.exe."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    monkeypatch.setattr(venv, "pyodide_dist_dir", lambda: dist_dir)
+
+    pyodide_venv = _windows_venv_with_spaces(tmp_path)
+    pyodide_venv._install_interpreter_launcher()
+
+    assert not pyodide_venv.script_interpreter_path.exists()
+
+
 @pytest.mark.parametrize(
     "make_venv",
     [_unix_venv_with_spaces, _windows_venv_with_spaces],
@@ -639,10 +672,10 @@ def test_pip_wrapper_executable_is_the_interpreter(tmp_path, make_venv):
     """The path pip bakes into console scripts must be the venv interpreter.
 
     ``pip_wrapper.get_executable`` rewrites ``sys.executable`` (the host python
-    symlink) into the Pyodide interpreter next to it. The two names differ by
-    more than the symlink suffix on Windows, where the host symlink ends in
-    ``.exe`` but the interpreter is a ``.bat``, so dropping the suffix alone
-    used to leave a path that does not exist.
+    symlink) into the interpreter a console script should invoke. The two names
+    differ by more than the symlink suffix on Windows, where the host symlink is
+    ``python-host-link.exe`` and the target is ``python.exe``, so dropping the
+    suffix alone used to leave a path that does not exist.
     """
     pyodide_venv = make_venv(tmp_path)
 
@@ -651,10 +684,10 @@ def test_pip_wrapper_executable_is_the_interpreter(tmp_path, make_venv):
     sys_executable = str(pyodide_venv.host_python_symlink_path)
     executable = (
         sys_executable.removesuffix(pyodide_venv.host_python_symlink_suffix)
-        + pyodide_venv.exe_suffix
+        + pyodide_venv.script_interpreter_suffix
     )
 
-    assert executable == str(pyodide_venv.interpreter_symlink_path)
+    assert executable == str(pyodide_venv.script_interpreter_path)
 
 
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -33,7 +33,7 @@ def base_test_dir(tmp_path_factory):
 
     manager = CrossBuildEnvManager(xbuildenv_test_name)
     manager.install(
-        url="https://github.com/pyodide/pyodide/releases/download/0.29.4/xbuildenv-0.29.4.tar.bz2"
+        url="https://github.com/pyodide/pyodide/releases/download/0.27.3/xbuildenv-0.27.3.tar.bz2"
     )
 
     os.chdir(cwd)
@@ -628,66 +628,6 @@ def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypa
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == [str(pyodide_root), "build ."]
-
-
-def test_windows_interpreter_launcher_is_copied(tmp_path, monkeypatch):
-    """``python.exe`` has to be a copy of the shim, not a symlink to it.
-
-    The shim resolves its own path before looking for ``python.bat`` beside it,
-    so a symlink would resolve into the dist directory and run the interpreter
-    outside the virtualenv.
-    """
-    dist_dir = tmp_path / "dist"
-    dist_dir.mkdir()
-    (dist_dir / "python.exe").write_bytes(b"pyodide launcher shim")
-    monkeypatch.setattr(venv, "pyodide_dist_dir", lambda: dist_dir)
-
-    pyodide_venv = _windows_venv_with_spaces(tmp_path)
-    pyodide_venv._install_interpreter_launcher()
-
-    launcher = pyodide_venv.script_interpreter_path
-    assert launcher.name == "python.exe"
-    assert not launcher.is_symlink()
-    assert launcher.read_bytes() == b"pyodide launcher shim"
-
-
-def test_windows_interpreter_launcher_may_be_absent(tmp_path, monkeypatch):
-    """Cross-build environments older than Pyodide 0.29.3 ship no python.exe."""
-    dist_dir = tmp_path / "dist"
-    dist_dir.mkdir()
-    monkeypatch.setattr(venv, "pyodide_dist_dir", lambda: dist_dir)
-
-    pyodide_venv = _windows_venv_with_spaces(tmp_path)
-    pyodide_venv._install_interpreter_launcher()
-
-    assert not pyodide_venv.script_interpreter_path.exists()
-
-
-@pytest.mark.parametrize(
-    "make_venv",
-    [_unix_venv_with_spaces, _windows_venv_with_spaces],
-    ids=["unix", "windows"],
-)
-def test_pip_wrapper_executable_is_the_interpreter(tmp_path, make_venv):
-    """The path pip bakes into console scripts must be the venv interpreter.
-
-    ``pip_wrapper.get_executable`` rewrites ``sys.executable`` (the host python
-    symlink) into the interpreter a console script should invoke. The two names
-    differ by more than the symlink suffix on Windows, where the host symlink is
-    ``python-host-link.exe`` and the target is ``python.exe``, so dropping the
-    suffix alone used to leave a path that does not exist.
-    """
-    pyodide_venv = make_venv(tmp_path)
-
-    # What pip_wrapper.get_executable() computes. It cannot import from
-    # pyodide-build, so the calculation is repeated rather than shared.
-    sys_executable = str(pyodide_venv.host_python_symlink_path)
-    executable = (
-        sys_executable.removesuffix(pyodide_venv.host_python_symlink_suffix)
-        + pyodide_venv.script_interpreter_suffix
-    )
-
-    assert executable == str(pyodide_venv.script_interpreter_path)
 
 
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -630,6 +630,33 @@ def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypa
     assert result.stdout.splitlines() == [str(pyodide_root), "build ."]
 
 
+@pytest.mark.parametrize(
+    "make_venv",
+    [_unix_venv_with_spaces, _windows_venv_with_spaces],
+    ids=["unix", "windows"],
+)
+def test_pip_wrapper_executable_is_the_interpreter(tmp_path, make_venv):
+    """The path pip bakes into console scripts must be the venv interpreter.
+
+    ``pip_wrapper.get_executable`` rewrites ``sys.executable`` (the host python
+    symlink) into the Pyodide interpreter next to it. The two names differ by
+    more than the symlink suffix on Windows, where the host symlink ends in
+    ``.exe`` but the interpreter is a ``.bat``, so dropping the suffix alone
+    used to leave a path that does not exist.
+    """
+    pyodide_venv = make_venv(tmp_path)
+
+    # What pip_wrapper.get_executable() computes. It cannot import from
+    # pyodide-build, so the calculation is repeated rather than shared.
+    sys_executable = str(pyodide_venv.host_python_symlink_path)
+    executable = (
+        sys_executable.removesuffix(pyodide_venv.host_python_symlink_suffix)
+        + pyodide_venv.exe_suffix
+    )
+
+    assert executable == str(pyodide_venv.interpreter_symlink_path)
+
+
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):
     """A failed venv creation must not delete a pre-existing destination."""
     dest = tmp_path / "existing-venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,8 @@ exclude = [
 [tool.pytest.ini_options]
 addopts = "-vra --strict-markers"
 markers = [
-  "integration: mark a test as an integration test"
+  "integration: mark a test as an integration test",
+  "windows: mark a test that is useful only on Windows"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Split off from #409. I have submitted this via `gh stack submit` (i.e., the GitHub Stacked PRs preview that I applied to and we received). A Pyodide venv on Windows has not had our `.exe` interpreter because `_create_python_symlink` deleted every `python*.exe` that `virtualenv` created and put `.bat` symlinks in their place. The launcher that pip generates for a console script refuses to invoke anything that is not an .exe, so no installed script could run.

The idea here is that we already ship a `python.exe` shim that forwards to `python.bat`, so we can now copy that into the venv and point `pip_wrapper.get_executable` at it. It is a copy rather than a symlink because the shim resolves its own path before looking for `python.bat` beside it, so a symlink would send it to the dist directory and lose the venv.

The shim currently mangles any  paths holding a space, for which I created pyodide/pyodide#6381 - it would be good to have that in Pyodide 314.0.4 release but it's not a blocker here because our Windows support is pretty much experimental anyway








---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>