### PR TITLE
Only install cross-build packages that are build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pyodide xbuildenv install` no longer installs cross-build packages at all.
   Instead `pyodide build` and `pyodide build-recipes` install only the
   cross-build packages that the package being built actually needs.
+  [#421](https://github.com/pyodide/pyodide-build/pull/421)
 
 - `pyodide build-recipes` now installs the cross-build packages listed in a
   recipe's `requirements/host` before the build script runs.
+  [#421](https://github.com/pyodide/pyodide-build/pull/421)
 
 ### Removed
 
 - Removed the deprecated no-op `--skip-cross-build-packages` flag and the
   `PYODIDE_SKIP_CROSS_BUILD_PACKAGES` environment variable from `pyodide
-  xbuildenv install`, along with the
-  `CrossBuildEnvManager.install(skip_install_cross_build_packages=...)`
-  parameter.
+  xbuildenv install`.
+  [#421](https://github.com/pyodide/pyodide-build/pull/421)
 
 ## [0.38.0] - 2026/08/01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `pyodide xbuildenv install` no longer installs cross-build packages at all.
+  Instead `pyodide build` and `pyodide build-recipes` install only the
+  cross-build packages that the package being built actually needs.
+
+- `pyodide build-recipes` now installs the cross-build packages listed in a
+  recipe's `requirements/host` before the build script runs.
+
+### Removed
+
+- Removed the deprecated no-op `--skip-cross-build-packages` flag and the
+  `PYODIDE_SKIP_CROSS_BUILD_PACKAGES` environment variable from `pyodide
+  xbuildenv install`, along with the
+  `CrossBuildEnvManager.install(skip_install_cross_build_packages=...)`
+  parameter.
+
 ## [0.38.0] - 2026/08/01
 
 ### Added

--- a/pyodide_build/build_env.py
+++ b/pyodide_build/build_env.py
@@ -225,6 +225,35 @@ def get_hostsitepackages() -> str:
     return get_build_flag("HOSTSITEPACKAGES")
 
 
+def read_pinned_requirements(requirements_file: Path) -> dict[str, str]:
+    """
+    Read the xbuildenv's `requirements.txt`, which lists the cross-build
+    packages as pinned `name==version` entries.
+
+    Returns
+    -------
+    A dictionary of package names and versions.
+    """
+    if not requirements_file.exists():
+        raise FileNotFoundError(
+            f"Expected {requirements_file} to exist in the xbuildenv. "
+            "The xbuildenv archive may be corrupt or from an incompatible version."
+        )
+
+    requirements: dict[str, str] = {}
+    for line in requirements_file.read_text().splitlines():
+        line = line.strip()
+        # The xbuildenv requirements.txt is machine-generated and always
+        # uses pinned name==version entries, but we skip blank lines,
+        # comments, and any non-pinned specs just in case. Shouldn't
+        # really happen though.
+        if not line or line.startswith("#") or "==" not in line:
+            continue
+        name, version = line.split("==", 1)
+        requirements[name] = version
+    return requirements
+
+
 # TODO: Remove this function (and use remote package index)
 # https://github.com/pyodide/pyodide-build/issues/43
 @functools.cache
@@ -245,23 +274,9 @@ def get_unisolated_packages() -> dict[str, str]:
 
     unisolated_packages: dict[str, str] = {}
     if in_xbuildenv():
-        unisolated_packages_file = PYODIDE_ROOT / ".." / "requirements.txt"
-
-        if not unisolated_packages_file.exists():
-            raise FileNotFoundError(
-                f"Expected {unisolated_packages_file} to exist in the xbuildenv. "
-                "The xbuildenv archive may be corrupt or from an incompatible version."
-            )
-        for line in unisolated_packages_file.read_text().splitlines():
-            line = line.strip()
-            # The xbuildenv requirements.txt is machine-generated and always
-            # uses pinned name==version entries, but we skip blank lines,
-            # comments, and any non-pinned specs just in case. Shouldn't
-            # really happen though.
-            if not line or line.startswith("#") or "==" not in line:
-                continue
-            name, version = line.split("==", 1)
-            unisolated_packages[name] = version
+        unisolated_packages = read_pinned_requirements(
+            PYODIDE_ROOT / ".." / "requirements.txt"
+        )
     else:
         from pyodide_build.recipe.loader import load_all_recipes
 

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -65,15 +65,6 @@ def check_xbuildenv_root(path: Path) -> None:
     default=False,
     help="install the debug variant of the cross-build environment. Combine with --nightly to install the nightly debug variant.",
 )
