### PR TITLE
Fix: Make `/path/to/pyodide venv` work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Fixed
 
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cross-build environment, or `PATH` contains a space. This previously broke
   `uv`-managed Pythons on macOS, which live under `Library/Application Support`.
   [#409](https://github.com/pyodide/pyodide-build/pull/409)
+
+- `pyodide venv` no longer fails with "pyodide cli not found" when the CLI is
+  invoked through an explicit path (e.g. `.venv/bin/pyodide venv`) without the
+  environment being activated. The CLI is now located relative to the running
+  interpreter instead of relying solely on `PATH`.
+  [#425](https://github.com/pyodide/pyodide-build/pull/425)
 
 ## [0.39.0] - 2026/08/03
 
@@ -65,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CMake's try_compile now uses the pywasmcross compiler wrappers.
   [416](https://github.com/pyodide/pyodide-build/pull/416)
+
 
 ## [0.37.0] - 2026/07/24
 

--- a/pyodide_build/out_of_tree/venv.py
+++ b/pyodide_build/out_of_tree/venv.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import sys
+import sysconfig
 import textwrap
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -67,6 +68,44 @@ def _pip_script_name(pip: Path, exe_suffix: str) -> Path:
         return pip
     base_name = pip.stem if pip.suffix else pip.name
     return pip.parent / (base_name + exe_suffix)
+
+
+def find_pyodide_cli() -> Path:
+    """Locate the ``pyodide`` CLI executable
+
+    Priority:
+    1. If sys.argv[0] is a fully qualified path, use that.
+    2. Search in the venv scripts directory.
+    3. Search next to the current running executable.
+    4. Look on the path
+    """
+    # sys.argv[0] is the script itself for console entrypoints, but it may be a
+    # bare name if the shell resolved it through PATH.
+    argv0 = Path(sys.argv[0])
+    is_bare = argv0.parent == Path()
+    if (not is_bare) and argv0.is_file():
+        return argv0.resolve()
+
+    # Directories that belong to the environment that is currently running,
+    # searched with `shutil.which` so that PATHEXT is honored on Windows.
+    search_dirs = [
+        sysconfig.get_path("scripts"),
+        str(Path(sys.executable).parent),
+    ]
+    for search_dir in search_dirs:
+        cli = shutil.which("pyodide", path=search_dir)
+        if cli:
+            return Path(cli).resolve()
+
+    cli = shutil.which("pyodide")
+    if cli:
+        return Path(cli).resolve()
+
+    raise RuntimeError(
+        "ERROR: pyodide cli not found. "
+        "Make sure the pyodide-build package is installed in the environment "
+        f"of {sys.executable}"
+    )
 
 
 def get_pyversion() -> str:
@@ -552,15 +591,13 @@ class UnixPyodideVenv(PyodideVenv):
         PATH = os.environ["PATH"]
         PYODIDE_ROOT = os.environ["PYODIDE_ROOT"]
 
-        original_pyodide_cli = shutil.which("pyodide")
-        if original_pyodide_cli is None:
-            raise RuntimeError("ERROR: pyodide cli not found")
+        original_pyodide_cli = find_pyodide_cli()
 
         self.pyodide_cli_path.write_text(
             dedent(
                 f"""
                 #!/usr/bin/env bash
-                PATH={shlex.quote(PATH)}:"$PATH" PYODIDE_ROOT={shlex.quote(PYODIDE_ROOT)} exec {shlex.quote(original_pyodide_cli)} "$@"
+                PATH={shlex.quote(PATH)}:"$PATH" PYODIDE_ROOT={shlex.quote(PYODIDE_ROOT)} exec {shlex.quote(str(original_pyodide_cli))} "$@"
                 """
             )
         )
@@ -650,9 +687,7 @@ class WindowsPyodideVenv(PyodideVenv):
         PATH = os.environ["PATH"]
         PYODIDE_ROOT = os.environ["PYODIDE_ROOT"]
 
-        original_pyodide_cli = shutil.which("pyodide")
-        if original_pyodide_cli is None:
-            raise RuntimeError("ERROR: pyodide cli not found")
+        original_pyodide_cli = find_pyodide_cli()
 
         self.pyodide_cli_path.write_text(
             dedent(

--- a/pyodide_build/tests/test_venv.py
+++ b/pyodide_build/tests/test_venv.py
@@ -549,7 +549,7 @@ def test_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypatch):
 
     monkeypatch.setenv("PATH", f"{cli.parent}{os.pathsep}{os.environ['PATH']}")
     monkeypatch.setenv("PYODIDE_ROOT", str(pyodide_root))
-    monkeypatch.setattr(shutil, "which", lambda name: str(cli))
+    monkeypatch.setattr(venv, "find_pyodide_cli", lambda: cli)
 
     pyodide_venv = _unix_venv_with_spaces(tmp_path)
     pyodide_venv._create_pyodide_script()
@@ -612,7 +612,7 @@ def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypa
 
     monkeypatch.setenv("PATH", f"{cli.parent}{os.pathsep}{os.environ['PATH']}")
     monkeypatch.setenv("PYODIDE_ROOT", str(pyodide_root))
-    monkeypatch.setattr(shutil, "which", lambda name: str(cli))
+    monkeypatch.setattr(venv, "find_pyodide_cli", lambda: cli)
 
     pyodide_venv = _windows_venv_with_spaces(tmp_path)
     pyodide_venv._create_pyodide_script()
@@ -625,6 +625,57 @@ def test_windows_pyodide_cli_script_runs_with_spaces_in_paths(tmp_path, monkeypa
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == [str(pyodide_root), "build ."]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows resolves executables via PATHEXT"
+)
+def test_find_pyodide_cli_from_argv(monkeypatch, tmp_path):
+    """The CLI must be found when invoked by path with its dir not on PATH."""
+    bin_dir = tmp_path / "somevenv" / "bin"
+    bin_dir.mkdir(parents=True)
+    cli = bin_dir / "pyodide"
+    cli.touch()
+
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(sys, "argv", [str(cli), "venv"])
+    assert shutil.which("pyodide") is None
+
+    assert venv.find_pyodide_cli() == cli.resolve()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows resolves executables via PATHEXT"
+)
+def test_find_pyodide_cli_from_interpreter_dir(monkeypatch, tmp_path):
+    """Fall back to the scripts dir of the running interpreter."""
+    bin_dir = tmp_path / "somevenv" / "bin"
+    bin_dir.mkdir(parents=True)
+    cli = bin_dir / "pyodide"
+    cli.touch()
+    cli.chmod(0o755)
+
+    monkeypatch.setenv("PATH", "")
+    # argv[0] is a bare name, so it cannot be used to locate the CLI
+    monkeypatch.setattr(sys, "argv", ["pyodide", "venv"])
+    monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(venv.sysconfig, "get_path", lambda name: str(tmp_path / "nope"))
+
+    assert venv.find_pyodide_cli() == cli.resolve()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows resolves executables via PATHEXT"
+)
+def test_find_pyodide_cli_not_found(monkeypatch, tmp_path):
+    """A helpful error is raised when the CLI really cannot be found."""
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(sys, "argv", ["pyodide", "venv"])
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "empty" / "python"))
+    monkeypatch.setattr(venv.sysconfig, "get_path", lambda name: str(tmp_path / "nope"))
+
+    with pytest.raises(RuntimeError, match="pyodide cli not found"):
+        venv.find_pyodide_cli()
 
 
 def test_cleanup_skips_preexisting_directory(monkeypatch, tmp_path):


### PR DESCRIPTION
Without sourcing the virtual environment.