### PR TITLE
NFC Improve write access check across platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       # is scoped to the tests that are specifically about Windows behaviour.
       - name: Run tests marked with windows
         if: runner.os == 'Windows'
-        run: pytest pyodide_build/tests/test_venv.py -m windows
+        run: pytest pyodide_build -m windows
 
       - name: Upload coverage
         # the Windows leg runs too little of the suite to be worth measuring

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -106,13 +106,17 @@ def default_xbuildenv_path() -> Path:
 
 def _has_write_access(folder: Path) -> bool:
     """
-    Checks if the current user has write access to the given folder using pathlib.
+    Checks if the current user has write access to the given folder by creating
+    a file in it.
     """
     try:
         if not folder.exists() and folder.parent != folder:
             return _has_write_access(folder.parent)
 
-        return os.access(str(folder), os.W_OK)
+        probe = folder / f".write-probe-{os.urandom(8).hex()}"
+        probe.touch(exist_ok=False)
+        probe.unlink(missing_ok=True)
+        return True
     except OSError:
         return False
 

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -272,6 +272,7 @@ def test_default_xbuildenv_path_env_var(tmp_path, reset_cache, monkeypatch):
     assert default_xbuildenv_path() == baseline_path
 
 
+@pytest.mark.windows
 def test_default_xbuildenv_path_env_var_non_writable(
     tmp_path, reset_cache, monkeypatch, request
 ):

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -1,3 +1,6 @@
+import os
+import stat
+import subprocess
 import zipfile
 from pathlib import Path
 
@@ -193,7 +196,6 @@ def test_xbuildenv_dirname_is_installation_scoped(tmp_path, monkeypatch):
 
 
 def test_default_xbuildenv_path_xdg_cache_home(tmp_path, reset_cache):
-    import os
     import sys
 
     import platformdirs
@@ -270,11 +272,8 @@ def test_default_xbuildenv_path_env_var(tmp_path, reset_cache, monkeypatch):
     assert default_xbuildenv_path() == baseline_path
 
 
-@pytest.mark.skipif(
-    IS_WIN, reason="Permission-based fallback is not reliable on Windows"
-)
 def test_default_xbuildenv_path_env_var_non_writable(
-    tmp_path, reset_cache, monkeypatch
+    tmp_path, reset_cache, monkeypatch, request
 ):
     import platformdirs
 
@@ -283,7 +282,28 @@ def test_default_xbuildenv_path_env_var_non_writable(
 
     non_writable_path = tmp_path / "non_writable"
     non_writable_path.mkdir(exist_ok=True)
-    non_writable_path.chmod(0o444)
+
+    # Remove write permissions
+    if IS_WIN:
+        # Windows ignores the read-only attribute on directories, so write
+        # access has to be denied through the directory's ACL instead.
+        username = os.environ["USERNAME"]
+        subprocess.run(
+            ["icacls", str(non_writable_path), "/deny", f"{username}:W"],
+            check=True,
+            capture_output=True,
+        )
+        request.addfinalizer(
+            lambda: subprocess.run(
+                ["icacls", str(non_writable_path), "/remove:d", username],
+                check=True,
+                capture_output=True,
+            )
+        )
+    else:
+        mode = stat.S_IMODE(non_writable_path.stat().st_mode)
+        non_writable_path.chmod(mode & ~stat.S_IWRITE)
+        request.addfinalizer(lambda: non_writable_path.chmod(mode))
 
     monkeypatch.setenv("PYODIDE_XBUILDENV_PATH", str(non_writable_path))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ exclude = [
 addopts = "-vra --strict-markers"
 markers = [
   "integration: mark a test as an integration test",
-  "windows: mark a test that is useful only on Windows"
+  "windows: mark a test to run on Windows"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
A small PR that:
- makes our write access check write a file into a directory, which is better than `os.access` – which, for one, doesn't work on Windows, but is also weak on Unix because it compares mode bits against the real UID and disagrees on things like read-only mounts, etc. This is similar to what conda does: https://github.com/conda/conda/blob/734737de62e4c6083f7d18bbbb2c15a922f2c777/conda/gateways/disk/test.py#L21-L38
- unskips a test we were skipping on Windows, via the `icacls` utility: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls, which is designed for this purpose of granting and taking away permissions.

Based on #333
See also: https://github.com/python/cpython/blob/v3.14.0/Modules/posixmodule.c#L3335-L3351