-@click.option(
-    "--skip-cross-build-packages",
-    is_flag=True,
-    default=False,
-    envvar="PYODIDE_SKIP_CROSS_BUILD_PACKAGES",
-    show_envvar=True,
-    help="Deprecated, no-op. Cross-build packages are installed lazily "
-    "when required by build dependencies.",
-)
 def _install(
     version: str | None,
     path: Path | None,
@@ -81,7 +72,6 @@ def _install(
     force_install: bool,
     nightly: bool,
     debug: bool,
-    skip_cross_build_packages: bool,
 ) -> None:
     """Install cross-build environment.
 

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -6,7 +6,7 @@ import sys
 import sysconfig
 import traceback
 import warnings
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal
@@ -141,7 +141,7 @@ def _copy_sysconfigdata_to_isolated_env(env: DefaultIsolatedEnv) -> None:
 
 def _replace_unisolated_packages(
     reqs: set[str], unisolated_packages: dict[str, str]
-) -> tuple[set[str], set[str]]:
+) -> tuple[set[str], dict[str, str]]:
     """
     Replace unisolated packages with the correct version.
 
@@ -154,7 +154,8 @@ def _replace_unisolated_packages(
 
     Returns
     -------
-    A tuple of (the filtered set of requirements, the set of unisolated requirements)
+    A tuple of (the filtered set of requirements, the unisolated requirements
+    that were found in ``reqs`` as a [name: version] dictionary)
     """
     canonical_unisolated = {
         canonicalize_name(name): (name, version)
@@ -162,7 +163,7 @@ def _replace_unisolated_packages(
     }
 
     new_reqs = reqs.copy()
-    unisolated: set[str] = set()
+    unisolated: dict[str, str] = {}
     for reqstr in reqs:
         req = Requirement(reqstr)
         # Evaluate the PEP 508 marker to see if the requirement
@@ -189,11 +190,11 @@ def _replace_unisolated_packages(
             )
         new_reqs.discard(reqstr)
         new_reqs.add(f"{name}=={version}")
-        unisolated.add(name)
+        unisolated[name] = version
     return new_reqs, unisolated
 
 
-def _install_cross_build_files(venv_path: str, unisolated: set[str]) -> None:
+def _install_cross_build_files(venv_path: str, unisolated: Collection[str]) -> None:
     """
     Install the cross build files (headers, .a libs, .pxd files) to the
     isolated environment's site packages.
@@ -204,7 +205,7 @@ def _install_cross_build_files(venv_path: str, unisolated: set[str]) -> None:
         The path to the isolated environment.
 
     unisolated
-        The set of unisolated packages.
+        The names of the unisolated packages.
     """
     if not unisolated:
         return
@@ -260,7 +261,7 @@ def install_reqs(
 
     if in_xbuildenv() and unisolated:
         get_current_xbuildenv_manager().ensure_cross_build_packages_installed(
-            unisolated
+            unisolated.items()
         )
 
     # propagate PIP config from build_env to current environment

--- a/pyodide_build/pypabuild.py
+++ b/pyodide_build/pypabuild.py
@@ -259,7 +259,9 @@ def install_reqs(
     reqs = remove_avoided_requirements(reqs, IGNORED_BUILD_REQUIREMENTS)
 
     if in_xbuildenv() and unisolated:
-        get_current_xbuildenv_manager().ensure_cross_build_packages_installed()
+        get_current_xbuildenv_manager().ensure_cross_build_packages_installed(
+            unisolated
+        )
 
     # propagate PIP config from build_env to current environment
     with common.replace_env(

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -26,9 +26,12 @@ from pyodide_build.build_env import (
     _create_constraints_file,
     get_build_environment_vars,
     get_build_flag,
+    get_current_xbuildenv_manager,
     get_pyodide_root,
     get_pyversion_major,
     get_pyversion_minor,
+    get_unisolated_packages,
+    in_xbuildenv,
     pyodide_tags,
     replace_so_abi_tags,
     wheel_platform,
@@ -310,11 +313,36 @@ class RecipeBuilder:
             self._prepare_source()
             self._patch()
 
+        self._ensure_cross_build_packages_for_host_requirements()
+
         with (
             chdir(self.pkg_root),
             get_bash_runner(self._get_helper_vars() | os.environ.copy()) as bash_runner,
         ):
             self._build_package(bash_runner)
+
+    def _ensure_cross_build_packages_for_host_requirements(self) -> None:
+        """
+        Install the cross-build packages this recipe lists in
+        `requirements/host` into the host site-packages before the build starts.
+
+        The PEP 517 build requirements are handled later by
+        `pypabuild.install_reqs`, but some recipes reach into the host
+        site-packages directly from their build script, which runs first. See
+        https://github.com/pyodide/pyodide-build/issues/365 for reference.
+        """
+        if not in_xbuildenv():
+            return
+
+        unisolated_packages = {name.lower() for name in get_unisolated_packages()}
+        needed = unisolated_packages & {
+            req.lower() for req in self.recipe.requirements.host
+        }
+
+        if needed:
+            get_current_xbuildenv_manager().ensure_cross_build_packages_installed(
+                needed
+            )
 
     def _check_executables(self) -> None:
         """

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -334,17 +334,19 @@ class RecipeBuilder:
         if not in_xbuildenv():
             return
 
-        unisolated_packages = {
-            canonicalize_name(name) for name in get_unisolated_packages()
-        }
-        needed = unisolated_packages & {
+        host_requirements = {
             canonicalize_name(req) for req in self.recipe.requirements.host
         }
+        needed = [
+            (name, version)
+            for name, version in get_unisolated_packages().items()
+            if canonicalize_name(name) in host_requirements
+        ]
 
-        if needed:
-            get_current_xbuildenv_manager().ensure_cross_build_packages_installed(
-                needed
-            )
+        if not needed:
+            return
+
+        get_current_xbuildenv_manager().ensure_cross_build_packages_installed(needed)
 
     def _check_executables(self) -> None:
         """

--- a/pyodide_build/recipe/builder.py
+++ b/pyodide_build/recipe/builder.py
@@ -17,7 +17,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, cast
 
 import requests
-from packaging.utils import parse_wheel_filename
+from packaging.utils import canonicalize_name, parse_wheel_filename
 
 from pyodide_build import common, pypabuild
 from pyodide_build.build_env import (
@@ -334,9 +334,11 @@ class RecipeBuilder:
         if not in_xbuildenv():
             return
 
-        unisolated_packages = {name.lower() for name in get_unisolated_packages()}
+        unisolated_packages = {
+            canonicalize_name(name) for name in get_unisolated_packages()
+        }
         needed = unisolated_packages & {
-            req.lower() for req in self.recipe.requirements.host
+            canonicalize_name(req) for req in self.recipe.requirements.host
         }
 
         if needed:

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -149,6 +149,42 @@ def test_check_executables(tmp_path, monkeypatch):
         builder._check_executables()
 
 
+def test_ensure_cross_build_packages_for_host_requirements(tmp_path, monkeypatch):
+    builder = RecipeBuilder.get_builder(
+        recipe=RECIPE_DIR / "pkg_1",
+        build_args=BuildArgs(),
+        build_dir=tmp_path,
+    )
+    assert builder.recipe.requirements.host == ["pkg_1_1", "pkg_3", "libtest_shared"]
+
+    calls = []
+
+    class DummyManager:
+        def ensure_cross_build_packages_installed(self, packages):
+            calls.append(set(packages))
+
+    monkeypatch.setattr(_builder, "in_xbuildenv", lambda: True)
+    monkeypatch.setattr(_builder, "get_current_xbuildenv_manager", DummyManager)
+
+    # Only the host requirements that are cross-build packages get installed.
+    monkeypatch.setattr(
+        _builder, "get_unisolated_packages", lambda: {"pkg_3": "1.0", "numpy": "2.0"}
+    )
+    builder._ensure_cross_build_packages_for_host_requirements()
+    assert calls == [{"pkg_3"}]
+
+    # None of the host requirements are cross-build packages, so nothing happens.
+    monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: {"numpy": "2.0"})
+    builder._ensure_cross_build_packages_for_host_requirements()
+    assert calls == [{"pkg_3"}]
+
+    # Outside of an xbuildenv, the install is never triggered.
+    monkeypatch.setattr(_builder, "in_xbuildenv", lambda: False)
+    monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: {"pkg_3": "1.0"})
+    builder._ensure_cross_build_packages_for_host_requirements()
+    assert calls == [{"pkg_3"}]
+
+
 def test_get_helper_vars(tmp_path):
     builder = RecipeBuilder.get_builder(
         recipe=RECIPE_DIR / "pkg_1",

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -161,7 +161,7 @@ def test_ensure_cross_build_packages_for_host_requirements(tmp_path, monkeypatch
 
     class DummyManager:
         def ensure_cross_build_packages_installed(self, packages):
-            calls.append(set(packages))
+            calls.append(dict(packages))
 
     monkeypatch.setattr(_builder, "in_xbuildenv", lambda: True)
     monkeypatch.setattr(_builder, "get_current_xbuildenv_manager", DummyManager)
@@ -171,18 +171,18 @@ def test_ensure_cross_build_packages_for_host_requirements(tmp_path, monkeypatch
         _builder, "get_unisolated_packages", lambda: {"pkg_3": "1.0", "numpy": "2.0"}
     )
     builder._ensure_cross_build_packages_for_host_requirements()
-    assert calls == [{"pkg-3"}]
+    assert calls == [{"pkg_3": "1.0"}]
 
     # None of the host requirements are cross-build packages, so nothing happens.
     monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: {"numpy": "2.0"})
     builder._ensure_cross_build_packages_for_host_requirements()
-    assert calls == [{"pkg-3"}]
+    assert calls == [{"pkg_3": "1.0"}]
 
     # Outside of an xbuildenv, the install is never triggered.
     monkeypatch.setattr(_builder, "in_xbuildenv", lambda: False)
     monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: {"pkg_3": "1.0"})
     builder._ensure_cross_build_packages_for_host_requirements()
-    assert calls == [{"pkg-3"}]
+    assert calls == [{"pkg_3": "1.0"}]
 
 
 def test_get_helper_vars(tmp_path):

--- a/pyodide_build/tests/recipe/test_builder.py
+++ b/pyodide_build/tests/recipe/test_builder.py
@@ -171,18 +171,18 @@ def test_ensure_cross_build_packages_for_host_requirements(tmp_path, monkeypatch
         _builder, "get_unisolated_packages", lambda: {"pkg_3": "1.0", "numpy": "2.0"}
     )
     builder._ensure_cross_build_packages_for_host_requirements()
-    assert calls == [{"pkg_3"}]
+    assert calls == [{"pkg-3"}]
 
     # None of the host requirements are cross-build packages, so nothing happens.
     monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: {"numpy": "2.0"})
     builder._ensure_cross_build_packages_for_host_requirements()
-    assert calls == [{"pkg_3"}]
+    assert calls == [{"pkg-3"}]
 
     # Outside of an xbuildenv, the install is never triggered.
     monkeypatch.setattr(_builder, "in_xbuildenv", lambda: False)
     monkeypatch.setattr(_builder, "get_unisolated_packages", lambda: {"pkg_3": "1.0"})
     builder._ensure_cross_build_packages_for_host_requirements()
-    assert calls == [{"pkg_3"}]
+    assert calls == [{"pkg-3"}]
 
 
 def test_get_helper_vars(tmp_path):

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -43,7 +43,7 @@ def test_replace_unisolated_packages():
         requires, unisolated
     )
     assert new_requires == {"foo==2.0", "bar==0.5", "baz==1.0", "qux"}
-    assert replaced == {"foo", "bar", "baz"}
+    assert replaced == {"foo": "2.0", "bar": "0.5", "baz": "1.0"}
 
 
 def test_replace_unisolated_packages_normalizes_names():
@@ -57,7 +57,7 @@ def test_replace_unisolated_packages_normalizes_names():
         requires, unisolated
     )
     assert new_requires == {"numpy==2.0.3", "ruamel.yaml==0.18.6"}
-    assert replaced == {"numpy", "ruamel.yaml"}
+    assert replaced == {"numpy": "2.0.3", "ruamel.yaml": "0.18.6"}
 
 
 def test_replace_unisolated_packages_version_mismatch():
@@ -71,7 +71,7 @@ def test_replace_unisolated_packages_version_mismatch():
             requires, unisolated
         )
     assert new_requires == {"baz==1.1"}
-    assert replaced == {"baz"}
+    assert replaced == {"baz": "1.1"}
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,7 @@ def test_replace_unisolated_packages_oldest_supported_numpy_marker_not_applicabl
 
     new_requires, replaced = pypabuild._replace_unisolated_packages(requires, {})
     assert new_requires == requires
-    assert replaced == set()
+    assert replaced == {}
 
 
 def test_install_reqs(tmp_path, dummy_xbuildenv, monkeypatch):
@@ -182,7 +182,7 @@ def test_install_reqs_triggers_lazy_install(tmp_path, monkeypatch):
     class DummyManager:
         def ensure_cross_build_packages_installed(self, packages):
             called["count"] += 1
-            called["packages"] = set(packages)
+            called["packages"] = dict(packages)
 
     monkeypatch.setattr(pypabuild, "in_xbuildenv", lambda: True)
     monkeypatch.setattr(pypabuild, "get_current_xbuildenv_manager", DummyManager)
@@ -199,7 +199,7 @@ def test_install_reqs_triggers_lazy_install(tmp_path, monkeypatch):
     assert called["count"] == 1
     # Only the cross-build packages that are actually build dependencies get
     # installed; scipy is not requested so it is left alone.
-    assert called["packages"] == {"numpy"}
+    assert called["packages"] == {"numpy": "1.0"}
 
 
 def test_install_reqs_skips_lazy_install_when_not_unisolated(tmp_path, monkeypatch):

--- a/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide_build/tests/test_pypabuild.py
@@ -177,28 +177,36 @@ def test_get_build_env(tmp_path, dummy_xbuildenv):
 
 
 def test_install_reqs_triggers_lazy_install(tmp_path, monkeypatch):
-    called = {"count": 0}
+    called = {"count": 0, "packages": None}
 
     class DummyManager:
-        def ensure_cross_build_packages_installed(self):
+        def ensure_cross_build_packages_installed(self, packages):
             called["count"] += 1
+            called["packages"] = set(packages)
 
     monkeypatch.setattr(pypabuild, "in_xbuildenv", lambda: True)
     monkeypatch.setattr(pypabuild, "get_current_xbuildenv_manager", DummyManager)
-    monkeypatch.setattr(pypabuild, "get_unisolated_packages", lambda: {"numpy": "1.0"})
+    monkeypatch.setattr(
+        pypabuild,
+        "get_unisolated_packages",
+        lambda: {"numpy": "1.0", "scipy": "2.0"},
+    )
     monkeypatch.setattr(pypabuild, "_install_cross_build_files", lambda *a, **kw: None)
 
     env = MockIsolatedEnv(tmp_path)
     pypabuild.install_reqs({}, env, {"numpy>=1.0"})
 
     assert called["count"] == 1
+    # Only the cross-build packages that are actually build dependencies get
+    # installed; scipy is not requested so it is left alone.
+    assert called["packages"] == {"numpy"}
 
 
 def test_install_reqs_skips_lazy_install_when_not_unisolated(tmp_path, monkeypatch):
     called = {"count": 0}
 
     class DummyManager:
-        def ensure_cross_build_packages_installed(self):
+        def ensure_cross_build_packages_installed(self, packages):
             called["count"] += 1
 
     monkeypatch.setattr(pypabuild, "in_xbuildenv", lambda: True)

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -8,7 +8,11 @@ import pytest
 
 from pyodide_build import build_env
 from pyodide_build.common import download_and_unpack_archive
-from pyodide_build.xbuildenv import CrossBuildEnvManager, _url_to_version
+from pyodide_build.xbuildenv import (
+    CrossBuildEnvManager,
+    _same_version,
+    _url_to_version,
+)
 
 
 def _pinned(manager, name):
@@ -350,14 +354,19 @@ class TestCrossBuildEnvManager:
             if use_uv
             else [sys.executable, "-m", "pip", "install", "--no-user"]
         )
-        assert len(pip_calls) == 1
-        assert pip_calls[0] == [
-            *install_prefix,
+        install_suffix = [
             "--constraint",
             str(xbuildenv_root / "requirements.txt"),
             "--target",
             str(hostsitepackages),
             f"numpy=={numpy_version}",
+        ]
+        # The requested packages are upgraded without their dependencies, then a
+        # second pass installs the dependencies without replacing anything that
+        # is already there.
+        assert pip_calls == [
+            [*install_prefix, "--upgrade", "--no-deps", *install_suffix],
+            [*install_prefix, *install_suffix],
         ]
 
         assert hostsitepackages.exists()
@@ -464,20 +473,21 @@ class TestCrossBuildEnvManager:
         manager.install(version=None, url=dummy_xbuildenv_url)
         assert pip_calls == []
 
-        # First ensure installs once
+        # First ensure installs once (two pip invocations, see
+        # _install_cross_build_packages)
         manager.ensure_cross_build_packages_installed(["numpy"])
-        assert len(pip_calls) == 1
+        assert len(pip_calls) == 2
         assert pip_calls[0][-1] == _pinned(manager, "numpy")
 
         # Second ensure is a no-op: numpy's dist-info is already there
         manager.ensure_cross_build_packages_installed(["numpy"])
-        assert len(pip_calls) == 1
+        assert len(pip_calls) == 2
 
         # ...but a package we have not installed yet still gets installed, and
         # only that package.
         manager.ensure_cross_build_packages_installed(["numpy", "scipy"])
-        assert len(pip_calls) == 2
-        assert pip_calls[1][-1] == _pinned(manager, "scipy")
+        assert len(pip_calls) == 4
+        assert pip_calls[2][-1] == _pinned(manager, "scipy")
 
     def test_ensure_cross_build_packages_installed_ignores_unknown(
         self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
@@ -501,11 +511,11 @@ class TestCrossBuildEnvManager:
         manager.install(version=None, url=dummy_xbuildenv_url)
 
         manager.ensure_cross_build_packages_installed(["NumPy"])
-        assert len(pip_calls) == 1
+        assert len(pip_calls) == 2
         assert pip_calls[0][-1] == _pinned(manager, "numpy")
 
         manager.ensure_cross_build_packages_installed(["NUMPY"])
-        assert len(pip_calls) == 1
+        assert len(pip_calls) == 2
 
     def test_use_version_dangling_symlink(self, tmp_path):
         # Regression test: a dangling xbuildenv symlink (target removed) must be
@@ -703,3 +713,23 @@ class TestCrossBuildEnvManager:
 )
 def test_url_to_version(url: str, version: str) -> None:
     assert _url_to_version(url) == version
+
+
+@pytest.mark.parametrize(
+    "installed, pinned, expected",
+    [
+        ("1.2.3", "1.2.3", True),
+        ("1.2.3", "1.2.4", False),
+        (None, "1.2.3", False),
+        # pip and uv normalize the version in the .dist-info directory name,
+        # the pin in requirements.txt is not necessarily normalized.
+        ("2024.2.2", "2024.02.02", True),
+        ("1.0", "1.0.0", True),
+        ("1.0rc1", "1.0-rc1", True),
+        # Unparsable versions fall back to a string comparison.
+        ("not+a+version", "not+a+version", True),
+        ("not+a+version", "1.0", False),
+    ],
+)
+def test_same_version(installed: str | None, pinned: str, expected: bool) -> None:
+    assert _same_version(installed, pinned) == expected

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -15,12 +15,18 @@ from pyodide_build.xbuildenv import (
 )
 
 
-def _pinned(manager, name):
-    """The `name==version` pin the xbuildenv ships for a cross-build package."""
+def _pins(manager, *names):
+    """The `(name, version)` pins the xbuildenv ships for cross-build packages."""
     requirements = build_env.read_pinned_requirements(
         manager.symlink_dir.resolve() / "xbuildenv" / "requirements.txt"
     )
-    return f"{name}=={requirements[name]}"
+    return [(name, requirements[name]) for name in names]
+
+
+def _pinned(manager, name):
+    """The `name==version` pin the xbuildenv ships for a cross-build package."""
+    [(name, version)] = _pins(manager, name)
+    return f"{name}=={version}"
 
 
 @pytest.fixture()
@@ -475,33 +481,19 @@ class TestCrossBuildEnvManager:
 
         # First ensure installs once (two pip invocations, see
         # _install_cross_build_packages)
-        manager.ensure_cross_build_packages_installed(["numpy"])
+        manager.ensure_cross_build_packages_installed(_pins(manager, "numpy"))
         assert len(pip_calls) == 2
         assert pip_calls[0][-1] == _pinned(manager, "numpy")
 
         # Second ensure is a no-op: numpy's dist-info is already there
-        manager.ensure_cross_build_packages_installed(["numpy"])
+        manager.ensure_cross_build_packages_installed(_pins(manager, "numpy"))
         assert len(pip_calls) == 2
 
         # ...but a package we have not installed yet still gets installed, and
         # only that package.
-        manager.ensure_cross_build_packages_installed(["numpy", "scipy"])
+        manager.ensure_cross_build_packages_installed(_pins(manager, "numpy", "scipy"))
         assert len(pip_calls) == 4
         assert pip_calls[2][-1] == _pinned(manager, "scipy")
-
-    def test_ensure_cross_build_packages_installed_ignores_unknown(
-        self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
-    ):
-        pip_calls = monkeypatch_subprocess_run_pip
-        manager = CrossBuildEnvManager(tmp_path)
-        manager.install(version=None, url=dummy_xbuildenv_url)
-
-        # Not cross-build packages of this xbuildenv, so nothing to install.
-        manager.ensure_cross_build_packages_installed(["setuptools", "wheel"])
-        assert pip_calls == []
-
-        manager.ensure_cross_build_packages_installed([])
-        assert pip_calls == []
 
     def test_ensure_cross_build_packages_installed_normalizes_names(
         self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
@@ -510,11 +502,15 @@ class TestCrossBuildEnvManager:
         manager = CrossBuildEnvManager(tmp_path)
         manager.install(version=None, url=dummy_xbuildenv_url)
 
-        manager.ensure_cross_build_packages_installed(["NumPy"])
-        assert len(pip_calls) == 2
-        assert pip_calls[0][-1] == _pinned(manager, "numpy")
+        [(_, version)] = _pins(manager, "numpy")
 
-        manager.ensure_cross_build_packages_installed(["NUMPY"])
+        manager.ensure_cross_build_packages_installed([("NumPy", version)])
+        assert len(pip_calls) == 2
+        assert pip_calls[0][-1] == f"NumPy=={version}"
+
+        # The already-installed check normalizes names, so this is a no-op even
+        # though the dist-info directory was written as `NumPy-<version>`.
+        manager.ensure_cross_build_packages_installed([("NUMPY", version)])
         assert len(pip_calls) == 2
 
     def test_use_version_dangling_symlink(self, tmp_path):
@@ -631,7 +627,7 @@ class TestCrossBuildEnvManager:
         download_path = tmp_path / version
 
         # Cross-build packages installed under the old Python version.
-        manager.ensure_cross_build_packages_installed(["numpy"])
+        manager.ensure_cross_build_packages_installed(_pins(manager, "numpy"))
         hostsitepackages = manager._host_site_packages_dir()
         numpy_dist_info = hostsitepackages / (
             _pinned(manager, "numpy").replace("==", "-") + ".dist-info"
@@ -670,7 +666,7 @@ class TestCrossBuildEnvManager:
         manager = CrossBuildEnvManager(tmp_path)
 
         manager.install(version=None, url=dummy_xbuildenv_url)
-        manager.ensure_cross_build_packages_installed(["numpy"])
+        manager.ensure_cross_build_packages_installed(_pins(manager, "numpy"))
         hostsitepackages = manager._host_site_packages_dir()
         numpy_dist_info = hostsitepackages / (
             _pinned(manager, "numpy").replace("==", "-") + ".dist-info"

--- a/pyodide_build/tests/test_xbuildenv.py
+++ b/pyodide_build/tests/test_xbuildenv.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 from collections import namedtuple
+from pathlib import Path
 
 import pytest
 
@@ -10,22 +11,57 @@ from pyodide_build.common import download_and_unpack_archive
 from pyodide_build.xbuildenv import CrossBuildEnvManager, _url_to_version
 
 
+def _pinned(manager, name):
+    """The `name==version` pin the xbuildenv ships for a cross-build package."""
+    requirements = build_env.read_pinned_requirements(
+        manager.symlink_dir.resolve() / "xbuildenv" / "requirements.txt"
+    )
+    return f"{name}=={requirements[name]}"
+
+
 @pytest.fixture()
 def monkeypatch_subprocess_run_pip(monkeypatch):
+    """
+    Intercept `pip install` / `uv pip install` invocations, recording each
+    call's argv and faking the resulting installation (a top-level package
+    directory plus a .dist-info directory per pinned requirement) inside the
+    --target directory.
+    """
     import subprocess
 
-    called_with = []
+    calls: list[list[str]] = []
     orig_run = subprocess.run
 
+    def is_pip_install(cmds):
+        cmds = [str(cmd) for cmd in cmds]
+        if cmds[0:3] == [sys.executable, "-m", "pip"]:
+            return True
+        if cmds[0] == "pip":
+            return True
+        # uv: `<path-to-uv> pip install ...`
+        return Path(cmds[0]).name.split(".")[0] == "uv" and cmds[1:2] == ["pip"]
+
+    def fake_install(cmds):
+        if "--target" not in cmds:
+            return
+        target = Path(cmds[cmds.index("--target") + 1])
+        for arg in cmds:
+            if arg.startswith("-") or "==" not in arg:
+                continue
+            name, _, version = arg.partition("==")
+            (target / name).mkdir(parents=True, exist_ok=True)
+            (target / f"{name}-{version}.dist-info").mkdir(parents=True, exist_ok=True)
+
     def monkeypatch_func(cmds, *args, **kwargs):
-        if cmds[0] == "pip" or cmds[0:3] == [sys.executable, "-m", "pip"]:
-            called_with.extend(cmds)
+        if is_pip_install(cmds):
+            calls.append(list(cmds))
+            fake_install(cmds)
             return subprocess.CompletedProcess(cmds, 0, "", "")
         else:
             return orig_run(cmds, *args, **kwargs)
 
     monkeypatch.setattr(subprocess, "run", monkeypatch_func)
-    yield called_with
+    yield calls
 
 
 class TestCrossBuildEnvManager:
@@ -278,10 +314,21 @@ class TestCrossBuildEnvManager:
         assert (tmp_path / version / ".installed").exists()
         assert manager.current_version == version
 
+    @pytest.mark.parametrize("use_uv", [False, True])
     def test_install_cross_build_packages(
-        self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
+        self,
+        tmp_path,
+        dummy_xbuildenv_url,
+        monkeypatch_subprocess_run_pip,
+        monkeypatch,
+        use_uv,
     ):
-        pip_called_with = monkeypatch_subprocess_run_pip
+        from pyodide_build import uv_helper
+
+        monkeypatch.setattr(uv_helper, "should_use_uv", lambda: use_uv)
+        monkeypatch.setattr(uv_helper, "find_uv_bin", lambda: "/fake/bin/uv")
+
+        pip_calls = monkeypatch_subprocess_run_pip
         manager = CrossBuildEnvManager(tmp_path)
 
         download_path = tmp_path / "test"
@@ -289,29 +336,36 @@ class TestCrossBuildEnvManager:
 
         xbuildenv_root = download_path / "xbuildenv"
         xbuildenv_pyodide_root = xbuildenv_root / "pyodide-root"
-        manager._install_cross_build_packages(xbuildenv_root, xbuildenv_pyodide_root)
+        hostsitepackages = manager._host_site_packages_dir(xbuildenv_pyodide_root)
+        numpy_version = build_env.read_pinned_requirements(
+            xbuildenv_root / "requirements.txt"
+        )["numpy"]
 
-        assert len(pip_called_with) == 9
-        assert pip_called_with[0:8] == [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--no-user",
-            "-r",
+        manager._install_cross_build_packages(
+            xbuildenv_root, xbuildenv_pyodide_root, {"numpy": numpy_version}
+        )
+
+        install_prefix = (
+            ["/fake/bin/uv", "pip", "install"]
+            if use_uv
+            else [sys.executable, "-m", "pip", "install", "--no-user"]
+        )
+        assert len(pip_calls) == 1
+        assert pip_calls[0] == [
+            *install_prefix,
+            "--constraint",
             str(xbuildenv_root / "requirements.txt"),
             "--target",
+            str(hostsitepackages),
+            f"numpy=={numpy_version}",
         ]
-        assert pip_called_with[8].startswith(
-            str(xbuildenv_pyodide_root)
-        )  # hostsitepackages
 
-        hostsitepackages = manager._host_site_packages_dir(xbuildenv_pyodide_root)
         assert hostsitepackages.exists()
 
-        cross_build_files = xbuildenv_root / "site-packages-extras"
-        for file in cross_build_files.iterdir():
-            assert (hostsitepackages / file.name).exists()
+        # The extras of the installed package are overlaid...
+        assert (hostsitepackages / "numpy" / "_core" / "lib" / "libnpymath.a").exists()
+        # ...but the extras of packages we did not install are not.
+        assert not (hostsitepackages / "scipy").exists()
 
     def test_create_package_index(self, tmp_path, dummy_xbuildenv_url):
         manager = CrossBuildEnvManager(tmp_path)
@@ -403,27 +457,55 @@ class TestCrossBuildEnvManager:
     def test_ensure_cross_build_packages_installed_idempotent(
         self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
     ):
-        pip_called_with = monkeypatch_subprocess_run_pip
+        pip_calls = monkeypatch_subprocess_run_pip
         manager = CrossBuildEnvManager(tmp_path)
 
-        # Lazy install path: no cross-build packages installed yet
-        manager.install(
-            version=None,
-            url=dummy_xbuildenv_url,
-            skip_install_cross_build_packages=True,
-        )
-        assert pip_called_with == []
+        # Installing the xbuildenv never installs cross-build packages
+        manager.install(version=None, url=dummy_xbuildenv_url)
+        assert pip_calls == []
 
         # First ensure installs once
-        manager.ensure_cross_build_packages_installed()
-        assert len(pip_called_with) == 9
+        manager.ensure_cross_build_packages_installed(["numpy"])
+        assert len(pip_calls) == 1
+        assert pip_calls[0][-1] == _pinned(manager, "numpy")
 
-        # Second ensure is a no-op
-        manager.ensure_cross_build_packages_installed()
-        assert len(pip_called_with) == 9
+        # Second ensure is a no-op: numpy's dist-info is already there
+        manager.ensure_cross_build_packages_installed(["numpy"])
+        assert len(pip_calls) == 1
 
-        marker = manager.symlink_dir.resolve() / ".cross-build-packages-installed"
-        assert marker.exists()
+        # ...but a package we have not installed yet still gets installed, and
+        # only that package.
+        manager.ensure_cross_build_packages_installed(["numpy", "scipy"])
+        assert len(pip_calls) == 2
+        assert pip_calls[1][-1] == _pinned(manager, "scipy")
+
+    def test_ensure_cross_build_packages_installed_ignores_unknown(
+        self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
+    ):
+        pip_calls = monkeypatch_subprocess_run_pip
+        manager = CrossBuildEnvManager(tmp_path)
+        manager.install(version=None, url=dummy_xbuildenv_url)
+
+        # Not cross-build packages of this xbuildenv, so nothing to install.
+        manager.ensure_cross_build_packages_installed(["setuptools", "wheel"])
+        assert pip_calls == []
+
+        manager.ensure_cross_build_packages_installed([])
+        assert pip_calls == []
+
+    def test_ensure_cross_build_packages_installed_normalizes_names(
+        self, tmp_path, dummy_xbuildenv_url, monkeypatch_subprocess_run_pip
+    ):
+        pip_calls = monkeypatch_subprocess_run_pip
+        manager = CrossBuildEnvManager(tmp_path)
+        manager.install(version=None, url=dummy_xbuildenv_url)
+
+        manager.ensure_cross_build_packages_installed(["NumPy"])
+        assert len(pip_calls) == 1
+        assert pip_calls[0][-1] == _pinned(manager, "numpy")
+
+        manager.ensure_cross_build_packages_installed(["NUMPY"])
+        assert len(pip_calls) == 1
 
     def test_use_version_dangling_symlink(self, tmp_path):
         # Regression test: a dangling xbuildenv symlink (target removed) must be
@@ -534,30 +616,27 @@ class TestCrossBuildEnvManager:
         # than skipping work and leaving the stale marker / silently passing.
         manager = CrossBuildEnvManager(tmp_path)
 
-        manager.install(
-            version=None,
-            url=dummy_xbuildenv_url,
-            skip_install_cross_build_packages=True,
-        )
+        manager.install(version=None, url=dummy_xbuildenv_url)
         version = _url_to_version(dummy_xbuildenv_url)
         download_path = tmp_path / version
 
-        # Simulate the env having been installed under a different Python and
-        # mark cross-build packages as already installed.
+        # Cross-build packages installed under the old Python version.
+        manager.ensure_cross_build_packages_installed(["numpy"])
+        hostsitepackages = manager._host_site_packages_dir()
+        numpy_dist_info = hostsitepackages / (
+            _pinned(manager, "numpy").replace("==", "-") + ".dist-info"
+        )
+        assert numpy_dist_info.exists()
+
+        # Simulate the env having been installed under a different Python.
         marker_file = download_path / ".build-python-version"
         marker_file.write_text("2.7.10")
-        cross_build_marker = download_path / ".cross-build-packages-installed"
-        cross_build_marker.touch()
 
         matches, _ = manager.version_marker_matches()
         assert not matches
 
         # Reinstall should rewrite the marker to the current Python version.
-        manager.install(
-            version=None,
-            url=dummy_xbuildenv_url,
-            skip_install_cross_build_packages=True,
-        )
+        manager.install(version=None, url=dummy_xbuildenv_url)
 
         matches, err = manager.version_marker_matches()
         assert matches, err
@@ -565,8 +644,9 @@ class TestCrossBuildEnvManager:
             marker_file.read_text()
             == f"{sys.version_info.major}.{sys.version_info.minor}"
         )
-        # Host-package marker dropped so packages get reinstalled lazily.
-        assert not cross_build_marker.exists()
+        # Host packages from the old Python version dropped, so they get
+        # reinstalled by the next build that needs them.
+        assert not numpy_dist_info.exists()
 
     def test_install_version_marker_match_no_marker_rewrite(
         self,
@@ -576,27 +656,21 @@ class TestCrossBuildEnvManager:
         monkeypatch_subprocess_run_pip,
     ):
         # When the marker already matches, a repeat install() should be a no-op
-        # and must not re-run installation work or drop the cross-build marker.
+        # and must not discard already-installed cross-build packages.
         manager = CrossBuildEnvManager(tmp_path)
 
-        manager.install(
-            version=None,
-            url=dummy_xbuildenv_url,
-            skip_install_cross_build_packages=True,
+        manager.install(version=None, url=dummy_xbuildenv_url)
+        manager.ensure_cross_build_packages_installed(["numpy"])
+        hostsitepackages = manager._host_site_packages_dir()
+        numpy_dist_info = hostsitepackages / (
+            _pinned(manager, "numpy").replace("==", "-") + ".dist-info"
         )
-        version = _url_to_version(dummy_xbuildenv_url)
-        download_path = tmp_path / version
-        cross_build_marker = download_path / ".cross-build-packages-installed"
-        cross_build_marker.touch()
+        assert numpy_dist_info.exists()
 
-        manager.install(
-            version=None,
-            url=dummy_xbuildenv_url,
-            skip_install_cross_build_packages=True,
-        )
+        manager.install(version=None, url=dummy_xbuildenv_url)
 
-        # Marker preserved (install did no work).
-        assert cross_build_marker.exists()
+        # Host packages preserved (install did no work).
+        assert numpy_dist_info.exists()
 
     def test_find_latest_version_empty_releases(self, tmp_path):
         # Regression test: empty releases metadata must produce a clear error,

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 from packaging.utils import canonicalize_name
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from pyodide_lock import PyodideLockSpec
 
 from pyodide_build import build_env, uv_helper
@@ -133,7 +133,7 @@ class CrossBuildEnvManager:
                 # Not a cross-build package of this xbuildenv, nothing to do.
                 continue
             name, version = match
-            if installed.get(canonical) == version:
+            if _same_version(installed.get(canonical), version):
                 continue
             to_install[name] = version
 
@@ -431,28 +431,38 @@ class CrossBuildEnvManager:
             ]
         )
 
-        result = subprocess.run(
-            [
-                *install_prefix,
-                # Constrain to the xbuildenv pins so that a cross-build package
-                # pulled in as a transitive dependency (scipy depends on numpy,
-                # for instance) still lands at the version the xbuildenv ships
-                # cross-build files for.
-                "--constraint",
-                str(requirements_file),
-                "--target",
-                str(host_site_packages),
-                *(f"{name}=={version}" for name, version in sorted(packages.items())),
-            ],
-            capture_output=True,
-            encoding="utf8",
-            check=False,
-        )
+        install_suffix = [
+            # Constrain to the xbuildenv pins so that a cross-build package
+            # pulled in as a transitive dependency (scipy depends on numpy,
+            # for instance) still lands at the version the xbuildenv ships
+            # cross-build files for.
+            "--constraint",
+            str(requirements_file),
+            "--target",
+            str(host_site_packages),
+            *(f"{name}=={version}" for name, version in sorted(packages.items())),
+        ]
 
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to install cross-build packages: {result.stderr}"
+        # `pip install --target` skips every entry that already exists in the
+        # target directory unless `--upgrade` is passed, so without it a package
+        # that is present at a different version would keep its old contents
+        # while gaining a second `.dist-info`. Upgrade the packages we were asked
+        # for, but with `--no-deps`: their dependencies may be cross-build
+        # packages themselves, and replacing those would drop the cross-build
+        # files that were copied over them. A second pass without `--upgrade`
+        # then installs the dependencies that are still missing.
+        for extra_args in (["--upgrade", "--no-deps"], []):
+            result = subprocess.run(
+                [*install_prefix, *extra_args, *install_suffix],
+                capture_output=True,
+                encoding="utf8",
+                check=False,
             )
+
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to install cross-build packages: {result.stderr}"
+                )
 
         self._copy_site_packages_extras(xbuildenv_root, host_site_packages)
 
@@ -473,14 +483,16 @@ class CrossBuildEnvManager:
         if not extras_root.is_dir():
             return
 
-        for extras_dir in extras_root.iterdir():
-            if not (host_site_packages / extras_dir.name).exists():
+        for extras_entry in extras_root.iterdir():
+            target = host_site_packages / extras_entry.name
+            if not extras_entry.is_dir():
+                # A cross-build file at the root of the wheel. There is no
+                # package directory to key it off, so always copy it.
+                shutil.copy2(extras_entry, target)
                 continue
-            shutil.copytree(
-                extras_dir,
-                host_site_packages / extras_dir.name,
-                dirs_exist_ok=True,
-            )
+            if not target.exists():
+                continue
+            shutil.copytree(extras_entry, target, dirs_exist_ok=True)
 
     def _host_site_packages_dir(
         self, xbuildenv_pyodide_root: Path | None = None
@@ -766,3 +778,20 @@ def _installed_distributions(site_packages: Path) -> dict[str, str]:
             continue
         installed[canonicalize_name(name)] = version
     return installed
+
+
+def _same_version(installed_version: str | None, pinned_version: str) -> bool:
+    """
+    Compare an installed version against a pinned one.
+
+    pip and uv write the PEP 440 normalized version into the `.dist-info`
+    directory name, whereas the pin in the xbuildenv `requirements.txt` is not
+    necessarily normalized, so a plain string comparison would report a
+    mismatch for e.g. `2024.02.02` versus `2024.2.2`.
+    """
+    if installed_version is None:
+        return False
+    try:
+        return Version(installed_version) == Version(pinned_version)
+    except InvalidVersion:
+        return installed_version == pinned_version

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -2,8 +2,10 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 from pyodide_lock import PyodideLockSpec
 
@@ -19,7 +21,6 @@ from pyodide_build.xbuildenv_releases import (
 
 CDN_BASE = "https://cdn.jsdelivr.net/pyodide/v{version}/full/"
 PYTHON_VERSION_MARKER_FILE = ".build-python-version"
-CROSS_BUILD_PACKAGES_MARKER_FILE = ".cross-build-packages-installed"
 EMSCRIPTEN_VERSION_MARKER_FILE = ".emscripten-version"
 
 
@@ -83,43 +84,70 @@ class CrossBuildEnvManager:
         """Returns the path to the xbuildenv for the given version."""
         return self.env_dir / version
 
-    def _cross_build_packages_marker_path(self, version_path: Path) -> Path:
+    def ensure_cross_build_packages_installed(self, packages: Iterable[str]) -> None:
         """
-        Return the marker file path used to record cross-build package installation.
+        Install the given cross-build packages into the host site-packages of
+        the active xbuildenv, if they are not installed there already.
+
+        Cross-build packages are not installed when the xbuildenv itself is
+        installed; instead `pyodide build` and `pyodide build-recipes` call this
+        with the subset of cross-build packages that the package being built
+        actually needs, so that we never pay for (say) a scipy install when
+        building something that only depends on numpy.
+
+        This method is idempotent: packages that are already present in the host
+        site-packages at the pinned version are skipped.
 
         Parameters
         ----------
-        version_path
-            Path to a concrete xbuildenv version directory (for example, `.../<version>`).
-        """
-        return version_path / CROSS_BUILD_PACKAGES_MARKER_FILE
-
-    def ensure_cross_build_packages_installed(self) -> None:
-        """
-        Install cross-build packages for the active xbuildenv only when needed.
-
-        This method is idempotent: if the marker file is already present, it does
-        nothing. Otherwise it installs packages into HOSTSITEPACKAGES and writes
-        the marker on success.
+        packages
+            Names of the cross-build packages to install. Names that are not
+            cross-build packages of this xbuildenv are ignored.
 
         Raises
         ------
-        ValueError
-            If no active xbuildenv is selected.
         RuntimeError
             If package installation fails.
         """
-        version_path = self.symlink_dir.resolve()
-        marker = self._cross_build_packages_marker_path(version_path)
-        if marker.exists():
+        requested = {canonicalize_name(name) for name in packages}
+        if not requested:
             return
 
-        xbuildenv_root = version_path / "xbuildenv"
+        xbuildenv_root = self.symlink_dir.resolve() / "xbuildenv"
         xbuildenv_pyodide_root = xbuildenv_root / "pyodide-root"
 
-        logger.info("Installing cross-build packages for %s", version_path.name)
-        self._install_cross_build_packages(xbuildenv_root, xbuildenv_pyodide_root)
-        marker.touch()
+        available = {
+            canonicalize_name(name): (name, version)
+            for name, version in build_env.read_pinned_requirements(
+                xbuildenv_root / "requirements.txt"
+            ).items()
+        }
+
+        host_site_packages = self._host_site_packages_dir(xbuildenv_pyodide_root)
+        installed = _installed_distributions(host_site_packages)
+
+        to_install = {}
+        for canonical in requested:
+            match = available.get(canonical)
+            if match is None:
+                # Not a cross-build package of this xbuildenv, nothing to do.
+                continue
+            name, version = match
+            if installed.get(canonical) == version:
+                continue
+            to_install[name] = version
+
+        if not to_install:
+            return
+
+        logger.info(
+            "Installing cross-build packages %s for %s",
+            ", ".join(sorted(to_install)),
+            self.symlink_dir.resolve().name,
+        )
+        self._install_cross_build_packages(
+            xbuildenv_root, xbuildenv_pyodide_root, to_install
+        )
 
     def list_versions(self) -> list[str]:
         """
@@ -180,7 +208,6 @@ class CrossBuildEnvManager:
         version: str | None = None,
         *,
         url: str | None = None,
-        skip_install_cross_build_packages: bool = True,
         force_install: bool = False,
     ) -> Path:
         """
@@ -199,8 +226,6 @@ class CrossBuildEnvManager:
             Warning: if you are downloading from a version that is not the same
             as the current version of pyodide-build, make sure that the cross-build
             environment is compatible with the current version of Pyodide.
-        skip_install_cross_build_packages
-            If True, skip installing the cross-build packages. This is mostly for testing purposes.
         force_install
             If True, force the installation even if the cross-build environment is not compatible
 
@@ -279,19 +304,14 @@ class CrossBuildEnvManager:
                 )
                 did_install_work = True
 
-                cross_build_packages_marker = self._cross_build_packages_marker_path(
-                    download_path
-                )
-
-                if not skip_install_cross_build_packages:
-                    self._install_cross_build_packages(
-                        xbuildenv_root, xbuildenv_pyodide_root
+                if version_marker_mismatch:
+                    # Any host packages present were installed under a different
+                    # Python version, so they are unusable. Drop them; the builds
+                    # that need them will reinstall them.
+                    shutil.rmtree(
+                        self._host_site_packages_dir(xbuildenv_pyodide_root),
+                        ignore_errors=True,
                     )
-                    cross_build_packages_marker.touch()
-                elif version_marker_mismatch:
-                    # The host packages were installed under a different Python
-                    # version. Drop the marker so they get reinstalled lazily.
-                    cross_build_packages_marker.unlink(missing_ok=True)
 
                 if not installed_from_url:
                     # If installed from url, skip creating the PyPI index
@@ -372,10 +392,13 @@ class CrossBuildEnvManager:
         return build_env.get_host_build_flag("DEFAULT_CROSS_BUILD_ENV_URL")
 
     def _install_cross_build_packages(
-        self, xbuildenv_root: Path, xbuildenv_pyodide_root: Path
+        self,
+        xbuildenv_root: Path,
+        xbuildenv_pyodide_root: Path,
+        packages: Mapping[str, str],
     ) -> None:
         """
-        Install package that are used in the cross-build environment.
+        Install the given cross-build packages into the host site-packages.
 
         Parameters
         ----------
@@ -383,9 +406,14 @@ class CrossBuildEnvManager:
             Path to the xbuildenv directory.
         xbuildenv_pyodide_root
             Path to the pyodide-root directory inside the xbuildenv directory.
+        packages
+            Mapping of cross-build package name to the version pinned by this
+            xbuildenv.
         """
         host_site_packages = self._host_site_packages_dir(xbuildenv_pyodide_root)
         host_site_packages.mkdir(exist_ok=True, parents=True)
+
+        requirements_file = xbuildenv_root / "requirements.txt"
 
         install_prefix = (
             [
@@ -406,10 +434,15 @@ class CrossBuildEnvManager:
         result = subprocess.run(
             [
                 *install_prefix,
-                "-r",
-                str(xbuildenv_root / "requirements.txt"),
+                # Constrain to the xbuildenv pins so that a cross-build package
+                # pulled in as a transitive dependency (scipy depends on numpy,
+                # for instance) still lands at the version the xbuildenv ships
+                # cross-build files for.
+                "--constraint",
+                str(requirements_file),
                 "--target",
                 str(host_site_packages),
+                *(f"{name}=={version}" for name, version in sorted(packages.items())),
             ],
             capture_output=True,
             encoding="utf8",
@@ -421,13 +454,33 @@ class CrossBuildEnvManager:
                 f"Failed to install cross-build packages: {result.stderr}"
             )
 
-        # Copy the site-packages-extras (coming from the cross-build-files meta.yaml
-        # key) over the site-packages directory with the newly installed packages.
-        shutil.copytree(
-            xbuildenv_root / "site-packages-extras",
-            host_site_packages,
-            dirs_exist_ok=True,
-        )
+        self._copy_site_packages_extras(xbuildenv_root, host_site_packages)
+
+    def _copy_site_packages_extras(
+        self, xbuildenv_root: Path, host_site_packages: Path
+    ) -> None:
+        """
+        Copy the site-packages-extras (coming from the cross-build-files
+        meta.yaml key) over the host site-packages.
+
+        Only extras belonging to a package that is actually present in the host
+        site-packages are copied. We re-copy the extras of every such package on
+        each install rather than only those of the packages we just installed,
+        because installing one cross-build package can overwrite the files of
+        another one that it depends on.
+        """
+        extras_root = xbuildenv_root / "site-packages-extras"
+        if not extras_root.is_dir():
+            return
+
+        for extras_dir in extras_root.iterdir():
+            if not (host_site_packages / extras_dir.name).exists():
+                continue
+            shutil.copytree(
+                extras_dir,
+                host_site_packages / extras_dir.name,
+                dirs_exist_ok=True,
+            )
 
     def _host_site_packages_dir(
         self, xbuildenv_pyodide_root: Path | None = None
@@ -692,3 +745,24 @@ class CrossBuildEnvManager:
 def _url_to_version(url: str) -> str:
     # : - invalid character on Windows.
     return url.replace("://", "_").replace(".", "_").replace("/", "_").replace(":", "_")
+
+
+def _installed_distributions(site_packages: Path) -> dict[str, str]:
+    """
+    Return the distributions installed in `site_packages` as a mapping of
+    canonicalized name to version, by looking at the `.dist-info` directories.
+
+    We use this instead of a marker file so that adding a package to an
+    xbuildenv whose cross-build packages were partially installed earlier
+    installs just the missing package.
+    """
+    installed: dict[str, str] = {}
+    if not site_packages.is_dir():
+        return installed
+
+    for dist_info in site_packages.glob("*.dist-info"):
+        name, _, version = dist_info.name.removesuffix(".dist-info").rpartition("-")
+        if not name or not version:
+            continue
+        installed[canonicalize_name(name)] = version
+    return installed

--- a/pyodide_build/xbuildenv.py
+++ b/pyodide_build/xbuildenv.py
@@ -84,7 +84,9 @@ class CrossBuildEnvManager:
         """Returns the path to the xbuildenv for the given version."""
         return self.env_dir / version
 
-    def ensure_cross_build_packages_installed(self, packages: Iterable[str]) -> None:
+    def ensure_cross_build_packages_installed(
+        self, packages: Iterable[tuple[str, str]]
+    ) -> None:
         """
         Install the given cross-build packages into the host site-packages of
         the active xbuildenv, if they are not installed there already.
@@ -101,41 +103,31 @@ class CrossBuildEnvManager:
         Parameters
         ----------
         packages
-            Names of the cross-build packages to install. Names that are not
-            cross-build packages of this xbuildenv are ignored.
+            `(name, version)` pairs of the cross-build packages to install,
+            where the version is the one pinned by this xbuildenv. Callers
+            select these from the xbuildenv's cross-build packages, see
+            `build_env.get_unisolated_packages`.
 
         Raises
         ------
         RuntimeError
             If package installation fails.
         """
-        requested = {canonicalize_name(name) for name in packages}
-        if not requested:
+        packages = list(packages)
+        if not packages:
             return
 
         xbuildenv_root = self.symlink_dir.resolve() / "xbuildenv"
         xbuildenv_pyodide_root = xbuildenv_root / "pyodide-root"
 
-        available = {
-            canonicalize_name(name): (name, version)
-            for name, version in build_env.read_pinned_requirements(
-                xbuildenv_root / "requirements.txt"
-            ).items()
-        }
-
         host_site_packages = self._host_site_packages_dir(xbuildenv_pyodide_root)
         installed = _installed_distributions(host_site_packages)
 
-        to_install = {}
-        for canonical in requested:
-            match = available.get(canonical)
-            if match is None:
-                # Not a cross-build package of this xbuildenv, nothing to do.
-                continue
-            name, version = match
-            if _same_version(installed.get(canonical), version):
-                continue
-            to_install[name] = version
+        to_install = {
+            name: version
+            for name, version in packages
+            if not _same_version(installed.get(canonicalize_name(name)), version)
+        }
 
         if not to_install:
             return


### PR DESCRIPTION
This resolves a problem with building for Python 3.15, namely that scipy has no wheels on pypi yet but when building a package that depends on another xbuild package, say numpy, we try to install native scipy which tries to build native scipy which very likely fails.

Instead, only install the cross-build packages that appear as build dependencies.

### Example
```sh
git clone git@github.com:PyWavelets/pywt.git
cd pywt
uv python -p 315
uv pip install pyodide-build
.venv/bin/pyodide build .
```
#### Without this change

```
Creating isolated environment: venv+uv...
Using external uv from /home/hood/.local/bin/uv
Installing cross-build packages for 315.0.0a1   

RuntimeError: Failed to install cross-build packages: Using CPython 3.15.0b3 interpreter at: .venv/bin/python3
Resolved 4 packages in 5ms
   Building scipy==1.18.0
  × Failed to build `scipy==1.18.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `mesonpy.build_wheel` failed (exit status: 1)
```

#### With this change

Builds successfully.