### PR TITLE
Enable xbuildenv source introspection via a marker file

### DIFF
--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -4,13 +4,15 @@ import click
 
 from pyodide_build.build_env import get_build_flag, local_versions
 from pyodide_build.common import IS_WIN, default_xbuildenv_path
-from pyodide_build.views import MetadataView, SourceType
+from pyodide_build.views import MetadataView
 from pyodide_build.xbuildenv import CrossBuildEnvManager
 from pyodide_build.xbuildenv_releases import (
+    DEFAULT_SOURCE,
     NIGHTLY_CROSS_BUILD_ENV_METADATA_URL,
     NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
     STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
     CrossBuildEnvReleaseSpec,
+    SourceType,
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,
 )
@@ -96,16 +98,24 @@ def _install(
     """
     if path is None:
         path = default_xbuildenv_path()
+
+    source: SourceType | None
+    metadata_url: str | None
     if nightly and debug:
+        source = "nightly-debug"
         metadata_url = NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL
     elif nightly:
+        source = "nightly"
         metadata_url = NIGHTLY_CROSS_BUILD_ENV_METADATA_URL
     elif debug:
+        source = "stable-debug"
         metadata_url = STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL
     else:
+        # Both left unset so PYODIDE_CROSS_BUILD_ENV_METADATA_URL can decide
+        source = None
         metadata_url = None
 
-    manager = CrossBuildEnvManager(path, metadata_url=metadata_url)
+    manager = CrossBuildEnvManager(path, metadata_url=metadata_url, source=source)
 
     if url:
         manager.install(url=url, force_install=force_install)
@@ -133,7 +143,13 @@ def _version(path: Path | None) -> None:
         click.echo("No version selected")
         raise SystemExit(1)
     else:
-        click.echo(version)
+        source = manager.current_source
+        # Stable and unlabelled environments print as just the version, for backward
+        # compatibility. Only a source worth reporting is appended, as in "0.29.4 (stable-debug)".
+        if source and source != DEFAULT_SOURCE:
+            click.echo(f"{version} ({source})")
+        else:
+            click.echo(version)
 
 
 @app.command("versions")

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -12,7 +12,7 @@ from pyodide_build.xbuildenv_releases import (
     NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
     STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
     CrossBuildEnvReleaseSpec,
-    SourceType,
+    ReleaseSource,
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,
 )
@@ -99,7 +99,7 @@ def _install(
     if path is None:
         path = default_xbuildenv_path()
 
-    source: SourceType | None
+    source: ReleaseSource | None
     metadata_url: str | None
     if nightly and debug:
         source = "nightly-debug"
@@ -285,7 +285,7 @@ def _search(
 
     def _make_view(
         release: CrossBuildEnvReleaseSpec,
-        source: SourceType = "stable",
+        source: ReleaseSource = "stable",
     ) -> MetadataView:
         return MetadataView(
             version=release.version,
@@ -304,7 +304,7 @@ def _search(
         )
 
     if nightly or debug:
-        sources: list[tuple[SourceType, str]]
+        sources: list[tuple[ReleaseSource, str]]
         if nightly and debug:
             sources = [("nightly-debug", NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL)]
         elif nightly:

--- a/pyodide_build/tests/test_cli_xbuildenv.py
+++ b/pyodide_build/tests/test_cli_xbuildenv.py
@@ -326,7 +326,35 @@ def test_xbuildenv_version(tmp_path):
     )
 
     assert result.exit_code == 0, result.output
-    assert "0.26.0" in result.output, result.output
+    assert result.output.strip() == "0.26.0", result.output
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("stable", "0.26.0"),
+        ("nightly", "0.26.0 (nightly)"),
+        ("stable-debug", "0.26.0 (stable-debug)"),
+    ],
+)
+def test_xbuildenv_version_source(tmp_path, source, expected):
+    envpath = Path(tmp_path) / ".xbuildenv"
+
+    (envpath / "0.26.0").mkdir(exist_ok=True, parents=True)
+    (envpath / "0.26.0" / ".xbuildenv-source").write_text(source)
+    (envpath / "xbuildenv").symlink_to(envpath / "0.26.0")
+
+    result = runner.invoke(
+        xbuildenv.app,
+        [
+            "version",
+            "--path",
+            str(envpath),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == expected, result.output
 
 
 def test_xbuildenv_versions(tmp_path):

--- a/pyodide_build/tests/test_cli_xbuildenv.py
+++ b/pyodide_build/tests/test_cli_xbuildenv.py
@@ -267,6 +267,56 @@ def test_xbuildenv_install_debug(tmp_path, mock_xbuildenv_url, monkeypatch):
     assert (envpath / "0.30.0").exists()
 
 
+def test_xbuildenv_install_debug_over_stable(
+    tmp_path, mock_xbuildenv_url, monkeypatch, fake_xbuildenv_releases_compatible
+):
+    """A cached stable release must not be handed back for its debug variant.
+
+    Both share the version string 0.1.0, so the debug install has to replace the
+    stable one rather than find the directory and skip the download.
+    """
+    from pyodide_build import build_env
+
+    envpath = Path(tmp_path) / ".xbuildenv"
+    local = build_env.local_versions()
+
+    debug_data = {
+        "releases": {
+            "0.1.0": {
+                "version": "0.1.0",
+                "url": mock_xbuildenv_url,
+                "sha256": None,
+                "python_version": f"{local['python']}.0",
+                "emscripten_version": "5.0.3",
+            }
+        }
+    }
+    metadata_path = tmp_path / "stable-debug.json"
+    metadata_path.write_text(json.dumps(debug_data))
+
+    monkeypatch.setattr(
+        "pyodide_build.cli.xbuildenv.STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL",
+        str(metadata_path),
+    )
+    monkeypatch.setenv(
+        CROSS_BUILD_ENV_METADATA_URL_ENV_VAR, str(fake_xbuildenv_releases_compatible)
+    )
+
+    result = runner.invoke(xbuildenv.app, ["install", "0.1.0", "--path", str(envpath)])
+    assert result.exit_code == 0, result.output
+    assert (envpath / "0.1.0" / ".xbuildenv-source").read_text() == "stable"
+
+    canary = envpath / "0.1.0" / "canary.txt"
+    canary.touch()
+
+    result = runner.invoke(
+        xbuildenv.app, ["install", "0.1.0", "--path", str(envpath), "--debug"]
+    )
+    assert result.exit_code == 0, result.output
+    assert not canary.exists()
+    assert (envpath / "0.1.0" / ".xbuildenv-source").read_text() == "stable-debug"
+
+
 def test_xbuildenv_install_nightly_debug(tmp_path, mock_xbuildenv_url, monkeypatch):
     """Installing with --nightly --debug uses the nightly-debug metadata URL."""
     from pyodide_build import build_env

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -661,6 +661,33 @@ class TestCrossBuildEnvManager:
         # Now labelled, so later installs do not have to guess.
         assert manager.installed_source(tmp_path / version) == "stable"
 
+    def test_install_unlabelled_replaced_by_debug(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        # An unlabelled environment cannot be shown to be the debug variant, so
+        # a debug install has to replace it rather than trust it.
+        version = "0.1.0"
+        metadata = str(fake_xbuildenv_releases_compatible)
+
+        manager = CrossBuildEnvManager(tmp_path, metadata)
+        manager.install(version)
+        (tmp_path / version / ".xbuildenv-source").unlink()
+
+        canary = tmp_path / version / "canary.txt"
+        canary.touch()
+
+        debug = CrossBuildEnvManager(tmp_path, metadata, source="stable-debug")
+        debug.install(version)
+
+        assert not canary.exists()
+        # Relabelled, so it no longer reports the source it was replaced from
+        assert debug.installed_source(tmp_path / version) == "stable-debug"
+        assert debug.current_source == "stable-debug"
+
     def test_find_latest_version_empty_releases(self, tmp_path):
         # Regression test: empty releases metadata must produce a clear error,
         # not an IndexError.

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -8,6 +8,12 @@ import pytest
 from pyodide_build import build_env
 from pyodide_build.common import download_and_unpack_archive
 from pyodide_build.xbuildenv import CrossBuildEnvManager, _url_to_version
+from pyodide_build.xbuildenv_releases import (
+    NIGHTLY_CROSS_BUILD_ENV_METADATA_URL,
+    NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
+    STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
+    parse_source_url,
+)
 
 
 @pytest.fixture()
@@ -688,6 +694,159 @@ class TestCrossBuildEnvManager:
         assert debug.installed_source(tmp_path / version) == "stable-debug"
         assert debug.current_source == "stable-debug"
 
+    def test_failed_reinstall_keeps_the_replaced_environment(
+        self,
+        tmp_path,
+        monkeypatch,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        # Replacing an environment must not leave the user with nothing when
+        # the download for its replacement fails.
+        version = "0.1.0"
+        metadata = str(fake_xbuildenv_releases_compatible)
+
+        stable = CrossBuildEnvManager(tmp_path, metadata)
+        stable.install(version)
+
+        canary = tmp_path / version / "canary.txt"
+        canary.touch()
+
+        def fail_download(*args, **kwargs):
+            raise RuntimeError("network is down")
+
+        monkeypatch.setattr(
+            "pyodide_build.xbuildenv.download_and_unpack_archive", fail_download
+        )
+
+        debug = CrossBuildEnvManager(tmp_path, metadata, source="stable-debug")
+        with pytest.raises(RuntimeError, match="network is down"):
+            debug.install(version)
+
+        # The original is back, rather than a half-installed or missing one
+        assert canary.exists()
+        assert stable.installed_source(tmp_path / version) == "stable"
+        assert not (tmp_path / f"{version}.replaced").exists()
+
+    def test_install_url_records_the_url_as_the_source(
+        self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
+    ):
+        # There is no release behind a URL install to name, and calling it
+        # 'stable' would claim a provenance we cannot check, so record the URL.
+        manager = CrossBuildEnvManager(tmp_path)
+
+        manager.install(version=None, url=dummy_xbuildenv_url)
+        version = _url_to_version(dummy_xbuildenv_url)
+
+        assert (
+            tmp_path / version / ".xbuildenv-source"
+        ).read_text() == dummy_xbuildenv_url
+        assert manager.installed_source(tmp_path / version) == dummy_xbuildenv_url
+        assert manager.current_source == dummy_xbuildenv_url
+
+    def test_install_url_twice_keeps_the_environment(
+        self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
+    ):
+        # The directory name comes from the URL, so a cached one came from this
+        # same URL and must not be treated as a source mismatch.
+        manager = CrossBuildEnvManager(tmp_path)
+        manager.install(version=None, url=dummy_xbuildenv_url)
+        version = _url_to_version(dummy_xbuildenv_url)
+
+        canary = tmp_path / version / "canary.txt"
+        canary.touch()
+
+        CrossBuildEnvManager(tmp_path).install(version=None, url=dummy_xbuildenv_url)
+
+        assert canary.exists()
+
+    def test_install_source_mismatch_triggers_reinstall(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        # Regression test: a stable release and its debug variant share a version
+        # string, so a cached stable environment must not satisfy a request for
+        # the debug one.
+        version = "0.1.0"
+        metadata = str(fake_xbuildenv_releases_compatible)
+
+        stable = CrossBuildEnvManager(tmp_path, metadata)
+        stable.install(version)
+
+        canary = tmp_path / version / "canary.txt"
+        canary.touch()
+
+        debug = CrossBuildEnvManager(tmp_path, metadata, source="stable-debug")
+        debug.install(version)
+
+        # The environment was downloaded again rather than reused in place.
+        assert not canary.exists()
+        assert debug.installed_source(tmp_path / version) == "stable-debug"
+        assert debug.current_source == "stable-debug"
+
+    def test_install_source_match_reuses_existing(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        version = "0.1.0"
+        metadata = str(fake_xbuildenv_releases_compatible)
+
+        manager = CrossBuildEnvManager(tmp_path, metadata, source="nightly")
+        manager.install(version)
+
+        canary = tmp_path / version / "canary.txt"
+        canary.touch()
+
+        CrossBuildEnvManager(tmp_path, metadata, source="nightly").install(version)
+
+        assert canary.exists()
+
+    def test_source_derived_from_metadata_url(self, tmp_path):
+        manager = CrossBuildEnvManager(
+            tmp_path, NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL
+        )
+
+        assert manager.source == "nightly-debug"
+
+    def test_source_derived_from_metadata_url_env_var(
+        self, tmp_path, monkeypatch, reset_cache
+    ):
+        monkeypatch.setenv(
+            "PYODIDE_CROSS_BUILD_ENV_METADATA_URL", NIGHTLY_CROSS_BUILD_ENV_METADATA_URL
+        )
+
+        manager = CrossBuildEnvManager(tmp_path)
+
+        assert manager.source == "nightly"
+        assert manager.metadata_url == NIGHTLY_CROSS_BUILD_ENV_METADATA_URL
+
+    def test_source_wins_over_metadata_url_env_var(
+        self, tmp_path, monkeypatch, reset_cache
+    ):
+        # Asking for a source explicitly is already a choice of metadata file,
+        # so the environment variable must not redirect it.
+        monkeypatch.setenv(
+            "PYODIDE_CROSS_BUILD_ENV_METADATA_URL", NIGHTLY_CROSS_BUILD_ENV_METADATA_URL
+        )
+
+        manager = CrossBuildEnvManager(tmp_path, source="stable-debug")
+
+        assert manager.source == "stable-debug"
+        assert manager.metadata_url == STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL
+
+    def test_installed_source_missing_env(self, tmp_path):
+        manager = CrossBuildEnvManager(tmp_path)
+
+        assert manager.installed_source(tmp_path / "0.1.0") is None
+        assert manager.current_source is None
+
     def test_find_latest_version_empty_releases(self, tmp_path):
         # Regression test: empty releases metadata must produce a clear error,
         # not an IndexError.
@@ -719,3 +878,34 @@ class TestCrossBuildEnvManager:
 )
 def test_url_to_version(url: str, version: str) -> None:
     assert _url_to_version(url) == version
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://example.com/xbuildenv-0.25.0.tar.bz2",
+        "http://example.com/a/b.tar.gz",
+        "file:///home/me/xbuildenv.tar.bz2",
+        # urlopen is not limited to http and file, so neither is this
+        "ftp://example.com/xbuildenv.tar.bz2",
+    ],
+)
+def test_parse_source_url_accepts_urls(value: str) -> None:
+    assert parse_source_url(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "stable",
+        "nightly-debug",
+        "",
+        "not a url",
+        # Contains "://" but has no scheme to go with it
+        "://example.com",
+        # A scheme addressing nothing
+        "https://",
+    ],
+)
+def test_parse_source_url_rejects_other_strings(value: str) -> None:
+    assert parse_source_url(value) is None

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -598,6 +598,44 @@ class TestCrossBuildEnvManager:
         # Marker preserved (install did no work).
         assert cross_build_marker.exists()
 
+    def test_install_records_source(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        manager = CrossBuildEnvManager(
+            tmp_path, str(fake_xbuildenv_releases_compatible), source="nightly-debug"
+        )
+        version = "0.1.0"
+
+        manager.install(version)
+
+        assert (tmp_path / version / ".xbuildenv-source").read_text() == "nightly-debug"
+        assert manager.installed_source(tmp_path / version) == "nightly-debug"
+        assert manager.current_source == "nightly-debug"
+
+    def test_install_source_defaults_to_stable(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        manager = CrossBuildEnvManager(
+            tmp_path, str(fake_xbuildenv_releases_compatible)
+        )
+        version = "0.1.0"
+
+        manager.install(version)
+
+        assert manager.current_source == "stable"
+        # An environment installed before the marker existed has no source.
+        (tmp_path / version / ".xbuildenv-source").unlink()
+        assert manager.installed_source(tmp_path / version) is None
+        assert manager.current_source is None
+
     def test_find_latest_version_empty_releases(self, tmp_path):
         # Regression test: empty releases metadata must produce a clear error,
         # not an IndexError.

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -636,6 +636,31 @@ class TestCrossBuildEnvManager:
         assert manager.installed_source(tmp_path / version) is None
         assert manager.current_source is None
 
+    def test_install_unlabelled_reused_by_stable(
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        fake_xbuildenv_releases_compatible,
+    ):
+        # An environment from before the marker is kept by a plain install
+        # rather than re-downloading a working one for everybody.
+        version = "0.1.0"
+        metadata = str(fake_xbuildenv_releases_compatible)
+
+        manager = CrossBuildEnvManager(tmp_path, metadata)
+        manager.install(version)
+        (tmp_path / version / ".xbuildenv-source").unlink()
+
+        canary = tmp_path / version / "canary.txt"
+        canary.touch()
+
+        CrossBuildEnvManager(tmp_path, metadata).install(version)
+
+        assert canary.exists()
+        # Now labelled, so later installs do not have to guess.
+        assert manager.installed_source(tmp_path / version) == "stable"
+
     def test_find_latest_version_empty_releases(self, tmp_path):
         # Regression test: empty releases metadata must produce a clear error,
         # not an IndexError.

--- a/pyodide_build/views.py
+++ b/pyodide_build/views.py
@@ -4,9 +4,10 @@
 
 import json
 from dataclasses import dataclass, field
-from typing import Literal
 
-type SourceType = Literal["stable", "stable-debug", "nightly", "nightly-debug"]
+from pyodide_build.xbuildenv_releases import SourceType
+
+__all__ = ["MetadataView"]
 
 
 @dataclass

--- a/pyodide_build/views.py
+++ b/pyodide_build/views.py
@@ -5,7 +5,7 @@
 import json
 from dataclasses import dataclass, field
 
-from pyodide_build.xbuildenv_releases import SourceType
+from pyodide_build.xbuildenv_releases import ReleaseSource
 
 __all__ = ["MetadataView"]
 
@@ -18,7 +18,7 @@ class MetadataView:
     pyodide_build: dict[str, str | None]
     compatible: bool
     published_at: str = ""
-    source: SourceType = field(default="stable")
+    source: ReleaseSource = field(default="stable")
 
     @classmethod
     def to_table(cls, views: list["MetadataView"], show_source: bool = False) -> str:

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -15,9 +15,12 @@ from pyodide_build.xbuildenv_releases import (
     CROSS_BUILD_ENV_METADATA_URLS,
     DEFAULT_SOURCE,
     CrossBuildEnvReleaseSpec,
+    ReleaseSource,
     SourceType,
+    SourceURL,
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,
+    parse_source_url,
     source_for_metadata_url,
 )
 
@@ -37,7 +40,7 @@ class CrossBuildEnvManager:
         self,
         env_dir: str | Path,
         metadata_url: str | None = None,
-        source: SourceType | None = None,
+        source: ReleaseSource | None = None,
     ) -> None:
         """
         Parameters
@@ -64,7 +67,7 @@ class CrossBuildEnvManager:
         if source is None:
             source = source_for_metadata_url(self.metadata_url)
 
-        self.source: SourceType = source or DEFAULT_SOURCE
+        self.source: ReleaseSource = source or DEFAULT_SOURCE
 
         try:
             self.env_dir.mkdir(parents=True, exist_ok=True)
@@ -100,7 +103,8 @@ class CrossBuildEnvManager:
     @property
     def current_source(self) -> SourceType | None:
         """
-        Return the source that the currently in-use xbuildenv was installed from.
+        Return the source that the currently in-use xbuildenv was installed from,
+        either a release stream or the URL it was installed from.
         """
         if not self.symlink_dir.exists():
             return None
@@ -201,8 +205,10 @@ class CrossBuildEnvManager:
         Returns
         -------
         SourceType | None
-            The recorded source, or None when there is no xbuildenv at
-            ``version_path`` or it was installed before the marker existed.
+            A release stream, or the URL an environment installed with ``--url``
+            came from. None when there is no xbuildenv at ``version_path``, it
+            was installed before the marker existed, or the marker does not hold
+            something recognisable.
         """
         if not version_path.is_dir():
             return None
@@ -212,10 +218,10 @@ class CrossBuildEnvManager:
             return None
 
         source = marker.read_text().strip()
-        if source not in CROSS_BUILD_ENV_METADATA_URLS:
-            return None
+        if source in CROSS_BUILD_ENV_METADATA_URLS:
+            return source
 
-        return source
+        return parse_source_url(source)
 
     def _find_remote_release(self, version: str) -> CrossBuildEnvReleaseSpec:
         """
@@ -388,7 +394,18 @@ class CrossBuildEnvManager:
 
         download_path = self._path_for_version(version)
 
-        replaced_path = self._set_aside_if_source_differs(download_path)
+        # An environment installed from a URL records that URL as its source,
+        # since there is no release behind it to name.
+        recorded_source: SourceType = (
+            SourceURL(download_url) if installed_from_url else self.source
+        )
+
+        if installed_from_url:
+            # The directory name is derived from the URL, so anything cached
+            # there came from this same URL and there is no source to reconcile.
+            replaced_path = None
+        else:
+            replaced_path = self._set_aside_if_source_differs(download_path)
 
         # Track whether THIS call created the directory, so that a failure later
         # in this method does not delete a previously-good cached installation.
@@ -448,7 +465,7 @@ class CrossBuildEnvManager:
             install_marker.touch()
             # Written even when the install was a no-op, so that environments
             # predating the marker get labelled.
-            self._source_marker_path(download_path).write_text(self.source)
+            self._source_marker_path(download_path).write_text(recorded_source)
             self.use_version(version)
             # Only (re)write the Python version marker when we actually performed
             # installation work, so a mismatch on a skipped install is not

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -12,15 +12,20 @@ from pyodide_build.common import download_and_unpack_archive, remove_readonly
 from pyodide_build.create_package_index import create_package_index
 from pyodide_build.logger import logger
 from pyodide_build.xbuildenv_releases import (
+    CROSS_BUILD_ENV_METADATA_URLS,
+    DEFAULT_SOURCE,
     CrossBuildEnvReleaseSpec,
+    SourceType,
     cross_build_env_metadata_url,
     load_cross_build_env_metadata,
+    source_for_metadata_url,
 )
 
 CDN_BASE = "https://cdn.jsdelivr.net/pyodide/v{version}/full/"
 PYTHON_VERSION_MARKER_FILE = ".build-python-version"
 CROSS_BUILD_PACKAGES_MARKER_FILE = ".cross-build-packages-installed"
 EMSCRIPTEN_VERSION_MARKER_FILE = ".emscripten-version"
+SOURCE_MARKER_FILE = ".xbuildenv-source"
 
 
 class CrossBuildEnvManager:
@@ -28,7 +33,12 @@ class CrossBuildEnvManager:
     Manager for the cross-build environment.
     """
 
-    def __init__(self, env_dir: str | Path, metadata_url: str | None = None) -> None:
+    def __init__(
+        self,
+        env_dir: str | Path,
+        metadata_url: str | None = None,
+        source: SourceType | None = None,
+    ) -> None:
         """
         Parameters
         ----------
@@ -36,10 +46,25 @@ class CrossBuildEnvManager:
             The directory to store the cross-build environments.
         metadata_url
             URL to the metadata file that contains the information about the available
-            cross-build environments. If not specified, the default metadata file is used.
+            cross-build environments. If not specified, the metadata file of ``source``
+            is used.
+        source
+            The source to install cross-build environments from. This is one of ``stable``,
+            ``stable-debug``, ``nightly``, or ``nightly-debug``. If not specified, it
+            is derived from ``metadata_url`` wherever possible, and it falls back to
+            ``stable``.
         """
         self.env_dir = Path(env_dir).resolve()
-        self.metadata_url = metadata_url or cross_build_env_metadata_url()
+        self.metadata_url = metadata_url or cross_build_env_metadata_url(
+            source or DEFAULT_SOURCE
+        )
+        # If source is not provided, derive it from the metadata file, so that
+        # pointing PYODIDE_CROSS_BUILD_ENV_METADATA_URL at the nightly metadata
+        # can still record what was installed.
+        if source is None:
+            source = source_for_metadata_url(self.metadata_url)
+
+        self.source: SourceType = source or DEFAULT_SOURCE
 
         try:
             self.env_dir.mkdir(parents=True, exist_ok=True)
@@ -71,6 +96,126 @@ class CrossBuildEnvManager:
             return None
 
         return self.symlink_dir.resolve().name
+
+    @property
+    def current_source(self) -> SourceType | None:
+        """
+        Return the source that the currently in-use xbuildenv was installed from.
+        """
+        if not self.symlink_dir.exists():
+            return None
+
+        return self.installed_source(self.symlink_dir.resolve())
+
+    def _source_marker_path(self, version_path: Path) -> Path:
+        """
+        Return the path to the ``.xbuildenv-source marker`` file used to record the
+        source of the xbuildenv.
+
+        Parameters
+        ----------
+        version_path
+            Path to a xbuildenv version directory (for example, `.../<version>`).
+        """
+        return version_path / SOURCE_MARKER_FILE
+
+    def _set_aside_if_source_differs(self, download_path: Path) -> Path | None:
+        """
+        Move a cached cross-build environment aside when it came from another
+        source.
+
+        A cached cross-build environment from a different source shares the version
+        string. However, it is not the one that was asked for by the user, so it has
+        to be replaced with the requested environment.
+
+        For example, if the user has a cached `314.0.3` environment that was installed
+        with `--nightly`, and they now request `314.0.3` with `--stable`, the cached
+        environment is moved aside and the requested one is downloaded.
+
+        Parameters
+        ----------
+        download_path
+            Path to the xbuildenv version directory that is about to be used.
+
+        Returns
+        -------
+        Path | None
+            Where the environment was moved to, or None if it was kept. It is
+            moved rather than deleted so that a download failing part way
+            through leaves the working environment behind instead of nothing.
+        """
+        if not download_path.is_dir():
+            return None
+
+        installed_source = self.installed_source(download_path)
+        if installed_source == self.source:
+            return None
+
+        if installed_source is None:
+            # If no marker file is present, this means that the xbuildenv creation
+            # predates source tracking in pyodide-build. The --nightly and
+            # --debug environments have existed since pyodide-build 0.35.0, so it
+            # could have come from any source. Throwing every one of them away would
+            # re-download a working environment for everyone, to catch the few that
+            # were not plain installs, so we assume the common case and let a
+            # --nightly/--debug request replace it. Recording the source afterwards
+            # means this only comes up once.
+            replace = self.source != DEFAULT_SOURCE
+            reason = "predates tracking of xbuildenv source"
+        else:
+            replace = True
+            reason = f"was installed from the '{installed_source}' source"
+
+        if not replace:
+            logger.info(
+                "The cross-build environment at '%s' %s, so it is being "
+                "recorded as '%s'. If it was installed with --nightly or "
+                "--debug, reinstall it with that flag.",
+                download_path,
+                reason,
+                self.source,
+            )
+            return None
+
+        logger.warning(
+            "Reinstalling the cross-build environment at '%s': it %s, "
+            "but the '%s' source was requested.",
+            download_path,
+            reason,
+            self.source,
+        )
+        replaced_path = download_path.with_name(download_path.name + ".replaced")
+        shutil.rmtree(replaced_path, ignore_errors=True)
+        download_path.rename(replaced_path)
+        return replaced_path
+
+    def installed_source(self, version_path: Path) -> SourceType | None:
+        """
+        Return the source recorded for the xbuildenv at ``version_path``.
+
+        Parameters
+        ----------
+        version_path
+            Path to an xbuildenv version directory (or the active symlink).
+
+        Returns
+        -------
+        SourceType | None
+            The recorded source, or None when there is no xbuildenv at
+            ``version_path`` or it was installed before the marker existed.
+        """
+        if not version_path.is_dir():
+            return None
+
+        marker = self._source_marker_path(version_path)
+        if not marker.exists():
+            return None
+
+        source = marker.read_text().strip()
+        if source not in CROSS_BUILD_ENV_METADATA_URLS:
+            return None
+
+        return source
 
     def _find_remote_release(self, version: str) -> CrossBuildEnvReleaseSpec:
         """
@@ -243,21 +388,23 @@ class CrossBuildEnvManager:
 
         download_path = self._path_for_version(version)
 
+        replaced_path = self._set_aside_if_source_differs(download_path)
+
         # Track whether THIS call created the directory, so that a failure later
         # in this method does not delete a previously-good cached installation.
         download_path_preexisted = download_path.exists()
 
-        if download_path_preexisted:
-            logger.info(
-                "The cross-build environment already exists at '%s', skipping download",
-                download_path,
-            )
-        else:
-            download_and_unpack_archive(
-                download_url, download_path, "Pyodide cross-build environment"
-            )
-
         try:
+            if download_path_preexisted:
+                logger.info(
+                    "The cross-build environment already exists at '%s', skipping download",
+                    download_path,
+                )
+            else:
+                download_and_unpack_archive(
+                    download_url, download_path, "Pyodide cross-build environment"
+                )
+
             # there is an redundant directory "xbuildenv" inside the xbuildenv archive
             # TODO: remove the redundant directory from the archive
             xbuildenv_root = download_path / "xbuildenv"
@@ -299,6 +446,9 @@ class CrossBuildEnvManager:
                     self._create_package_index(xbuildenv_pyodide_root, version)
 
             install_marker.touch()
+            # Written even when the install was a no-op, so that environments
+            # predating the marker get labelled.
+            self._source_marker_path(download_path).write_text(self.source)
             self.use_version(version)
             # Only (re)write the Python version marker when we actually performed
             # installation work, so a mismatch on a skipped install is not
@@ -310,7 +460,14 @@ class CrossBuildEnvManager:
             # failed, remove it. Do not delete a pre-existing cached install.
             if not download_path_preexisted:
                 shutil.rmtree(download_path, ignore_errors=True)
+            # Put back the environment that was replaced, so a failure here
+            # leaves the one that was working rather than nothing.
+            if replaced_path is not None:
+                replaced_path.rename(download_path)
             raise
+
+        if replaced_path is not None:
+            shutil.rmtree(replaced_path, onexc=remove_readonly)
 
         return xbuildenv_pyodide_root
 

--- a/pyodide_build/xbuildenv_releases.py
+++ b/pyodide_build/xbuildenv_releases.py
@@ -3,7 +3,8 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import cache
-from typing import Any, Literal
+from typing import Any, Literal, NewType
+from urllib.parse import urlparse
 
 import cattrs
 from attrs import asdict, define, field
@@ -23,17 +24,55 @@ STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL = (
 )
 CROSS_BUILD_ENV_METADATA_URL_ENV_VAR = "PYODIDE_CROSS_BUILD_ENV_METADATA_URL"
 
-# Indicate where a cross-build environment was published from
-type SourceType = Literal["stable", "stable-debug", "nightly", "nightly-debug"]
+# The published streams a cross-build environment can be installed from. These
+# are the ones with release metadata behind them, so only these can be asked for
+# by name, with --nightly and --debug.
+type ReleaseSource = Literal["stable", "stable-debug", "nightly", "nightly-debug"]
 
-DEFAULT_SOURCE: SourceType = "stable"
+# An environment installed with --url has no release behind it to name, so the
+# URL it came from is its source. A distinct type rather than a bare str, so
+# that a URL cannot be passed where a release stream is expected.
+SourceURL = NewType("SourceURL", str)
 
-CROSS_BUILD_ENV_METADATA_URLS: dict[SourceType, str] = {
+# Where a cross-build environment came from, once installed
+type SourceType = ReleaseSource | SourceURL
+
+DEFAULT_SOURCE: ReleaseSource = "stable"
+
+CROSS_BUILD_ENV_METADATA_URLS: dict[ReleaseSource, str] = {
     "stable": DEFAULT_CROSS_BUILD_ENV_METADATA_URL,
     "stable-debug": STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
     "nightly": NIGHTLY_CROSS_BUILD_ENV_METADATA_URL,
     "nightly-debug": NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
 }
+
+
+def parse_source_url(value: str) -> SourceURL | None:
+    """
+    Return ``value`` as a `SourceURL`, or None when it is not one.
+
+    Parameters
+    ----------
+    value
+        The string to interpret as a URL an xbuildenv was downloaded from.
+
+    Returns
+    -------
+    SourceURL | None
+        The URL, or None if it does not parse as one. Any scheme is accepted:
+        the archive is fetched with `urlopen`, which handles ftp and whatever
+        else the openers in use support.
+    """
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return None
+
+    # A URL needs a scheme, and something for that scheme to address
+    if not parsed.scheme or not (parsed.netloc or parsed.path):
+        return None
+
+    return SourceURL(value)
 
 
 @define
@@ -245,7 +284,7 @@ def _suppress_urllib3_logging():
         logger.setLevel(original_level)
 
 
-def cross_build_env_metadata_url(source: SourceType = DEFAULT_SOURCE) -> str:
+def cross_build_env_metadata_url(source: ReleaseSource = DEFAULT_SOURCE) -> str:
     """
     Get the URL to the Pyodide cross-build environment metadata
 
@@ -279,13 +318,13 @@ def cross_build_env_metadata_url(source: SourceType = DEFAULT_SOURCE) -> str:
     return url
 
 
-def source_for_metadata_url(url: str) -> SourceType | None:
+def source_for_metadata_url(url: str) -> ReleaseSource | None:
     """
     Get the source that publishes its metadata at the given URL.
 
     Returns
     -------
-    SourceType | None
+    ReleaseSource | None
         The matching source, or None if the URL is not one of the known
         metadata files (a custom metadata file, for instance).
     """

--- a/pyodide_build/xbuildenv_releases.py
+++ b/pyodide_build/xbuildenv_releases.py
@@ -3,7 +3,7 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import cache
-from typing import Any
+from typing import Any, Literal
 
 import cattrs
 from attrs import asdict, define, field
@@ -22,6 +22,18 @@ STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL = (
     "https://pyodide.github.io/pyodide/api/v2/debug.json"
 )
 CROSS_BUILD_ENV_METADATA_URL_ENV_VAR = "PYODIDE_CROSS_BUILD_ENV_METADATA_URL"
+
+# Indicate where a cross-build environment was published from
+type SourceType = Literal["stable", "stable-debug", "nightly", "nightly-debug"]
+
+DEFAULT_SOURCE: SourceType = "stable"
+
+CROSS_BUILD_ENV_METADATA_URLS: dict[SourceType, str] = {
+    "stable": DEFAULT_CROSS_BUILD_ENV_METADATA_URL,
+    "stable-debug": STABLE_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
+    "nightly": NIGHTLY_CROSS_BUILD_ENV_METADATA_URL,
+    "nightly-debug": NIGHTLY_DEBUG_CROSS_BUILD_ENV_METADATA_URL,
+}
 
 
 @define
@@ -233,15 +245,26 @@ def _suppress_urllib3_logging():
         logger.setLevel(original_level)
 
 
-def cross_build_env_metadata_url() -> str:
+def cross_build_env_metadata_url(source: SourceType = DEFAULT_SOURCE) -> str:
     """
     Get the URL to the Pyodide cross-build environment metadata
+
+    Parameters
+    ----------
+    source
+        The source to get the metadata for. Only the stable source honours the
+        environment variable override below, since naming any other source is
+        already a choice of metadata file.
 
     Returns
     -------
     str
         The URL to the Pyodide cross-build environment metadata
     """
+
+    # If it's not a stable environment, we know which metadata file to use, so don't check the environment variable
+    if source != DEFAULT_SOURCE:
+        return CROSS_BUILD_ENV_METADATA_URLS[source]
 
     # The default URL can be overridden by the PYODIDE_CROSS_BUILD_ENV_METADATA_URL environment variable
     # This has two purposes:
@@ -254,6 +277,23 @@ def cross_build_env_metadata_url() -> str:
     )
 
     return url
+
+
+def source_for_metadata_url(url: str) -> SourceType | None:
+    """
+    Get the source that publishes its metadata at the given URL.
+
+    Returns
+    -------
+    SourceType | None
+        The matching source, or None if the URL is not one of the known
+        metadata files (a custom metadata file, for instance).
+    """
+    for source, source_url in CROSS_BUILD_ENV_METADATA_URLS.items():
+        if url == source_url:
+            return source
+
+    return None
 
 
 @cache


### PR DESCRIPTION
I don't particularly like the ergonomics of this PR... hence, this is ready for review, but not ready to merge just yet and I am scouting opinions.

The idea is to have a file called `.xbuildenv-source`, which will record where the xbuildenv came from – whether it's a release xbuildenv, a stable-debug xbuildenv, a nightly one, or a nightly-debug one. We can think of these as "channels". Of course, we also support custom URLs for the source of the xbuildenv, in which case we record the URL itself into the marker file.

LMK what you think about this!