### PR TITLE
Add _cross-build-env-skip-install

### DIFF
--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -675,7 +675,10 @@ class RecipeBuilderPackage(RecipeBuilder):
                 Path(self.build_args.host_install_dir)
                 / f"lib/{python_dir}/site-packages"
             )
-            if self.build_metadata.cross_build_env:
+            if (
+                self.build_metadata.cross_build_env
+                and not self.build_metadata.cross_build_env_skip_install
+            ):
                 subprocess.run(
                     [
                         "pip",
@@ -710,11 +713,11 @@ class RecipeBuilderPackage(RecipeBuilder):
                     check=True,
                 )
 
-            for cross_build_file in self.build_metadata.cross_build_files:
-                shutil.copy(
-                    (wheel_dir / cross_build_file),
-                    host_site_packages / cross_build_file,
-                )
+                for cross_build_file in self.build_metadata.cross_build_files:
+                    shutil.copy(
+                        (wheel_dir / cross_build_file),
+                        host_site_packages / cross_build_file,
+                    )
 
 
 class RecipeBuilderStaticLibrary(RecipeBuilder):

--- a/pyodide_build/recipe/spec.py
+++ b/pyodide_build/recipe/spec.py
@@ -119,6 +119,9 @@ class _BuildSpec:
     )
     vendor_sharedlib: bool = _afield(True, alias="vendor-sharedlib")
     cross_build_env: bool = _afield(False, alias="cross-build-env")
+    cross_build_env_skip_install: bool = _afield(
+        False, alias="_cross-build-env-skip-install"
+    )
     cross_build_files: list[str] = _afield(factory=list, alias="cross-build-files")
 
     @classmethod
@@ -257,6 +260,7 @@ class MetaConfig:
             allowed_keys = {
                 "post",
                 "cross_build_env",
+                "cross_build_env_skip_install",
                 "cross_build_files",
                 "exports",
                 "unvendor_tests",


### PR DESCRIPTION
This adds a private field to the build spec which makes it not install the cross-build package into .artifacts. This can only be used for "leaf" xbuild packages for which we don't build any recipes that are dependents (e.g., scipy but not numpy). It is useful for pre-release Python versions when there is no native wheel available and we can't or don't want to build a native wheel.

Ideally, we would only install xbuild packages when they are used as a host dep of a recipe and that would have all the benefits of this automatically. I intend to do this in a followup and remove this key but that is a substantially larger diff.