### PR TITLE
Fix CLI command names in docs

### DIFF
--- a/pyodide_build/cli/build.py
+++ b/pyodide_build/cli/build.py
@@ -234,6 +234,7 @@ def _extract_extras(source_location: str) -> tuple[str, list[str]]:
 
 
 @click.command(
+    "build",
     context_settings={
         "ignore_unknown_options": True,
         "allow_extra_args": True,

--- a/pyodide_build/cli/build_recipes.py
+++ b/pyodide_build/cli/build_recipes.py
@@ -61,7 +61,7 @@ class InstallOptions:
     metadata_files: bool
 
 
-@click.command()
+@click.command("build-recipes-no-deps")
 @click.argument("packages", nargs=-1, required=True)
 @click.option(
     "--recipe-dir",
@@ -212,7 +212,7 @@ def build_recipes_no_deps_impl(
             builder.clean(include_dist=False)
 
 
-@click.command()
+@click.command("build-recipes")
 @click.argument("packages", nargs=-1, required=True)
 @click.option(
     "--recipe-dir",

--- a/pyodide_build/cli/clean.py
+++ b/pyodide_build/cli/clean.py
@@ -7,7 +7,7 @@ from pyodide_build.logger import logger
 from pyodide_build.recipe import cleanup
 
 
-@click.group(invoke_without_command=True)
+@click.group("clean", invoke_without_command=True)
 @click.pass_context
 def app(ctx: click.Context) -> None:
     """Clean build artifacts."""

--- a/pyodide_build/cli/config.py
+++ b/pyodide_build/cli/config.py
@@ -8,7 +8,7 @@ from pyodide_build.build_env import (
 from pyodide_build.config import PYODIDE_CLI_CONFIGS
 
 
-@click.group(invoke_without_command=True)
+@click.group("config", invoke_without_command=True)
 @click.pass_context
 def app(ctx: click.Context) -> None:
     """Manage config variables used in pyodide."""

--- a/pyodide_build/cli/py_compile.py
+++ b/pyodide_build/cli/py_compile.py
@@ -6,7 +6,7 @@ import click
 from pyodide_build._py_compile import _py_compile_archive, _py_compile_archive_dir
 
 
-@click.command()
+@click.command("py-compile")
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--silent/--no-silent",

--- a/pyodide_build/cli/skeleton.py
+++ b/pyodide_build/cli/skeleton.py
@@ -12,7 +12,7 @@ from pyodide_build.logger import logger
 from pyodide_build.recipe import skeleton
 
 
-@click.group(invoke_without_command=True)
+@click.group("skeleton", invoke_without_command=True)
 @click.pass_context
 def app(ctx: click.Context) -> None:
     """Add a new package build recipe or update an existing recipe."""

--- a/pyodide_build/cli/venv.py
+++ b/pyodide_build/cli/venv.py
@@ -8,7 +8,7 @@ from pyodide_build.out_of_tree import venv
 
 # TODO: disabled options that can be later supported have been commented out, fix them
 # --copies/--always-copy and symlink_app_data
-@click.command()
+@click.command("venv")
 @click.argument("dest", type=click.Path(path_type=Path))
 @click.option(
     "--clear/--no-clear",

--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -16,7 +16,7 @@ from pyodide_build.xbuildenv_releases import (
 )
 
 
-@click.group(invoke_without_command=True)
+@click.group("xbuildenv", invoke_without_command=True)
 @click.pass_context
 def app(ctx: click.Context) -> None:
     """Manage cross-build environment for building packages for Pyodide."""

--- a/pyodide_build/tests/test_cli.py
+++ b/pyodide_build/tests/test_cli.py
@@ -1,9 +1,12 @@
 import shutil
 import sys
+import tomllib
 import zipfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -31,6 +34,19 @@ def assert_runner_succeeded(result):
 
         traceback.print_exception(result.exception)
     assert result.exit_code == 0
+
+
+def test_cli_entry_point_names_match_click_command_names():
+    pyproject = Path(__file__).parents[2] / "pyproject.toml"
+    entry_points = tomllib.loads(pyproject.read_text())["project"]["entry-points"][
+        "pyodide.cli"
+    ]
+
+    for entry_point_name, value in entry_points.items():
+        module_name, object_name = value.split(":")
+        command = getattr(import_module(module_name), object_name)
+        assert isinstance(command, click.Command)
+        assert command.name == entry_point_name
 
 
 def test_cli_import_does_not_resolve_xbuildenv_path(monkeypatch):


### PR DESCRIPTION
If you look at https://pyodide.org/en/stable/usage/api/pyodide-cli.html, most entries in the table of contents under `pyodide` are not showing the actual CLI commands but are instead repeated as `app` or `main`.

Reason is that Click infers the command name from the Python function name unless it is set explicitly. So `def main()` becomes `main`, and `def app()` becomes `app`, which does not match the pyodide.cli entry point names like `build`, `clean`.

This PR sets the Click command names explicitly, so sphinx correctly renders the command names.

& Same changes are needed to be made in the auditwheel_emscripten, pyodide-lock repositories as well.