### PR TITLE
pywasmcross: Disable openmp

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -223,7 +223,7 @@ def replay_genargs_handle_linker_opts(arg: str) -> str | None:
         return None
 
 
-def replay_genargs_handle_argument(arg: str) -> str | None:
+def replay_genargs_handle_argument(arg: str) -> str | int | None:
     """
     Figure out how to replace a general argument.
 
@@ -271,6 +271,12 @@ def replay_genargs_handle_argument(arg: str) -> str | None:
 
     if arg.startswith("-J"):  # fortran flag that clang does not support
         return None
+
+    # Emscripten 6.0.3 added OpenMP support but Pyodide doesn't support threads.
+    # Exit with nonzero status code so that we treat OpenMP as unavailable.
+    # Leave -fopenmp-simd alone since simd is okay.
+    if arg.startswith("-fopenmp=") or arg == "-fopenmp":
+        return 1
 
     return arg
 
@@ -485,7 +491,7 @@ def get_export_flags(
 
 def handle_command_generate_args(  # noqa: C901
     line: list[str], build_args: CrossCompileArgs
-) -> list[str]:
+) -> list[str] | int:
     """
     A helper command for `handle_command` that generates the new arguments for
     the compilation.
@@ -583,6 +589,7 @@ def handle_command_generate_args(  # noqa: C901
             del new_args[-1]
             continue
 
+        result: str | int | None
         if arg.startswith("-l"):
             result = replay_genargs_handle_dashl(arg, used_libs, build_args.abi)
         elif arg.startswith("-I"):
@@ -591,6 +598,9 @@ def handle_command_generate_args(  # noqa: C901
             result = replay_genargs_handle_linker_opts(arg)
         else:
             result = replay_genargs_handle_argument(arg)
+
+        if isinstance(result, int):
+            return result
 
         if result:
             new_args.append(result)
@@ -649,6 +659,8 @@ def handle_command(
         line = tmp
 
     new_args = handle_command_generate_args(line, build_args)
+    if isinstance(new_args, int):
+        return new_args
 
     if build_args.pkgname == "scipy":
         from _f2c_fixes import scipy_fixes

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, NamedTuple
 
@@ -77,6 +78,12 @@ class CrossCompileArgs(NamedTuple):
     # Pyodide abi, e.g., 2025_0
     # Sometimes we have to inject compile flags only for certain abis.
     abi: str = ""
+
+
+@dataclass
+class ExitCodeWithReason:
+    exitcode: int
+    reason: str
 
 
 def is_link_cmd(line: list[str]) -> bool:
@@ -223,7 +230,7 @@ def replay_genargs_handle_linker_opts(arg: str) -> str | None:
         return None
 
 
-def replay_genargs_handle_argument(arg: str) -> str | int | None:
+def replay_genargs_handle_argument(arg: str) -> str | ExitCodeWithReason | None:
     """
     Figure out how to replace a general argument.
 
@@ -276,7 +283,7 @@ def replay_genargs_handle_argument(arg: str) -> str | int | None:
     # Exit with nonzero status code so that we treat OpenMP as unavailable.
     # Leave -fopenmp-simd alone since simd is okay.
     if arg.startswith("-fopenmp=") or arg == "-fopenmp":
-        return 1
+        return ExitCodeWithReason(1, "openmp requires threads and is not supported")
 
     return arg
 
@@ -491,7 +498,7 @@ def get_export_flags(
 
 def handle_command_generate_args(  # noqa: C901
     line: list[str], build_args: CrossCompileArgs
-) -> list[str] | int:
+) -> list[str] | ExitCodeWithReason:
     """
     A helper command for `handle_command` that generates the new arguments for
     the compilation.
@@ -589,7 +596,7 @@ def handle_command_generate_args(  # noqa: C901
             del new_args[-1]
             continue
 
-        result: str | int | None
+        result: str | ExitCodeWithReason | None
         if arg.startswith("-l"):
             result = replay_genargs_handle_dashl(arg, used_libs, build_args.abi)
         elif arg.startswith("-I"):
@@ -599,7 +606,7 @@ def handle_command_generate_args(  # noqa: C901
         else:
             result = replay_genargs_handle_argument(arg)
 
-        if isinstance(result, int):
+        if isinstance(result, ExitCodeWithReason):
             return result
 
         if result:
@@ -635,7 +642,7 @@ def handle_command_generate_args(  # noqa: C901
 def handle_command(
     line: list[str],
     build_args: CrossCompileArgs,
-) -> int:
+) -> int | ExitCodeWithReason:
     """Handle a compilation command. Exit with an appropriate exit code when done.
 
     Parameters
@@ -659,7 +666,7 @@ def handle_command(
         line = tmp
 
     new_args = handle_command_generate_args(line, build_args)
-    if isinstance(new_args, int):
+    if isinstance(new_args, ExitCodeWithReason):
         return new_args
 
     if build_args.pkgname == "scipy":
@@ -685,7 +692,13 @@ def compiler_main():
     basename = Path(sys.argv[0]).name
     args = list(sys.argv)
     args[0] = basename
-    sys.exit(handle_command(args, build_args))
+    result = handle_command(args, build_args)
+    if isinstance(result, ExitCodeWithReason):
+        print(result.reason, file=sys.stderr)
+        exitcode = result.exitcode
+    else:
+        exitcode = result
+    sys.exit(exitcode)
 
 
 if IS_COMPILER_INVOCATION:

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -287,3 +287,22 @@ def test_is_link_cmd():
     assert is_link_cmd(["test.so"])
     assert is_link_cmd(["test.so.1.2.3"])
     assert not is_link_cmd(["test", "test.a", "test.o", "test.c", "test.cpp", "test.h"])
+
+
+@pytest.mark.parametrize(
+    "flag", ["-fopenmp", "-fopenmp=libomp", "-fopenmp=libgomp", "-pthread"]
+)
+def test_openmp_and_thread_flags_are_dropped(build_args, flag):
+    """Pyodide doesn't support threads.
+
+    Dropping -fopenmp additionally makes autoconf/meson detect OpenMP as
+    unavailable, since they probe for the _OPENMP macro that it defines.
+    """
+    res = generate_args(f"cc -c {flag} test.c", build_args)
+    assert res == 1
+
+
+def test_fopenmp_simd_is_kept(build_args):
+    """-fopenmp-simd does not define _OPENMP and does not imply threads."""
+    res = generate_args("cc -c -fopenmp-simd test.c", build_args)
+    assert "-fopenmp-simd" in res

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -28,6 +28,8 @@ def build_args():
 def generate_args(line: str, args: CrossCompileArgs, is_link_cmd: bool = False) -> str:
     splitline = line.split()
     res = handle_command_generate_args(splitline, args)
+    if isinstance(res, int):
+        return res
 
     if res[0] in ("emcc", "em++"):
         for arg in [
@@ -289,14 +291,11 @@ def test_is_link_cmd():
     assert not is_link_cmd(["test", "test.a", "test.o", "test.c", "test.cpp", "test.h"])
 
 
-@pytest.mark.parametrize(
-    "flag", ["-fopenmp", "-fopenmp=libomp", "-fopenmp=libgomp", "-pthread"]
-)
-def test_openmp_and_thread_flags_are_dropped(build_args, flag):
-    """Pyodide doesn't support threads.
+@pytest.mark.parametrize("flag", ["-fopenmp", "-fopenmp=libomp", "-fopenmp=libgomp"])
+def test_openmp_flags_are_dropped(build_args, flag):
+    """Pyodide doesn't support threads and openmp requires them.
 
-    Dropping -fopenmp additionally makes autoconf/meson detect OpenMP as
-    unavailable, since they probe for the _OPENMP macro that it defines.
+    We error out if they are requested.
     """
     res = generate_args(f"cc -c {flag} test.c", build_args)
     assert res == 1

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyodide_build.pywasmcross import (
     CrossCompileArgs,
+    ExitCodeWithReason,
     calculate_exports,
     filter_objects,
     get_cmake_compiler_flags,
@@ -28,7 +29,7 @@ def build_args():
 def generate_args(line: str, args: CrossCompileArgs, is_link_cmd: bool = False) -> str:
     splitline = line.split()
     res = handle_command_generate_args(splitline, args)
-    if isinstance(res, int):
+    if isinstance(res, ExitCodeWithReason):
         return res
 
     if res[0] in ("emcc", "em++"):
@@ -298,7 +299,7 @@ def test_openmp_flags_are_dropped(build_args, flag):
     We error out if they are requested.
     """
     res = generate_args(f"cc -c {flag} test.c", build_args)
-    assert res == 1
+    assert res == ExitCodeWithReason(1, "openmp requires threads and is not supported")
 
 
 def test_fopenmp_simd_is_kept(build_args):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ lint.ignore = [
   "C408",    # Unnecessary `dict()` call
   "PERF401", # Replace for loops that build lists with list comprehension
   "PLW2901", # Redefined loop variable
+  "PLR0911", # Too many returns in function
   "PLR0912", # Too many branches in function
   "PLC0415"  # Import inside function or class
 ]


### PR DESCRIPTION
Emscripten 6.0.3 added support for openmp, and build systems started feature detecting it and using it. However, it requires pthreads and fails to link or to load. This updates pywasmcross to make it so that openmp is feature detected as not present.