### PR TITLE
install-emscripten: hint `emsdk_env.fish` for fish shell

### DIFF
--- a/pyodide_build/cli/xbuildenv.py
+++ b/pyodide_build/cli/xbuildenv.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 
 from pyodide_build.build_env import get_build_flag, local_versions
-from pyodide_build.common import IS_WIN, default_xbuildenv_path
+from pyodide_build.common import default_xbuildenv_path, emsdk_activation_command
 from pyodide_build.views import MetadataView, SourceType
 from pyodide_build.xbuildenv import CrossBuildEnvManager
 from pyodide_build.xbuildenv_releases import (
@@ -367,8 +367,5 @@ def _install_emscripten(
     emsdk_dir = manager.install_emscripten(version, force=force)
 
     print("Installing emsdk complete.")
-    if IS_WIN:
-        cmd = f"{emsdk_dir}/emsdk_env.bat"
-    else:
-        cmd = f"source {emsdk_dir}/emsdk_env.sh"
+    cmd = emsdk_activation_command(emsdk_dir)
     print(f"Use `{cmd}` to set up the environment.")

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -672,3 +672,25 @@ def remove_readonly(func, path, _):
     """
     os.chmod(path, stat.S_IWRITE)
     func(path)
+
+
+def emsdk_activation_command(emsdk_dir: Path) -> str:
+    """
+    Get the command to activate the given emsdk directory for the current shell.
+
+    Parameters
+    ----------
+    emsdk_dir
+        Path to the emsdk directory containing the emsdk_env script
+
+    Returns
+    -------
+    str
+        The command to run to activate the emsdk environment.
+    """
+    if IS_WIN:
+        return f"{emsdk_dir}/emsdk_env.bat"
+
+    shell = os.getenv("SHELL")
+    suffix = "fish" if shell and Path(shell).name == "fish" else "sh"
+    return f"source {emsdk_dir}/emsdk_env.{suffix}"

--- a/pyodide_build/tests/test_cli_install_emscripten.py
+++ b/pyodide_build/tests/test_cli_install_emscripten.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from pyodide_build.cli import xbuildenv
+from pyodide_build.common import emsdk_activation_command
 
 runner = CliRunner()
 
@@ -60,8 +61,8 @@ def test_install_emscripten_default_version(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert "Installing emsdk..." in result.output, result.output
     assert "Installing emsdk complete." in result.output, result.output
-    assert "Use `source" in result.output, result.output
-    assert "emsdk_env.sh` to set up the environment." in result.output, result.output
+    cmd = emsdk_activation_command(envpath / "emsdk")
+    assert f"Use `{cmd}` to set up the environment." in result.output, result.output
     assert called["version"] == "3.1.46"
 
 
@@ -134,7 +135,7 @@ def test_install_emscripten_with_existing_emsdk(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert "Installing emsdk..." in result.output, result.output
     assert "Installing emsdk complete." in result.output, result.output
-    assert str(existing_emsdk / "emsdk_env.sh") in result.output
+    assert emsdk_activation_command(existing_emsdk) in result.output
 
 
 def test_install_emscripten_git_failure(tmp_path, monkeypatch):
@@ -256,5 +257,5 @@ def test_install_emscripten_output_format(tmp_path, monkeypatch):
     # Verify output format - check for key messages (logger adds extra lines)
     assert "Installing emsdk..." in result.output
     assert "Installing emsdk complete." in result.output
-    assert "Use `source" in result.output
-    assert "emsdk_env.sh` to set up the environment." in result.output
+    cmd = emsdk_activation_command(expected_path)
+    assert f"Use `{cmd}` to set up the environment." in result.output, result.output

--- a/pyodide_build/tests/test_cli_install_emscripten.py
+++ b/pyodide_build/tests/test_cli_install_emscripten.py
@@ -3,6 +3,7 @@
 import subprocess
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from pyodide_build.cli import xbuildenv
@@ -11,6 +12,7 @@ from pyodide_build.common import emsdk_activation_command
 runner = CliRunner()
 
 
+@pytest.mark.windows
 def test_install_emscripten_no_xbuildenv(tmp_path):
     """Test that install-emscripten fails when no xbuildenv exists"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -28,6 +30,7 @@ def test_install_emscripten_no_xbuildenv(tmp_path):
     assert "Cross-build environment not found" in result.output, result.output
 
 
+@pytest.mark.windows
 def test_install_emscripten_default_version(tmp_path, monkeypatch):
     """Test installing Emscripten with default version"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -66,6 +69,7 @@ def test_install_emscripten_default_version(tmp_path, monkeypatch):
     assert called["version"] == "3.1.46"
 
 
+@pytest.mark.windows
 def test_install_emscripten_specific_version(tmp_path, monkeypatch):
     """Test installing Emscripten with a specific version"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -100,6 +104,7 @@ def test_install_emscripten_specific_version(tmp_path, monkeypatch):
     assert called["version"] == emscripten_version
 
 
+@pytest.mark.windows
 def test_install_emscripten_with_existing_emsdk(tmp_path, monkeypatch):
     """Test installing Emscripten when emsdk already exists (should pull updates)"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -138,6 +143,7 @@ def test_install_emscripten_with_existing_emsdk(tmp_path, monkeypatch):
     assert emsdk_activation_command(existing_emsdk) in result.output
 
 
+@pytest.mark.windows
 def test_install_emscripten_git_failure(tmp_path, monkeypatch):
     """Test handling of git clone failure"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -164,6 +170,7 @@ def test_install_emscripten_git_failure(tmp_path, monkeypatch):
     assert isinstance(result.exception, subprocess.CalledProcessError)
 
 
+@pytest.mark.windows
 def test_install_emscripten_emsdk_install_failure(tmp_path, monkeypatch):
     """Test handling of emsdk install command failure"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -190,6 +197,7 @@ def test_install_emscripten_emsdk_install_failure(tmp_path, monkeypatch):
     assert isinstance(result.exception, subprocess.CalledProcessError)
 
 
+@pytest.mark.windows
 def test_install_emscripten_force_flag(tmp_path, monkeypatch):
     """Test that --force flag triggers reinstallation"""
     envpath = Path(tmp_path) / ".xbuildenv"
@@ -226,6 +234,7 @@ def test_install_emscripten_force_flag(tmp_path, monkeypatch):
     assert called["version"] == "3.1.46"
 
 
+@pytest.mark.windows
 def test_install_emscripten_output_format(tmp_path, monkeypatch):
     """Test that the output message format is correct"""
     envpath = Path(tmp_path) / ".xbuildenv"


### PR DESCRIPTION
Small change to print
```
Use `source /.../0.29.4/emsdk/emsdk_env.fish` to set up the environment.
```

instead of
```
Use `source /.../0.29.4/emsdk/emsdk_env.sh` to set up the environment.
```

Kept stumbling upon trying to copy the string to source the environment and running it without modifying extension.

Relying on `SHELL` env variable is not ideal (e.g. if someone logins with `fish` and then enters `bash`, `SHELL` is still fish), but it should do for the most cases.

Tests also don't hardcode path to script anymore, which also resolves the mismatch if those tests will be ran on Windows.

Unsure if those tests will actually are unblocked on Windows, let's test in CI.